### PR TITLE
[CHAZ-22] Support moved Jira issues: alias resolved issue back to requested key

### DIFF
--- a/source/jira-provider.test.ts
+++ b/source/jira-provider.test.ts
@@ -690,16 +690,23 @@ test('getIssues populates cache and stateColors', async t => {
 });
 
 test('getIssues caches null for keys not found in results', async t => {
-	const exec: CliExecutor = async () =>
-		JSON.stringify([
-			{
-				key: 'CHEX-20',
-				fields: {
-					summary: 'Found',
-					status: {name: 'Done', statusCategory: {name: 'Done'}},
+	const exec: CliExecutor = async (_cmd, args) => {
+		if (args.includes('search')) {
+			return JSON.stringify([
+				{
+					key: 'CHEX-20',
+					fields: {
+						summary: 'Found',
+						status: {name: 'Done', statusCategory: {name: 'Done'}},
+					},
 				},
-			},
-		]);
+			]);
+		}
+
+		// Unmatched keys fall back to an individual `view`. A genuinely-missing
+		// key fails with no stdout, so getIssue() resolves it to null.
+		throw new Error('Issue does not exist');
+	};
 
 	const provider = new JiraProvider(
 		'https://example.com',
@@ -712,6 +719,150 @@ test('getIssues caches null for keys not found in results', async t => {
 	t.truthy(result.get('CHEX-20'));
 	t.is(result.get('CHEX-21'), null);
 	t.is(provider.getIssueCached('CHEX-21'), null);
+});
+
+// ============================================================================
+// Moved issues (CHAZ-22)
+//
+// When a Jira issue is moved between projects (e.g. CHAZ-7 → FXAI-54), acli
+// transparently follows the move: `view CHAZ-7` and `search "key in (CHAZ-7)"`
+// both return the *destination* issue, keyed by its new identifier (FXAI-54).
+// Pappardelle tracks worktrees by their original key, so we alias the moved
+// issue's data back to the requested key.
+// ============================================================================
+
+test('getIssue aliases a moved issue back to the requested key', async t => {
+	// `view CHAZ-7` follows the move, returning the destination keyed FXAI-54.
+	const json = makeJiraResponse('FXAI-54', 'Moved issue title');
+	const provider = new JiraProvider(
+		'https://example.com',
+		async () => json,
+		noopSleep,
+		tempCache(),
+	);
+
+	const issue = await provider.getIssue('CHAZ-7');
+	t.truthy(issue);
+	t.is(
+		issue!.identifier,
+		'CHAZ-7',
+		'identifier should be aliased to the requested key',
+	);
+	t.is(issue!.title, 'Moved issue title');
+	t.is(
+		provider.getIssueCached('CHAZ-7')!.identifier,
+		'CHAZ-7',
+		'cache should be keyed and aliased to the requested key',
+	);
+});
+
+test('getIssue aliases a moved issue from non-zero exit stdout', async t => {
+	// `view --json` on a moved issue prints valid JSON to stdout but exits 1.
+	const json = makeJiraResponse('FXAI-54', 'Moved via stderr exit');
+	const provider = new JiraProvider(
+		'https://example.com',
+		async () => {
+			const err = new Error('Command failed: exit code 1') as Error & {
+				stdout: string;
+				status: number;
+			};
+			err.stdout = json;
+			err.status = 1;
+			throw err;
+		},
+		noopSleep,
+		tempCache(),
+	);
+
+	const issue = await provider.getIssue('CHAZ-7');
+	t.truthy(issue);
+	t.is(issue!.identifier, 'CHAZ-7');
+	t.is(issue!.title, 'Moved via stderr exit');
+});
+
+test('getIssues resolves a moved issue back to the requested key', async t => {
+	const exec: CliExecutor = async (_cmd, args) => {
+		if (args.includes('search')) {
+			// JQL `key in (CHAZ-7)` follows the move → destination key FXAI-54.
+			return JSON.stringify([
+				{
+					key: 'FXAI-54',
+					fields: {
+						summary: 'Moved batch issue',
+						status: {
+							name: 'In Review',
+							statusCategory: {name: 'In Progress'},
+						},
+					},
+				},
+			]);
+		}
+
+		// Per-key `view` fallback for the unmatched requested key.
+		return makeJiraResponse(
+			'FXAI-54',
+			'Moved batch issue',
+			'In Review',
+			'In Progress',
+		);
+	};
+
+	const provider = new JiraProvider(
+		'https://example.com',
+		exec,
+		noopSleep,
+		tempCache(),
+	);
+	const result = await provider.getIssues(['CHAZ-7']);
+
+	const issue = result.get('CHAZ-7');
+	t.truthy(issue, 'moved issue should resolve under the requested key');
+	t.is(issue!.identifier, 'CHAZ-7');
+	t.is(issue!.title, 'Moved batch issue');
+	t.is(
+		result.get('FXAI-54'),
+		undefined,
+		'should not pollute results with the destination key',
+	);
+});
+
+test('getIssues resolves mixed direct and moved issues', async t => {
+	const exec: CliExecutor = async (_cmd, args) => {
+		if (args.includes('search')) {
+			return JSON.stringify([
+				{
+					key: 'CHEX-1',
+					fields: {
+						summary: 'Direct',
+						status: {name: 'Done', statusCategory: {name: 'Done'}},
+					},
+				},
+				{
+					key: 'FXAI-54',
+					fields: {
+						summary: 'Moved',
+						status: {name: 'To Do', statusCategory: {name: 'To Do'}},
+					},
+				},
+			]);
+		}
+
+		// `view` fallback for the unmatched requested key (CHAZ-7).
+		return makeJiraResponse('FXAI-54', 'Moved');
+	};
+
+	const provider = new JiraProvider(
+		'https://example.com',
+		exec,
+		noopSleep,
+		tempCache(),
+	);
+	const result = await provider.getIssues(['CHEX-1', 'CHAZ-7']);
+
+	t.is(result.get('CHEX-1')!.title, 'Direct');
+	t.is(result.get('CHEX-1')!.identifier, 'CHEX-1');
+	t.is(result.get('CHAZ-7')!.title, 'Moved');
+	t.is(result.get('CHAZ-7')!.identifier, 'CHAZ-7');
 });
 
 test('getIssues falls back to individual calls when search fails', async t => {

--- a/source/providers/jira-provider.ts
+++ b/source/providers/jira-provider.ts
@@ -113,6 +113,21 @@ export class JiraProvider implements IssueTrackerProvider {
 		this.stateColors = stateColorCache ?? new StateColorCache();
 	}
 
+	// Jira follows moved issues transparently: fetching a moved key (e.g.
+	// CHAZ-7) returns the destination issue keyed by its new identifier
+	// (e.g. FXAI-54). Pappardelle tracks worktrees by their original key, so
+	// alias the resolved issue's identifier back to the key we asked for.
+	private aliasToRequestedKey(
+		issue: TrackerIssue,
+		requestedKey: string,
+	): TrackerIssue {
+		if (issue.identifier === requestedKey) return issue;
+		log.debug(
+			`Issue ${requestedKey} has moved to ${issue.identifier}; aliasing back to requested key`,
+		);
+		return {...issue, identifier: requestedKey};
+	}
+
 	async getIssue(issueKey: string): Promise<TrackerIssue | null> {
 		if (this.acliMissing) {
 			return this.issueCache.get(issueKey)?.issue ?? null;
@@ -147,7 +162,7 @@ export class JiraProvider implements IssueTrackerProvider {
 					{encoding: 'utf-8', timeout: 15_000},
 				);
 				const raw = JSON.parse(output) as Record<string, unknown>;
-				const issue = mapJiraIssue(raw);
+				const issue = this.aliasToRequestedKey(mapJiraIssue(raw), issueKey);
 				this.issueCache.set(issueKey, {issue, timestamp: Date.now()});
 				this.stateColors.update(issue.state.name, issue.state.color);
 				log.debug(`Fetched Jira issue ${issueKey}: ${issue.title}`);
@@ -169,7 +184,7 @@ export class JiraProvider implements IssueTrackerProvider {
 					if (typeof stdout === 'string' && stdout.trim().startsWith('{')) {
 						try {
 							const raw = JSON.parse(stdout) as Record<string, unknown>;
-							const issue = mapJiraIssue(raw);
+							const issue = this.aliasToRequestedKey(mapJiraIssue(raw), issueKey);
 							this.issueCache.set(issueKey, {issue, timestamp: Date.now()});
 							this.stateColors.update(issue.state.name, issue.state.color);
 							log.debug(
@@ -232,10 +247,17 @@ export class JiraProvider implements IssueTrackerProvider {
 				{encoding: 'utf-8', timeout: 30_000},
 			);
 			const rawList = JSON.parse(output) as Array<Record<string, unknown>>;
+			const requested = new Set(issueKeys);
 			const found = new Set<string>();
 
 			for (const raw of rawList) {
 				const issue = mapJiraIssue(raw);
+				// A batch `key in (...)` search follows moved issues and returns
+				// them under their *new* key. Only accept direct matches here;
+				// moved issues (whose returned key we never asked for) are
+				// resolved per-key below, where each can be aliased back to the
+				// requested key unambiguously.
+				if (!requested.has(issue.identifier)) continue;
 				found.add(issue.identifier);
 				results.set(issue.identifier, issue);
 				this.issueCache.set(issue.identifier, {
@@ -245,11 +267,20 @@ export class JiraProvider implements IssueTrackerProvider {
 				this.stateColors.update(issue.state.name, issue.state.color);
 			}
 
-			// Keys not in results → cache as null
-			for (const key of issueKeys) {
-				if (!found.has(key)) {
-					results.set(key, null);
-					this.issueCache.set(key, {issue: null, timestamp: Date.now()});
+			// Unmatched keys are either moved (acli resolves the destination via
+			// a single `view`) or genuinely missing. Resolve each individually so
+			// moves get aliased back to the requested key, and misses cache null.
+			const unresolved = issueKeys.filter(key => !found.has(key));
+			if (unresolved.length > 0) {
+				const tasks = unresolved.map(
+					key => async () =>
+						this.getIssue(key).then(
+							issue => [key, issue] as [string, TrackerIssue | null],
+						),
+				);
+				const fetched = await pLimit(tasks, 3);
+				for (const entry of fetched) {
+					if (entry) results.set(entry[0], entry[1]);
 				}
 			}
 


### PR DESCRIPTION
## Problem

When a Jira issue is moved between projects (e.g. `CHAZ-7` → `FXAI-54`), `acli` **transparently follows the move** — both `acli jira workitem view CHAZ-7` and a `key in (CHAZ-7)` search return the *destination* issue, keyed by its **new** identifier (`FXAI-54`).

Pappardelle, however, tracks worktrees/branches by their *original* key. The batch fetch (`getIssues`) keyed results by the returned identifier, so the originally-requested key was never matched → cached as `null` → the worktree row showed the issue as missing.

(Quirk worth noting: `acli ... view --json` on a moved issue writes valid JSON to **stdout** but exits **1** with a stderr error. `getIssue` already tolerated that; the fix preserves it.)

## Fix

- **`getIssue`** — alias the resolved issue's `identifier` back to the requested key (covers both the normal path and the `--json` non-zero-exit recovery path).
- **`getIssues`** — only accept *direct* JQL matches in the batch pass; resolve any unmatched keys via individual `view` calls (which follow the move unambiguously per-key) so:
  - moves get aliased back to the requested key, and
  - genuine misses still cache `null`,
  - and moved-*destination* keys no longer pollute `results`.

Net effect: fetching a moved key returns the destination issue's title/status under the key pappardelle actually tracks.

## Tests

Red→green TDD. Added to `source/jira-provider.test.ts`:
- `getIssue` aliases a moved issue back to the requested key (normal + non-zero-exit stdout paths)
- `getIssues` resolves a moved issue back to the requested key (and doesn't leak the destination key)
- `getIssues` resolves mixed direct + moved issues in one batch
- Updated `getIssues caches null for keys not found` to reflect the new per-key `view` fallback

`npx ava source/jira-provider.test.ts` → **52 passed**. `npm run build` clean. (Pre-existing, unrelated `node-engine-compat` failure re: `string-width@8` Node-18 floor is untouched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Live proof (real `acli`, real moved issue)

Verified locally by driving the **default `JiraProvider` executor** — which shells out to the real `acli` binary, no mocks — against a genuinely-moved issue: **`CHAZ-7` was moved to `FXAI-54`** ("FanX AI MCP eval dashboard").

**Before (`origin/main`) — moved issue is dropped:**
```
=== getIssue("CHAZ-7") — single fetch path ===
identifier=FXAI-54 | title=FanX AI MCP eval dashboard | state=In Review     ← surfaced under the wrong key
cached under CHAZ-7: identifier=FXAI-54 | ...

=== getIssues(["CHAZ-7"]) — batch JQL path ===
  FXAI-54 -> identifier=FXAI-54 | ...
  CHAZ-7  -> null                                                           ← BROKEN: worktree shows issue as missing
  leaked destination key FXAI-54 in results? true                          ← pollutes results

=== getIssues(["CHAZ-7", "CHAZ-22"]) — mixed moved + direct ===
  FXAI-54  -> identifier=FXAI-54 | ...
  CHAZ-22  -> identifier=CHAZ-22 | ...
  CHAZ-7   -> null                                                          ← BROKEN
```

**After (this branch) — moved issue resolves under the requested key:**
```
=== getIssue("CHAZ-7") — single fetch path ===
identifier=CHAZ-7 | title=FanX AI MCP eval dashboard | state=In Review      ← aliased back to CHAZ-7
cached under CHAZ-7: identifier=CHAZ-7 | ...

=== getIssues(["CHAZ-7"]) — batch JQL path ===
  CHAZ-7 -> identifier=CHAZ-7 | title=FanX AI MCP eval dashboard | state=In Review
  leaked destination key FXAI-54 in results? false                         ← no pollution

=== getIssues(["CHAZ-7", "CHAZ-22"]) — mixed moved + direct ===
  CHAZ-22 -> identifier=CHAZ-22 | ...
  CHAZ-7  -> identifier=CHAZ-7  | title=FanX AI MCP eval dashboard | state=In Review
```

Both the single-fetch and batch paths now return the moved issue's live title/status under the originally-requested key, with no leaked destination key.
