### PR TITLE
Make Jira issue type configurable instead of hardcoding Task

### DIFF
--- a/pappardelle-config.md
+++ b/pappardelle-config.md
@@ -388,6 +388,7 @@ interface PappardelleConfig {
 	issue_tracker?: {
 		provider: 'linear' | 'jira';
 		base_url?: string; // Required for jira
+		default_issue_type?: string; // Jira-only. Default issue type for new issues. Defaults to "Task".
 	};
 	vcs_host?: {
 		provider: 'github' | 'gitlab';
@@ -407,6 +408,9 @@ interface Profile {
 	display_name: string;
 	emoji?: string; // Shown in the TUI ticket rail to the left of the Claude status icon
 	team_prefix?: string; // Override global team_prefix for issue creation
+	jira?: {
+		issue_type?: string; // Override the Jira issue type used when creating issues under this profile (e.g. "Feature", "Bug"). Falls back to issue_tracker.default_issue_type, then "Task".
+	};
 	claude?: {
 		initialization_command?: string; // Override global init command for this profile
 	};
@@ -553,6 +557,24 @@ issue_tracker:
 issue_tracker:
   provider: jira
   base_url: https://mycompany.atlassian.net
+  # Optional. Issue type used when creating new issues. Defaults to "Task".
+  # Set this if your Jira project doesn't allow "Task" (e.g. your project's
+  # allowed types are "Feature, Epic, Bug, ..."). Can be overridden per
+  # profile via `profiles.<name>.jira.issue_type`.
+  default_issue_type: Task
+```
+
+**Per-profile Jira issue type override.** When you have multiple profiles
+each pointing at a different Jira project, set `jira.issue_type` on the
+profile to override the global default. Resolution order:
+`profiles.<name>.jira.issue_type` → `issue_tracker.default_issue_type` → `"Task"`.
+
+```yaml
+profiles:
+  data-analytics:
+    team_prefix: DA
+    jira:
+      issue_type: Feature   # DA project doesn't accept "Task"
 ```
 
 ### VCS Host Providers

--- a/pappardelle.example.yml
+++ b/pappardelle.example.yml
@@ -20,6 +20,14 @@ default_emoji: ''
 # Team prefix for Linear issues (e.g., 'ENG' for 'ENG-123')
 team_prefix: ENG
 
+# Issue tracker (optional). Linear is assumed when omitted.
+# For Jira, you can set `default_issue_type` if your project doesn't accept the
+# default of "Task" — and override it per-profile via `profiles.<name>.jira.issue_type`.
+# issue_tracker:
+#   provider: jira
+#   base_url: https://mycompany.atlassian.net
+#   default_issue_type: Task
+
 # Claude configuration (optional)
 # claude:
 #   initialization_command: "/idow"        # Command passed to Claude when a new session opens
@@ -72,6 +80,10 @@ profiles:
     # Per-profile team prefix override (optional).
     # Issues created under this profile will use this prefix instead of the global one.
     # team_prefix: IOS
+    # Per-profile Jira issue type override (optional).
+    # Falls back to issue_tracker.default_issue_type, then "Task".
+    # jira:
+    #   issue_type: Feature
     vars:
       IOS_APP_DIR: 'ios/MyApp'
       BUNDLE_ID: 'com.example.myapp'

--- a/scripts/idow
+++ b/scripts/idow
@@ -411,6 +411,10 @@ else
     EFFECTIVE_TEAM_PREFIX="$TEAM_PREFIX"
 fi
 
+# Read per-profile Jira issue type override (provider-helpers falls back to
+# .issue_tracker.default_issue_type and finally "Task" when this is empty).
+PROFILE_JIRA_ISSUE_TYPE=$(yq -r ".profiles.$SELECTED_PROFILE.jira.issue_type // \"\"" "$CONFIG_PATH")
+
 # Use profile name as project key
 PROJECT_KEY="$SELECTED_PROFILE"
 
@@ -437,7 +441,11 @@ if [[ "$IS_NEW_ISSUE" == true ]]; then
 
     # Create issue via provider
     print_step 4 "Creating issue..."
-    ISSUE_JSON=$(create_issue --title "$TITLE" --prompt "$DESCRIPTION" --config "$CONFIG_PATH" --team "$EFFECTIVE_TEAM_PREFIX") || error "Failed to create issue"
+    CREATE_ISSUE_ARGS=(--title "$TITLE" --prompt "$DESCRIPTION" --config "$CONFIG_PATH" --team "$EFFECTIVE_TEAM_PREFIX")
+    if [[ -n "$PROFILE_JIRA_ISSUE_TYPE" ]]; then
+        CREATE_ISSUE_ARGS+=(--issue-type "$PROFILE_JIRA_ISSUE_TYPE")
+    fi
+    ISSUE_JSON=$(create_issue "${CREATE_ISSUE_ARGS[@]}") || error "Failed to create issue"
     ISSUE_KEY=$(echo "$ISSUE_JSON" | jq -r '.issue_key')
     ISSUE_URL=$(echo "$ISSUE_JSON" | jq -r '.issue_url')
     print_success "Created issue: $ISSUE_KEY (project will be assigned by Claude)"

--- a/scripts/provider-helpers.sh
+++ b/scripts/provider-helpers.sh
@@ -152,10 +152,10 @@ check_existing_pr() {
 }
 
 # Create an issue in the configured tracker
-# Args: --title <title> --prompt <prompt> --config <config_path> [--team <team>]
+# Args: --title <title> --prompt <prompt> --config <config_path> [--team <team>] [--issue-type <type>]
 # Outputs: JSON with issue_key and issue_url
 create_issue() {
-    local title="" prompt="" config_path="" team=""
+    local title="" prompt="" config_path="" team="" issue_type=""
 
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -163,6 +163,7 @@ create_issue() {
             --prompt) prompt="$2"; shift 2 ;;
             --config) config_path="$2"; shift 2 ;;
             --team) team="$2"; shift 2 ;;
+            --issue-type) issue_type="$2"; shift 2 ;;
             *) shift ;;
         esac
     done
@@ -172,6 +173,12 @@ create_issue() {
         team=$(yq -r '.team_prefix // "STA"' "$config_path" | tr '[:lower:]' '[:upper:]')
     fi
     team="${team:-STA}"
+
+    # Resolve Jira issue type: explicit arg → global default in config → "Task"
+    if [[ -z "$issue_type" && -n "$config_path" ]]; then
+        issue_type=$(yq -r '.issue_tracker.default_issue_type // ""' "$config_path")
+    fi
+    issue_type="${issue_type:-Task}"
 
     local provider
     provider=$(get_issue_tracker_provider "$config_path")
@@ -206,7 +213,7 @@ $quoted_prompt"
             fi
 
             local output
-            output=$(acli jira workitem create --project "$team" --type Task --summary "$title" --description-file "$adf_tmp" 2>&1)
+            output=$(acli jira workitem create --project "$team" --type "$issue_type" --summary "$title" --description-file "$adf_tmp" 2>&1)
             local exit_code=$?
             rm -f "$adf_tmp"
             if [[ $exit_code -ne 0 ]]; then

--- a/scripts/test-jira-issue-type.sh
+++ b/scripts/test-jira-issue-type.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+# Test: Jira issue_type resolution in create_issue / idow
+#
+# Verifies the resolution chain:
+#   profiles.<name>.jira.issue_type → issue_tracker.default_issue_type → "Task"
+#
+# This mirrors the yq logic embedded in:
+#   - scripts/provider-helpers.sh  (global default + flag fallback)
+#   - scripts/idow                 (per-profile override read)
+#
+# Usage: ./test-jira-issue-type.sh
+
+set -e
+
+PASS=0
+FAIL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+cleanup() {
+    if [[ -n "${TMPDIR_ROOT:-}" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local test_name="$1"
+    local expected="$2"
+    local actual="$3"
+
+    if [[ "$actual" == "$expected" ]]; then
+        echo -e "  ${GREEN}PASS${RESET} $test_name"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${RESET} $test_name"
+        echo "    Expected: \"$expected\""
+        echo "    Actual:   \"$actual\""
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Mirror provider-helpers.sh issue_type resolution.
+# Args: <issue_type_arg> <config_path>
+resolve_issue_type() {
+    local issue_type="$1"
+    local config_path="$2"
+
+    if [[ -z "$issue_type" && -n "$config_path" ]]; then
+        issue_type=$(yq -r '.issue_tracker.default_issue_type // ""' "$config_path")
+    fi
+    issue_type="${issue_type:-Task}"
+    echo "$issue_type"
+}
+
+# Mirror idow's per-profile read.
+# Args: <profile_name> <config_path>
+read_profile_issue_type() {
+    local profile="$1"
+    local config_path="$2"
+    yq -r ".profiles.$profile.jira.issue_type // \"\"" "$config_path"
+}
+
+setup_config() {
+    local body="$1"
+    TMPDIR_ROOT=$(mktemp -d)
+    printf '%s\n' "$body" > "$TMPDIR_ROOT/.pappardelle.yml"
+}
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: defaults to \"Task\" when no config and no flag${RESET}"
+result=$(resolve_issue_type "" "")
+assert_eq "default fallback" "Task" "$result"
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: defaults to \"Task\" when config omits issue_tracker${RESET}"
+setup_config "version: 1
+team_prefix: ENG
+default_profile: api
+profiles:
+  api:
+    display_name: API
+    keywords: [api]"
+result=$(resolve_issue_type "" "$TMPDIR_ROOT/.pappardelle.yml")
+assert_eq "no issue_tracker block" "Task" "$result"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: reads issue_tracker.default_issue_type when set${RESET}"
+setup_config "version: 1
+team_prefix: ENG
+default_profile: api
+issue_tracker:
+  provider: jira
+  base_url: https://example.atlassian.net
+  default_issue_type: Feature
+profiles:
+  api:
+    display_name: API
+    keywords: [api]"
+result=$(resolve_issue_type "" "$TMPDIR_ROOT/.pappardelle.yml")
+assert_eq "global default Feature" "Feature" "$result"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: explicit --issue-type overrides global default${RESET}"
+setup_config "version: 1
+team_prefix: ENG
+default_profile: api
+issue_tracker:
+  provider: jira
+  base_url: https://example.atlassian.net
+  default_issue_type: Feature
+profiles:
+  api:
+    display_name: API
+    keywords: [api]"
+result=$(resolve_issue_type "Bug" "$TMPDIR_ROOT/.pappardelle.yml")
+assert_eq "explicit arg wins" "Bug" "$result"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: per-profile jira.issue_type read by idow${RESET}"
+setup_config "version: 1
+team_prefix: ENG
+default_profile: data-analytics
+issue_tracker:
+  provider: jira
+  base_url: https://example.atlassian.net
+  default_issue_type: Task
+profiles:
+  data-analytics:
+    display_name: Data Analytics
+    keywords: [analytics]
+    team_prefix: DA
+    jira:
+      issue_type: Feature
+  api:
+    display_name: API
+    keywords: [api]"
+profile_type=$(read_profile_issue_type "data-analytics" "$TMPDIR_ROOT/.pappardelle.yml")
+assert_eq "per-profile read returns Feature" "Feature" "$profile_type"
+
+# When idow passes the per-profile value as --issue-type, that wins over global default.
+result=$(resolve_issue_type "$profile_type" "$TMPDIR_ROOT/.pappardelle.yml")
+assert_eq "per-profile beats global Task" "Feature" "$result"
+
+# Profile without override → idow passes empty → resolver falls back to global default.
+profile_type=$(read_profile_issue_type "api" "$TMPDIR_ROOT/.pappardelle.yml")
+assert_eq "profile without override returns empty" "" "$profile_type"
+result=$(resolve_issue_type "$profile_type" "$TMPDIR_ROOT/.pappardelle.yml")
+assert_eq "no per-profile → global Task" "Task" "$result"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo ""
+TOTAL=$((PASS + FAIL))
+if [[ "$FAIL" -eq 0 ]]; then
+    echo -e "${GREEN}${BOLD}All $TOTAL tests passed${RESET}"
+    exit 0
+else
+    echo -e "${RED}${BOLD}$FAIL of $TOTAL tests failed${RESET}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

`acli jira workitem create --type Task` is hardcoded in `provider-helpers.sh`, which fails on any Jira project that doesn't include "Task" in its allowed issue types. Some real-world projects only permit Feature/Epic/Bug/Subtask — for example SeatGeek's Data Analytics project errors with:

```
Failed to create Jira issue: Please provide valid issue type.
Allowed issue types for project are: Feature, Epic, Subtask, Bug,
Research, Data Warehouse Access Request, Mixpanel Action Request, ...
```

This PR makes the issue type configurable via a global default plus a per-profile override, with a fallback to `"Task"` so existing configs keep working unchanged.

**Resolution order:** `profiles.<name>.jira.issue_type` → `issue_tracker.default_issue_type` → `"Task"`.

## Why per-profile, not just global

Multi-team monorepos route different profiles to different Jira projects, each with its own allowed issue types. The existing `team_prefix` field already follows the same global+per-profile pattern; this mirrors it.

```yaml
issue_tracker:
  provider: jira
  base_url: https://mycompany.atlassian.net
  default_issue_type: Task   # optional, default

profiles:
  data-analytics:
    team_prefix: DA
    jira:
      issue_type: Feature    # DA project doesn't accept "Task"
```

## Changes

- `scripts/provider-helpers.sh` — `create_issue()` gains an optional `--issue-type` flag. Replaces hardcoded `--type Task` with the resolved value.
- `scripts/idow` — reads `.profiles.<selected>.jira.issue_type` after profile resolution and passes it to `create_issue` when set.
- `scripts/test-jira-issue-type.sh` — new file with 8 tests covering the resolution chain (default fallback, no-config fallback, global default, explicit arg override, per-profile beats global, per-profile-empty falls through).
- `pappardelle-config.md` — schema (TS interface) + prose docs for the new fields.
- `pappardelle.example.yml` — commented-out usage examples.

## Test plan

- [x] `bash scripts/test-jira-issue-type.sh` (new — 8 tests pass)
- [x] `bash scripts/test-team-prefix.sh` (existing — 10 tests still pass)
- [x] `bash -n` syntax check on all modified scripts
- [ ] Manual smoke test against a Jira project that doesn't allow `Task` (locally verified by patching install and creating an issue against SeatGeek's DA project)

## Backwards compatibility

100%. Any config without the new fields keeps using `"Task"` exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)