### PR TITLE
Rename NTFY_TOPIC to PAPPARDELLE_NTFY_TOPIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Because Pappardelle runs entirely inside tmux, you can access your full workspac
 
 ### Nice-to-haves
 
-- **[ntfy](https://ntfy.sh/)** — Push notifications to your phone when Claude needs input. Pappardelle ships with a [`zap-notification.py`](hooks/zap-notification.py) hook that sends a push via ntfy whenever Claude asks a question or hits a permission prompt. To get it working, set the `NTFY_TOPIC` environment variable and subscribe to the same topic in the ntfy app on your phone — the hook only fires when an Tailscale SSH session is active. This way you don't have to babysit the terminal — just wait for the buzz.
+- **[ntfy](https://ntfy.sh/)** — Push notifications to your phone when Claude needs input. Pappardelle ships with a [`zap-notification.py`](hooks/zap-notification.py) hook that sends a push via ntfy whenever Claude asks a question or hits a permission prompt. To get it working, set the `PAPPARDELLE_NTFY_TOPIC` environment variable and subscribe to the same topic in the ntfy app on your phone — the hook only fires when an Tailscale SSH session is active. This way you don't have to babysit the terminal — just wait for the buzz.
 - **[Wispr Flow](https://apps.apple.com/us/app/wispr-flow-ai-voice-keyboard/id6497229487)** — Voice-to-text dictation that works system-wide, including inside Termius. Lets you talk to Claude instead of thumb-typing on a phone keyboard.
 
 ### Useful keybindings
@@ -199,7 +199,7 @@ keybindings:
       if [ -n "$PR_NUM" ]; then
         curl -d "${ISSUE_KEY} GitHub PR #$PR_NUM"
           -H "Click: $(gh pr list --head ${ISSUE_KEY} --json url -q '.[0].url')"
-          ntfy.sh/${NTFY_TOPIC};
+          ntfy.sh/${PAPPARDELLE_NTFY_TOPIC};
       fi
 ```
 

--- a/hooks/test_zap_notification.py
+++ b/hooks/test_zap_notification.py
@@ -73,7 +73,7 @@ class TestIsTailscaleSshActive:
 
 class TestSendZap:
     def test_calls_curl_with_correct_args(self):
-        with patch.object(zap_mod, "NTFY_TOPIC", "test-topic"), patch("subprocess.run") as mock_run:
+        with patch.object(zap_mod, "PAPPARDELLE_NTFY_TOPIC", "test-topic"), patch("subprocess.run") as mock_run:
             send_zap("test message")
             mock_run.assert_called_once()
             args = mock_run.call_args[0][0]
@@ -100,7 +100,7 @@ class TestMainLogic:
 
         stdin_mock = io.StringIO(json.dumps(input_data))
         with (
-            patch.object(zap_mod, "NTFY_TOPIC", ntfy_topic),
+            patch.object(zap_mod, "PAPPARDELLE_NTFY_TOPIC", ntfy_topic),
             patch.object(zap_mod, "is_tailscale_ssh_active", return_value=tailscale_active),
             patch.object(zap_mod, "send_zap") as mock_zap,
             patch("sys.stdin", stdin_mock),

--- a/hooks/zap-notification.py
+++ b/hooks/zap-notification.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 import sys
 
-NTFY_TOPIC = os.environ.get("NTFY_TOPIC")
+PAPPARDELLE_NTFY_TOPIC = os.environ.get("PAPPARDELLE_NTFY_TOPIC")
 TERMIUS_DEEPLINK = "termius://terminal"
 
 
@@ -59,7 +59,7 @@ def send_zap(message: str) -> None:
                 message,
                 "-H",
                 f"Click: {TERMIUS_DEEPLINK}",
-                f"ntfy.sh/{NTFY_TOPIC}",
+                f"ntfy.sh/{PAPPARDELLE_NTFY_TOPIC}",
             ],
             capture_output=True,
             timeout=10,
@@ -74,7 +74,7 @@ def main() -> None:
     except json.JSONDecodeError:
         input_data = {}
 
-    if not NTFY_TOPIC or not is_tailscale_ssh_active():
+    if not PAPPARDELLE_NTFY_TOPIC or not is_tailscale_ssh_active():
         sys.exit(0)
 
     hook_event = input_data.get("hook_event_name", "")


### PR DESCRIPTION
Use a namespaced env var to avoid collisions with other tools that might use ntfy.

Files changed:
- `hooks/zap-notification.py` — env var read
- `hooks/test_zap_notification.py` — test references
- `README.md` — documentation