### PR TITLE
Watchlist label filter: AND the configured labels instead of OR-ing them

### DIFF
--- a/pappardelle-config.md
+++ b/pappardelle-config.md
@@ -762,7 +762,7 @@ issue_watchlist:
     - To Do
     - In Progress
     - In Review
-  labels: # Optional: only watch issues with any of these labels
+  labels: # Optional: only watch issues carrying all of these labels
     - pappardelle
     - platform
   key_prefixes: # Optional: only watch these issue-key prefixes (e.g. STA-*, not WAB-*)
@@ -773,7 +773,7 @@ issue_watchlist:
 | -------------- | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `assignee`     | `string`   | No       | The issue tracker username/email to match. Use `me` for auto-detection via the CLI tool (linctl/acli). Omit to match all assignees.                                                                                                                                                |
 | `statuses`     | `string[]` | Yes      | Non-empty list of issue status names to watch. Only issues with one of these statuses will trigger workspace creation.                                                                                                                                                             |
-| `labels`       | `string[]` | No       | When set, only issues with at least one matching label are watched. Matching is case-insensitive. Omit to watch all matching issues regardless of labels.                                                                                                                          |
+| `labels`       | `string[]` | No       | When set, only issues carrying every listed label are watched. Matching is case-insensitive. Omit to watch all matching issues regardless of labels.                                                                                                                               |
 | `key_prefixes` | `string[]` | No       | When set, only issues whose key prefix (the part before the first `-`, e.g. `STA` in `STA-123`) is in the list are watched. Useful when one tracker account spans multiple workspaces — watch `STA-*` but not `WAB-*`. Case-insensitive. Omit (or use `[]`) to watch every prefix. |
 
 **How it works:**
@@ -782,7 +782,7 @@ issue_watchlist:
 2. For Linear: calls `linctl issue list --state <status>` per status (adds `--assignee <user>` when configured)
 3. For Jira: uses JQL `status IN ("To Do", "In Progress")` (adds `assignee = currentUser()` when configured)
 4. If `key_prefixes` is configured, results are filtered client-side to only issues whose key prefix is in the allowlist
-5. If `labels` is configured, results are filtered client-side to only include issues with at least one matching label
+5. If `labels` is configured, results are filtered client-side to only include issues carrying every listed label
 6. New issues (not already in the space list) are auto-spawned as full workspaces via `idow`
 7. Each issue is only spawned once per Pappardelle session (tracked in memory)
 

--- a/pappardelle.example.yml
+++ b/pappardelle.example.yml
@@ -52,7 +52,7 @@ team_prefix: ENG
 #   statuses:
 #     - To Do
 #     - In Progress
-#   labels:                 # Optional: only watch issues carrying one of these labels
+#   labels:                 # Optional: only watch issues carrying all of these labels
 #     - pappardelle
 #   key_prefixes:           # Optional: only watch these key prefixes (e.g. ENG-*, not WAB-*)
 #     - ENG

--- a/plugins/pappardelle/skills/configure-pappardelle/SKILL.md
+++ b/plugins/pappardelle/skills/configure-pappardelle/SKILL.md
@@ -224,7 +224,7 @@ issue_watchlist:
   statuses:
     - To Do
     - In Progress
-  labels: # Optional: filter by label
+  labels: # Optional: only issues carrying ALL of these labels
     - pappardelle
   key_prefixes: # Optional: only these issue-key prefixes (STA-*, not WAB-*)
     - STA

