### PR TITLE
[pappardelle-ot8] Wire the home config layer into idow and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,7 @@ Every `AskUserQuestion` exchange is automatically posted as a comment on the Lin
 
 Use `/configure-pappardelle` to interactively edit your config — it walks you through adding profiles, keybindings, hooks, and more using `AskUserQuestion`. Available via the [plugin marketplace](#plugin-marketplace) or by asking Claude directly (it's model-invocable).
 
-Pappardelle is configured via a `.pappardelle.yml` file at your repo root, optionally layered with personal settings from `~/.pappardelle/.pappardelle.yml` and per-repo overrides in `.pappardelle.local.yml`. The key concepts:
-
-- **Three config layers** — `~/.pappardelle/.pappardelle.yml` (your defaults everywhere) → `<repo>/.pappardelle.yml` (committed, team-wide) → `<repo>/.pappardelle.local.yml` (gitignored, yours). Deep-merged in that order, so a home-level `claude.model` applies in every repo that doesn't override it. Note the home config lives inside the `~/.pappardelle/` directory — a bare `~/.pappardelle.yml` is never read.
+Pappardelle is configured via a `.pappardelle.yml` file at your repo root. The key concepts:
 
 - **Issue watchlist** — Auto-discover issues assigned to you and spawn workspaces for them. Pappardelle polls your issue tracker and creates workspaces for new matching issues. Filter by status, labels, or `key_prefixes` (e.g. watch `STA-*` but not `WAB-*` when one account spans multiple workspaces). A profile can also declare its own `issue_watchlist`, polled _in addition_ to the top-level one and auto-scoped to that profile's `team_prefix` — so you can watch one status everywhere and a bespoke status (e.g. "For Pappardelle") for a single project.
 - **Auto-remove when done** — Opt-in flag (`auto_remove_when_done: true`) that drops a space from the rail as soon as the tracker reports its issue as completed or canceled. Same teardown as pressing `d`; the on-disk worktree is left untouched.
@@ -374,15 +372,15 @@ npm link                # makes `pappardelle` available globally
 
 **Directories created by the installer:**
 
-| Directory / File                                   | Purpose                                                                 |
-| -------------------------------------------------- | ----------------------------------------------------------------------- |
-| `~/.pappardelle/`                                  | Config, hooks, logs, and Claude status files                            |
-| `~/.pappardelle/.pappardelle.yml`                  | Optional home config layer — create it yourself; the installer does not |
-| `~/.pappardelle/repos/{repoName}/open-spaces.json` | Persisted workspace registry (per-repo, survives reboots)               |
-| `~/.pappardelle/repos/{repoName}/issue-meta/`      | Issue metadata for hook tracking (per-repo)                             |
-| `~/.pappardelle/claude-status/`                    | Real-time status JSON files from Claude hooks                           |
-| `~/.pappardelle/logs/`                             | Daily log files (7-day retention)                                       |
-| `~/.worktrees/`                                    | Git worktrees for all your workspaces                                   |
+| Directory / File                                   | Purpose                                                   |
+| -------------------------------------------------- | --------------------------------------------------------- |
+| `~/.pappardelle/`                                  | Config, hooks, logs, and Claude status files              |
+| `~/.pappardelle/.pappardelle.yml`                  | Optional home config layer                                |
+| `~/.pappardelle/repos/{repoName}/open-spaces.json` | Persisted workspace registry (per-repo, survives reboots) |
+| `~/.pappardelle/repos/{repoName}/issue-meta/`      | Issue metadata for hook tracking (per-repo)               |
+| `~/.pappardelle/claude-status/`                    | Real-time status JSON files from Claude hooks             |
+| `~/.pappardelle/logs/`                             | Daily log files (7-day retention)                         |
+| `~/.worktrees/`                                    | Git worktrees for all your workspaces                     |
 
 > **Multi-repo support:** State is namespaced per repository under `~/.pappardelle/repos/{repoName}/`.
 > Running pappardelle in two different repos keeps their workspace registries completely separate.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ Every `AskUserQuestion` exchange is automatically posted as a comment on the Lin
 
 Use `/configure-pappardelle` to interactively edit your config — it walks you through adding profiles, keybindings, hooks, and more using `AskUserQuestion`. Available via the [plugin marketplace](#plugin-marketplace) or by asking Claude directly (it's model-invocable).
 
-Pappardelle is configured via a `.pappardelle.yml` file at your repo root. The key concepts:
+Pappardelle is configured via a `.pappardelle.yml` file at your repo root, optionally layered with personal settings from `~/.pappardelle/.pappardelle.yml` and per-repo overrides in `.pappardelle.local.yml`. The key concepts:
+
+- **Three config layers** — `~/.pappardelle/.pappardelle.yml` (your defaults everywhere) → `<repo>/.pappardelle.yml` (committed, team-wide) → `<repo>/.pappardelle.local.yml` (gitignored, yours). Deep-merged in that order, so a home-level `claude.model` applies in every repo that doesn't override it. Note the home config lives inside the `~/.pappardelle/` directory — a bare `~/.pappardelle.yml` is never read.
 
 - **Issue watchlist** — Auto-discover issues assigned to you and spawn workspaces for them. Pappardelle polls your issue tracker and creates workspaces for new matching issues. Filter by status, labels, or `key_prefixes` (e.g. watch `STA-*` but not `WAB-*` when one account spans multiple workspaces). A profile can also declare its own `issue_watchlist`, polled _in addition_ to the top-level one and auto-scoped to that profile's `team_prefix` — so you can watch one status everywhere and a bespoke status (e.g. "For Pappardelle") for a single project.
 - **Auto-remove when done** — Opt-in flag (`auto_remove_when_done: true`) that drops a space from the rail as soon as the tracker reports its issue as completed or canceled. Same teardown as pressing `d`; the on-disk worktree is left untouched.
@@ -372,14 +374,15 @@ npm link                # makes `pappardelle` available globally
 
 **Directories created by the installer:**
 
-| Directory / File                                   | Purpose                                                   |
-| -------------------------------------------------- | --------------------------------------------------------- |
-| `~/.pappardelle/`                                  | Config, hooks, logs, and Claude status files              |
-| `~/.pappardelle/repos/{repoName}/open-spaces.json` | Persisted workspace registry (per-repo, survives reboots) |
-| `~/.pappardelle/repos/{repoName}/issue-meta/`      | Issue metadata for hook tracking (per-repo)               |
-| `~/.pappardelle/claude-status/`                    | Real-time status JSON files from Claude hooks             |
-| `~/.pappardelle/logs/`                             | Daily log files (7-day retention)                         |
-| `~/.worktrees/`                                    | Git worktrees for all your workspaces                     |
+| Directory / File                                   | Purpose                                                                 |
+| -------------------------------------------------- | ----------------------------------------------------------------------- |
+| `~/.pappardelle/`                                  | Config, hooks, logs, and Claude status files                            |
+| `~/.pappardelle/.pappardelle.yml`                  | Optional home config layer — create it yourself; the installer does not |
+| `~/.pappardelle/repos/{repoName}/open-spaces.json` | Persisted workspace registry (per-repo, survives reboots)               |
+| `~/.pappardelle/repos/{repoName}/issue-meta/`      | Issue metadata for hook tracking (per-repo)                             |
+| `~/.pappardelle/claude-status/`                    | Real-time status JSON files from Claude hooks                           |
+| `~/.pappardelle/logs/`                             | Daily log files (7-day retention)                                       |
+| `~/.worktrees/`                                    | Git worktrees for all your workspaces                                   |
 
 > **Multi-repo support:** State is namespaced per repository under `~/.pappardelle/repos/{repoName}/`.
 > Running pappardelle in two different repos keeps their workspace registries completely separate.

--- a/pappardelle-config.md
+++ b/pappardelle-config.md
@@ -8,20 +8,29 @@ The `.pappardelle.yml` file replaces the previous `.git` directory requirement. 
 
 **Key Design Decisions:**
 
-- **Repository-wide configuration**: One `.pappardelle.yml` at the git repository root
+- **Layered configuration**: A personal home config, the repo's committed config, and a gitignored local override, deep-merged in that order
 - **Profile-based**: Different project types (iOS apps, backend services) have named profiles
-- **Required**: Pappardelle exits with an error if no config file is found
+- **Required**: Pappardelle exits with an error if no layer provides a config file
 - **Templated**: Supports variable expansion for dynamic values
 - **Provider-agnostic**: Supports multiple issue trackers (Linear, Jira) and VCS hosts (GitHub, GitLab)
 
 ## File Location
 
-Pappardelle searches for `.pappardelle.yml` at the git repository root only:
+Config is assembled from up to three files, deep-merged lowest → highest priority:
 
-```bash
-git rev-parse --show-toplevel  # Find repo root
-# Then look for: <repo-root>/.pappardelle.yml
-```
+| #   | Layer   | Path                                 | Purpose                                  | Committed?            |
+| --- | ------- | ------------------------------------ | ---------------------------------------- | --------------------- |
+| 1   | Home    | `~/.pappardelle/.pappardelle.yml`    | Your personal defaults across every repo | No (outside the repo) |
+| 2   | Project | `<repo-root>/.pappardelle.yml`       | Repo-level settings shared with the team | Yes                   |
+| 3   | Local   | `<repo-root>/.pappardelle.local.yml` | Your per-repo overrides                  | No (gitignored)       |
+
+The repo root comes from `git rev-parse --show-toplevel`.
+
+> **The home config lives _inside_ `~/.pappardelle/`, not at `~/.pappardelle.yml`.** A bare `~/.pappardelle.yml` in your home directory is never read.
+
+Later layers override earlier ones key by key, so a home config setting `claude.model` still applies in a repo whose `.pappardelle.yml` never mentions it. Only the conflicting keys are replaced — `keybindings` are smart-merged rather than wholesale replaced.
+
+At least one layer must supply a file. A home config alone is enough for the TUI; note that `idow` additionally requires a project `.pappardelle.yml` to exist and errors out without one.
 
 ## Configuration Schema
 

--- a/pappardelle-config.md
+++ b/pappardelle-config.md
@@ -24,13 +24,7 @@ Config is assembled from up to three files, deep-merged lowest → highest prior
 | 2   | Project | `<repo-root>/.pappardelle.yml`       | Repo-level settings shared with the team | Yes                   |
 | 3   | Local   | `<repo-root>/.pappardelle.local.yml` | Your per-repo overrides                  | No (gitignored)       |
 
-The repo root comes from `git rev-parse --show-toplevel`.
-
-> **The home config lives _inside_ `~/.pappardelle/`, not at `~/.pappardelle.yml`.** A bare `~/.pappardelle.yml` in your home directory is never read.
-
 Later layers override earlier ones key by key, so a home config setting `claude.model` still applies in a repo whose `.pappardelle.yml` never mentions it. Only the conflicting keys are replaced — `keybindings` are smart-merged rather than wholesale replaced.
-
-At least one layer must supply a file. A home config alone is enough for the TUI; note that `idow` additionally requires a project `.pappardelle.yml` to exist and errors out without one.
 
 ## Configuration Schema
 
@@ -291,8 +285,8 @@ Variables are expanded using `${VAR_NAME}` syntax. Environment variables are als
 
 ```yaml
 # All of these work:
-path: "${WORKTREE_PATH}"
-path: "${HOME}/.worktrees/${REPO_NAME}/${ISSUE_KEY}"
+path: '${WORKTREE_PATH}'
+path: '${HOME}/.worktrees/${REPO_NAME}/${ISSUE_KEY}'
 run: "echo ${ISSUE_KEY} | tr '[:upper:]' '[:lower:]'"
 ```
 

--- a/scripts/idow
+++ b/scripts/idow
@@ -115,6 +115,9 @@ else
     REPO_ROOT=$(git rev-parse --show-toplevel)
 fi
 CONFIG_PATH="$REPO_ROOT/.pappardelle.yml"
+# Personal defaults shared across every repo. Must stay in step with
+# getDefaultHomeConfigDir() in source/config.ts, which is what the TUI reads.
+HOME_CONFIG_PATH="$HOME/.pappardelle/.pappardelle.yml"
 
 # Source $REPO_ROOT/.envrc if present so per-repo env vars (e.g. a non-default
 # LINCTL_API_KEY for a separate Linear workspace) reach downstream tools like
@@ -149,7 +152,7 @@ fi
 # These are the top-level values; once a profile is selected, the launch flags
 # are re-resolved profile-first via resolve_claude_launch_flags below.
 LOCAL_CONFIG_PATH="$REPO_ROOT/.pappardelle.local.yml"
-CLAUDE_CONFIG_JSON=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH")
+CLAUDE_CONFIG_JSON=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH" --home-config "$HOME_CONFIG_PATH")
 INIT_CMD=$(echo "$CLAUDE_CONFIG_JSON" | jq -r '.init_cmd')
 SKIP_PERMISSIONS=$(echo "$CLAUDE_CONFIG_JSON" | jq -r '.skip_permissions')
 CLAUDE_MODEL=$(echo "$CLAUDE_CONFIG_JSON" | jq -r '.model')
@@ -164,7 +167,7 @@ CLAUDE_EFFORT=$(echo "$CLAUDE_CONFIG_JSON" | jq -r '.effort')
 resolve_claude_launch_flags() {
     local profile="$1"
     local json
-    json=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH" --profile "$profile")
+    json=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH" --home-config "$HOME_CONFIG_PATH" --profile "$profile")
     CLAUDE_MODEL=$(echo "$json" | jq -r '.model')
     CLAUDE_EFFORT=$(echo "$json" | jq -r '.effort')
     [[ -n "$CLAUDE_MODEL" ]] && log "Claude model: $CLAUDE_MODEL"

--- a/scripts/resolve-claude-config.sh
+++ b/scripts/resolve-claude-config.sh
@@ -5,9 +5,9 @@
 # Usage: resolve-claude-config.sh --config <path> [--local-config <path>] [--home-config <path>] [--profile <name>]
 #
 # Layers (lowest → highest priority):
-#   1. Home config   (~/.pappardelle.yml)     — personal defaults across all repos
-#   2. Project config (.pappardelle.yml)       — repo-level settings
-#   3. Local config   (.pappardelle.local.yml) — personal overrides (gitignored)
+#   1. Home config    (~/.pappardelle/.pappardelle.yml) — personal defaults across all repos
+#   2. Project config (.pappardelle.yml)                — repo-level settings
+#   3. Local config   (.pappardelle.local.yml)          — personal overrides (gitignored)
 #
 # Uses yq deep merge so ANY field in the claude section (or any future section)
 # is automatically resolved without per-field override logic.

--- a/scripts/test-claude-model-effort.sh
+++ b/scripts/test-claude-model-effort.sh
@@ -280,8 +280,13 @@ cleanup; unset TMPDIR_ROOT
 # prevent.
 
 echo -e "\n${BOLD}Test: idow passes the home layer to the resolver${RESET}"
-IDOW_CALLS=$(grep -c 'resolve-claude-config\.sh"' "$SCRIPT_DIR/idow")
-IDOW_HOME_CALLS=$(grep 'resolve-claude-config\.sh"' "$SCRIPT_DIR/idow" | grep -c -- '--home-config')
+# `|| true` on both counts: grep -c exits 1 when it matches nothing, and this
+# file runs under `set -e`. Without it the regression case this test exists to
+# catch — zero calls carrying --home-config — kills the suite mid-test instead
+# of failing it, printing no FAIL line, no summary, and silently skipping every
+# test block below.
+IDOW_CALLS=$(grep -c 'resolve-claude-config\.sh"' "$SCRIPT_DIR/idow" || true)
+IDOW_HOME_CALLS=$(grep 'resolve-claude-config\.sh"' "$SCRIPT_DIR/idow" | grep -c -- '--home-config' || true)
 assert_eq "every idow resolver call passes --home-config" "$IDOW_CALLS" "$IDOW_HOME_CALLS"
 assert_eq "idow's home path matches getDefaultHomeConfigDir()" \
     'HOME_CONFIG_PATH="$HOME/.pappardelle/.pappardelle.yml"' \

--- a/scripts/test-claude-model-effort.sh
+++ b/scripts/test-claude-model-effort.sh
@@ -258,6 +258,37 @@ cleanup; unset TMPDIR_ROOT
 
 # ==========================================================================
 
+echo -e "\n${BOLD}Test: home and local both apply when the project config is silent${RESET}"
+setup_configs "version: 1
+$BASE_PROFILES" "version: 1
+claude:
+  effort: max" "version: 1
+claude:
+  model: haiku
+  effort: low"
+OUT=$(resolve --profile backend)
+assert_eq "home model survives — local is silent on it" "haiku" "$(echo "$OUT" | field model)"
+assert_eq "local effort beats home effort" "max" "$(echo "$OUT" | field effort)"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+# idow is the production caller and can't be run headlessly (needs tmux, a git
+# repo, and live providers), so pin its wiring by inspection instead. It shipped
+# without --home-config on either call site, which silently dropped the home
+# layer for everyone launching a workspace while the TUI's loadConfig() honored
+# it — the two resolvers disagreeing is the exact failure this file exists to
+# prevent.
+
+echo -e "\n${BOLD}Test: idow passes the home layer to the resolver${RESET}"
+IDOW_CALLS=$(grep -c 'resolve-claude-config\.sh"' "$SCRIPT_DIR/idow")
+IDOW_HOME_CALLS=$(grep 'resolve-claude-config\.sh"' "$SCRIPT_DIR/idow" | grep -c -- '--home-config')
+assert_eq "every idow resolver call passes --home-config" "$IDOW_CALLS" "$IDOW_HOME_CALLS"
+assert_eq "idow's home path matches getDefaultHomeConfigDir()" \
+    'HOME_CONFIG_PATH="$HOME/.pappardelle/.pappardelle.yml"' \
+    "$(grep -o 'HOME_CONFIG_PATH="\$HOME/[^"]*"' "$SCRIPT_DIR/idow" | head -1)"
+
+# ==========================================================================
+
 echo -e "\n${BOLD}Test: exotic model ids survive the JSON round-trip${RESET}"
 setup_configs "version: 1
 claude:


### PR DESCRIPTION
## Summary

Started as a question — *does pappardelle read my global `~/.pappardelle.yml`?* The answer is no: it reads `~/.pappardelle/.pappardelle.yml`, **inside** the directory.

`loadConfig()` (source/config.ts) merges three layers — home → project → local — and every TUI caller honors all three. `idow` did not. It never passed `--home-config` to `resolve-claude-config.sh`, even though the script has supported the flag since it was written; only the tests passed it. So claude model/effort/init-cmd resolution silently dropped the home layer on the workspace-launch path while the TUI applied it. The two resolvers disagreeing is exactly what `test-claude-model-effort.sh` exists to prevent.

The home layer was also undocumented everywhere, and both places that named a home path pointed at a bare `~/.pappardelle.yml`, which nothing reads.

All issues resolved.

## Test plan

```bash
./scripts/test-claude-model-effort.sh   # 44 pass (4 pre-existing osascript failures, see below)
npx ava                                  # 1454 pass
npx xo                                   # 0 errors
```
