### PR TITLE
[pappardelle-stm] Recommend `allow-passthrough on` in examples/tmux.conf

### DIFF
--- a/examples/tmux.conf
+++ b/examples/tmux.conf
@@ -33,3 +33,11 @@ set -g status-left '#{?client_prefix,#[bg=colour208]#[fg=colour0] ^B ,#[bg=colou
 set -g window-status-format ''
 set -g window-status-current-format ''
 set -g status-right ''
+
+# Let programs inside a pane send escape sequences straight to the outer
+# terminal. Pappardelle's claude and companion panes each host a nested
+# `tmux -L pappardelle_inner attach`, so anything the inner app emits — OSC 52
+# clipboard writes, image protocols, hyperlinks — has two tmux layers to cross
+# before it reaches the real terminal, and tmux swallows it at each one by
+# default
+set -g allow-passthrough on

--- a/source/synchronized-output.test.ts
+++ b/source/synchronized-output.test.ts
@@ -1,0 +1,139 @@
+// Tests for the tmux synchronized-output (DEC 2026) opt-in that stops the TUI
+// flickering while you type.
+//
+// Root cause, established by measurement against a real captured tmux client
+// (`script -q … tmux attach`): tmux only wraps a redraw in `ESC [ ? 2026 h/l`
+// when it believes the client's terminal supports Sync, and it infers that from
+// the client's TERM. Pappardelle's clients routinely report `tmux-256color`
+// (nested tmux is this app's normal shape — the claude and companion panes each
+// host a `tmux -L pappardelle_inner attach`), which advertises no Sync. With
+// `terminal-features` left at tmux's defaults a typing burst produced **0**
+// synchronized updates downstream; with `*:Sync` appended the same burst
+// produced 11. Unbatched repaints let the outer terminal present a half-drawn
+// frame, which is the flicker.
+//
+// These tests don't exercise real tmux (that's integration-tests/) — they lock
+// down the argv shape, because the whole fix is one option and getting `-ga`
+// wrong silently reintroduces the bug or destroys the user's config.
+import {readFileSync} from 'node:fs';
+import {join, dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import test from 'ava';
+import {
+	SYNC_TERMINAL_FEATURE,
+	enableSynchronizedOutput,
+	innerTmuxArgs,
+	type OuterTmuxRunner,
+} from './tmux.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TMUX_SOURCE = readFileSync(join(__dirname, 'tmux.ts'), 'utf-8');
+
+type Call = readonly string[];
+
+const recorder = (
+	result: {error?: Error; status: number | null; stdout: string} = {
+		status: 0,
+		stdout: '',
+	},
+): {calls: Call[]; runner: OuterTmuxRunner} => {
+	const calls: Call[] = [];
+	return {
+		calls,
+		runner: args => {
+			calls.push(args);
+			return result;
+		},
+	};
+};
+
+test('sets terminal-features on both the outer and the inner socket', t => {
+	const outer = recorder();
+	const inner = recorder();
+
+	enableSynchronizedOutput(outer.runner, inner.runner);
+
+	const expected = [
+		'set-option',
+		'-ga',
+		'terminal-features',
+		`,${SYNC_TERMINAL_FEATURE}`,
+	];
+	t.deepEqual(outer.calls, [expected]);
+	t.deepEqual(inner.calls, [expected]);
+});
+
+test('appends rather than assigns, so user-configured features survive', t => {
+	// `set -g` would replace the whole option and silently drop whatever the
+	// user configured in ~/.tmux.conf. `-a` with a leading comma is tmux's
+	// documented way to add an array entry.
+	const outer = recorder();
+	enableSynchronizedOutput(outer.runner, recorder().runner);
+
+	const [args] = outer.calls;
+	t.true(args!.includes('-ga'), 'must append');
+	t.false(args!.includes('-g'), 'must not use a bare assigning -g');
+	t.true(
+		args!.at(-1)!.startsWith(','),
+		'leading comma is what makes tmux add a new array entry instead of concatenating onto the last one',
+	);
+});
+
+test('the inner-socket call routes through innerTmuxArgs (keeps the -L flag)', t => {
+	// The inner runner is the only thing that adds `-L pappardelle_inner`; this
+	// pins that the argv we hand it is the un-prefixed form it expects, so the
+	// socket flag can't end up doubled or missing.
+	const inner = recorder();
+	enableSynchronizedOutput(recorder().runner, inner.runner);
+
+	t.deepEqual(innerTmuxArgs(inner.calls[0]!), [
+		'-L',
+		'pappardelle_inner',
+		'set-option',
+		'-ga',
+		'terminal-features',
+		`,${SYNC_TERMINAL_FEATURE}`,
+	]);
+});
+
+test('a failing or throwing tmux never breaks layout setup', t => {
+	// This runs inside setupPappardellLayout. Synchronized output is a rendering
+	// nicety; an old tmux that rejects the option must not cost the user their
+	// panes.
+	const failing: OuterTmuxRunner = () => ({status: 1, stdout: ''});
+	const throwing: OuterTmuxRunner = () => {
+		throw new Error('tmux not found');
+	};
+
+	t.notThrows(() => {
+		enableSynchronizedOutput(failing, throwing);
+	});
+	t.notThrows(() => {
+		enableSynchronizedOutput(throwing, failing);
+	});
+});
+
+test('a failure on the outer socket still attempts the inner socket', t => {
+	const throwing: OuterTmuxRunner = () => {
+		throw new Error('tmux not found');
+	};
+	const inner = recorder();
+
+	enableSynchronizedOutput(throwing, inner.runner);
+
+	t.is(inner.calls.length, 1);
+});
+
+test('setupPappardellLayout enables synchronized output', t => {
+	// The option is server-scope and only needs setting once per run, so it
+	// piggybacks on layout setup alongside the other tmux set-options. Pinning
+	// the call site keeps it from being dropped in a future refactor of that
+	// function, which would bring the flicker back with no test failing.
+	const layoutBody = TMUX_SOURCE.slice(
+		TMUX_SOURCE.indexOf('export function setupPappardellLayout'),
+	);
+	t.true(
+		layoutBody.includes('enableSynchronizedOutput()'),
+		'setupPappardellLayout must call enableSynchronizedOutput()',
+	);
+});

--- a/source/tmux.ts
+++ b/source/tmux.ts
@@ -478,6 +478,57 @@ const defaultInnerTmuxRunner: OuterTmuxRunner = args => {
 };
 
 /**
+ * DEC 2026 "synchronized output": the terminal buffers everything between
+ * `ESC [ ? 2026 h` and `ESC [ ? 2026 l` and presents it as one frame.
+ */
+export const SYNC_TERMINAL_FEATURE = '*:Sync';
+
+/**
+ * Make tmux batch each repaint into a single atomic frame.
+ *
+ * tmux only wraps a redraw in DEC 2026 when it believes the attached client's
+ * terminal supports Sync, and it decides that from the client's TERM. Our panes
+ * routinely run clients whose TERM is `tmux-256color` — a client attached from
+ * inside another tmux, which is the *normal* shape here, since the claude and
+ * companion panes each host a nested `tmux -L pappardelle_inner attach` — and
+ * that TERM advertises no Sync. tmux then streams every repaint out unbatched,
+ * so the outer terminal can present a half-drawn frame. That is the flicker seen
+ * while typing, worst when the zoomed list pane repaints full-screen per
+ * keystroke.
+ *
+ * `terminal-features` is server-scope; tmux offers no session or window scope
+ * for it, so on the outer socket this necessarily touches the whole tmux server.
+ * Two things keep that honest: we append (`-ga`) instead of assigning, so any
+ * user-configured features survive, and terminals that don't implement DEC 2026
+ * ignore the private mode — which is what makes the blanket `*` safe.
+ *
+ * Runners are exposed for tests only; production uses the spawnSync defaults.
+ */
+export function enableSynchronizedOutput(
+	outerRunner: OuterTmuxRunner = defaultOuterTmuxRunner,
+	innerRunner: OuterTmuxRunner = defaultInnerTmuxRunner,
+): void {
+	for (const [label, run] of [
+		['outer', outerRunner],
+		['inner', innerRunner],
+	] as const) {
+		try {
+			const {error, status} = run([
+				'set-option',
+				'-ga',
+				'terminal-features',
+				`,${SYNC_TERMINAL_FEATURE}`,
+			]);
+			if (error || status !== 0) {
+				log.debug(`Could not enable synchronized output on ${label} socket`);
+			}
+		} catch {
+			// Purely a rendering nicety — never let it break layout setup.
+		}
+	}
+}
+
+/**
  * STA-1420 layer 2: reap orphaned `claude-{repo}-*` / `companion-{repo}-*`
  * (and legacy `lazygit-{repo}-*`) sessions on the inner socket whose key is
  * neither in the registry nor the
@@ -1055,6 +1106,8 @@ export function setupPappardellLayout(): {
 			encoding: 'utf-8',
 			timeout: 5000,
 		});
+
+		enableSynchronizedOutput();
 
 		// Return focus to list pane
 		execSync(`tmux select-pane -t "${listPaneId}"`, {


### PR DESCRIPTION
## Summary

- Add `set -g allow-passthrough on` to `examples/tmux.conf`. Pappardelle's claude and companion panes each host a nested `tmux -L pappardelle_inner attach`, so an escape sequence emitted by the app inside a pane has two tmux layers to cross before reaching the real terminal. tmux discards DCS passthrough at each layer unless this is on, which costs OSC 52 clipboard writes, image protocols, and OSC 8 hyperlinks from anything running in a workspace pane.
- Appended at the end of the file rather than grouped with the other terminal settings, because #5 concurrently rewrites the focus-hook block near the top and appending keeps the two conflict-free.

## Test plan

- `tmux -L pptest -f examples/tmux.conf new-session -d` on tmux 3.7b — parses clean, no errors.
- `tmux -L pptest show -g allow-passthrough` reports `on`.

## Note on this branch

This branch was cut from the fork's `main`, which already contains #5's first commit `a143768`; `upstream/main` does not. So this PR currently carries `a143768` and a placeholder commit in addition to the one-line change above. Worth rebasing onto `upstream/main` before merge.

## Also in this session

A code review of #5 was run alongside this change. Findings are reported separately — nothing cleared the confidence bar for posting to that PR, and two proposed findings were disproved by direct experiment against tmux.

## Issue

pappardelle-stm

---

_Original prompt:_

> code review the https://github.com/chardigio/pappardelle/pull/5 MR on medium and also add `set -g allow-passthrough on` to the recommended tmux config

---
Generated with [Claude Code](https://claude.com/claude-code)