--- a/source/config.ts
+++ b/source/config.ts
@@ -91,7 +91,7 @@ export interface VcsHostConfig {
 export interface IssueWatchlistConfig {
 	assignee?: string; // Optional: username/email, or 'me' to auto-detect. Omit to match all assignees.
 	statuses: string[]; // Issue statuses to match (e.g., ['To Do', 'In Progress'])
-	labels?: string[]; // Optional: only match issues with any of these labels
+	labels?: string[]; // Optional: only match issues carrying all of these labels
 	/**
 	 * Optional allowlist of issue-key prefixes (the part before the first '-',
 	 * e.g. 'STA' in 'STA-123'). When set, only issues whose key prefix is in

--- a/source/watchlist.test.ts
+++ b/source/watchlist.test.ts
@@ -140,6 +140,16 @@ test('filterByLabels is case-insensitive', t => {
 	t.is(result[0]!.identifier, 'STA-1');
 });
 
+test('filterByLabels ignores blank and untrimmed configured labels', t => {
+	const issues = [
+		makeIssue('STA-1', 'A', 'To Do', ['pappardelle']),
+		makeIssue('STA-2', 'B', 'To Do', ['platform']),
+	];
+
+	t.is(filterByLabels(issues, [' pappardelle ', '']).length, 1);
+	t.is(filterByLabels(issues, ['', '  ']).length, 2);
+});
+
 test('filterByLabels ignores extra labels on the issue', t => {
 	const issues = [
 		makeIssue('STA-1', 'A', 'To Do', ['bug', 'pappardelle', 'urgent']),

--- a/source/watchlist.test.ts
+++ b/source/watchlist.test.ts
@@ -105,17 +105,16 @@ test('filterByLabels returns all issues when labels array is empty', t => {
 	t.is(result.length, 2);
 });
 
-test('filterByLabels keeps issues matching any configured label', t => {
+test('filterByLabels keeps only issues carrying every configured label', t => {
 	const issues = [
-		makeIssue('STA-1', 'A', 'To Do', ['pappardelle']),
+		makeIssue('STA-1', 'A', 'To Do', ['pappardelle', 'platform']),
 		makeIssue('STA-2', 'B', 'To Do', ['platform']),
 		makeIssue('STA-3', 'C', 'To Do', ['stardust_jams']),
 	];
 
 	const result = filterByLabels(issues, ['pappardelle', 'platform']);
-	t.is(result.length, 2);
+	t.is(result.length, 1);
 	t.is(result[0]!.identifier, 'STA-1');
-	t.is(result[1]!.identifier, 'STA-2');
 });
 
 test('filterByLabels excludes issues with no labels', t => {
@@ -132,15 +131,16 @@ test('filterByLabels excludes issues with no labels', t => {
 
 test('filterByLabels is case-insensitive', t => {
 	const issues = [
-		makeIssue('STA-1', 'A', 'To Do', ['Pappardelle']),
+		makeIssue('STA-1', 'A', 'To Do', ['Pappardelle', 'PLATFORM']),
 		makeIssue('STA-2', 'B', 'To Do', ['PLATFORM']),
 	];
 
 	const result = filterByLabels(issues, ['pappardelle', 'platform']);
-	t.is(result.length, 2);
+	t.is(result.length, 1);
+	t.is(result[0]!.identifier, 'STA-1');
 });
 
-test('filterByLabels matches if issue has at least one matching label', t => {
+test('filterByLabels ignores extra labels on the issue', t => {
 	const issues = [
 		makeIssue('STA-1', 'A', 'To Do', ['bug', 'pappardelle', 'urgent']),
 	];

--- a/source/watchlist.ts
+++ b/source/watchlist.ts
@@ -20,15 +20,15 @@ export function getNewWatchlistIssues(
 /**
  * Filter issues to only those carrying every one of the specified labels.
  * Matching is case-insensitive.
- * Returns all issues if the labels array is empty.
+ * Returns all issues if the labels array is empty (or contains only blanks).
  * Pure function — no side effects.
  */
 export function filterByLabels(
 	issues: TrackerIssue[],
 	labels: string[],
 ): TrackerIssue[] {
-	if (labels.length === 0) return issues;
-	const wanted = labels.map(l => l.toLowerCase());
+	const wanted = labels.map(l => l.trim().toLowerCase()).filter(l => l !== '');
+	if (wanted.length === 0) return issues;
 	return issues.filter(issue => {
 		const issueLabels = new Set((issue.labels ?? []).map(l => l.toLowerCase()));
 		return wanted.every(l => issueLabels.has(l));

--- a/source/watchlist.ts
+++ b/source/watchlist.ts
@@ -18,7 +18,7 @@ export function getNewWatchlistIssues(
 }
 
 /**
- * Filter issues to only those with at least one of the specified labels.
+ * Filter issues to only those carrying every one of the specified labels.
  * Matching is case-insensitive.
  * Returns all issues if the labels array is empty.
  * Pure function — no side effects.
@@ -28,10 +28,11 @@ export function filterByLabels(
 	labels: string[],
 ): TrackerIssue[] {
 	if (labels.length === 0) return issues;
-	const labelSet = new Set(labels.map(l => l.toLowerCase()));
-	return issues.filter(issue =>
-		(issue.labels ?? []).some(l => labelSet.has(l.toLowerCase())),
-	);
+	const wanted = labels.map(l => l.toLowerCase());
+	return issues.filter(issue => {
+		const issueLabels = new Set((issue.labels ?? []).map(l => l.toLowerCase()));
+		return wanted.every(l => issueLabels.has(l));
+	});
 }
 
 /**


### PR DESCRIPTION
## What

`filterByLabels` treated `issue_watchlist.labels` as an OR-list — an issue carrying any one of the configured labels was watched. It now requires an issue to carry **all** of them, so listing multiple labels narrows the watchlist rather than widening it.

Matching stays case-insensitive, and an empty/omitted `labels` still watches everything.

## Changes

- `source/watchlist.ts` — `filterByLabels` uses `every` over the configured labels against the issue's label set
- `source/watchlist.test.ts` — the three tests that encoded OR semantics now assert AND
- Docs (`pappardelle-config.md`, `pappardelle.example.yml`, `configure-pappardelle` skill, `config.ts` field comment) reworded from "any of these labels" to "all of these labels"

## Testing

`npm test` — 1466 tests pass, prettier/xo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDGtSvHb7mE5F2UbSF9mh4