### PR TITLE
Add beads as an integrated issue tracker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,34 @@ jobs:
       - name: Run tests
         run: npx ava 'source/**/*.test.ts'
 
+  # The beads prefix rules are deliberately implemented three times — in
+  # source/config.ts, hooks/tracker_config.py and scripts/provider-helpers.sh —
+  # and all three have to agree or the same input is a key in one place and
+  # prose in another. Node and Python were gated above; the bash third had no
+  # gate at all, so drift there shipped green.
+  #
+  # macOS because test-session-name-encoding.sh runs the AppleScript out of
+  # open-iterm-claude.sh through osascript, which exists nowhere else.
+  shell-tests:
+    name: Shell Tests
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install yq
+        run: brew install yq
+
+      - name: Beads ID prefix matching
+        run: ./scripts/test-beads-id-prefixes.sh
+
+      - name: Issue project extraction
+        run: ./scripts/test-extract-issue-project.sh
+
+      - name: tmux session name encoding
+        run: ./scripts/test-session-name-encoding.sh
+
   python-tests:
     name: Python Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,14 +42,6 @@ jobs:
       - name: Run tests
         run: npx ava 'source/**/*.test.ts'
 
-  # The beads prefix rules are deliberately implemented three times — in
-  # source/config.ts, hooks/tracker_config.py and scripts/provider-helpers.sh —
-  # and all three have to agree or the same input is a key in one place and
-  # prose in another. Node and Python were gated above; the bash third had no
-  # gate at all, so drift there shipped green.
-  #
-  # macOS because test-session-name-encoding.sh runs the AppleScript out of
-  # open-iterm-claude.sh through osascript, which exists nowhere else.
   shell-tests:
     name: Shell Tests
     runs-on: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,14 +44,17 @@ jobs:
 
   shell-tests:
     name: Shell Tests
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Install yq
-        run: brew install yq
+        run: |
+          sudo curl -fsSL -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
 
       - name: Beads ID prefix matching
         run: ./scripts/test-beads-id-prefixes.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules
 dist
 
 __pycache__
+.pytest_cache
+
+# The beads database is per-machine state, not source.
+.beads
+.claude/settings.local.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,8 @@
 dist
+
+# Tracker and tool state, none of it hand-edited and none of it ours to format.
+# `npm test` is `prettier --check . && xo && ava`, so a stray JSON file in here
+# stops the chain before a single test runs.
+.beads
+.pytest_cache
+.claude/settings.local.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,5 @@
 dist
 
-# Tracker and tool state, none of it hand-edited and none of it ours to format.
-# `npm test` is `prettier --check . && xo && ava`, so a stray JSON file in here
-# stops the chain before a single test runs.
 .beads
 .pytest_cache
 .claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A TUI for multi-clauding without losing your marbles.
 
-You type a description, it reads or creates an issue in Linear/Jira, spawns a configured git worktree, builds a PR/MR, and starts a Claude Code session alongside a companion pane (gitui by default, configurable to any command) — all wired together in a 3-pane tmux layout you can navigate with simple, customizable keystrokes.
+You type a description, it reads or creates an issue in Linear, Jira or beads, spawns a configured git worktree, builds a PR/MR, and starts a Claude Code session alongside a companion pane (gitui by default, configurable to any command) — all wired together in a 3-pane tmux layout you can navigate with simple, customizable keystrokes.
 
 **Video:**
 
@@ -118,9 +118,18 @@ Enter moves focus to a **profile picker** below the prompt, with the
 keyword-matched profile already selected — so `Enter`, `Enter` spawns exactly
 what the keyword would have chosen on its own. Arrow (or `j`/`k`) to any other
 profile to override it without rewording your prompt, and `Esc` to go back to
-editing. Issue keys, bare numbers, and Linear URLs skip the picker entirely and
-spawn on a single `Enter`, since their profile comes from the issue's tracker
-project rather than from your text.
+editing.
+
+An issue key or Linear URL has no keywords to match, but its prefix still says
+which profiles could own it, so the picker opens for those too — ranked by
+prefix, behind a leading **Determined by issue project** row that names no
+profile and lets the issue's own tracker project decide. That row is
+preselected, so `Enter`, `Enter` on a key behaves exactly as a single `Enter`
+used to. A profile claims a prefix by setting its own `team_prefix`, by listing
+the prefix in `tracker_projects` (Jira issue keys are their project key), by
+listing it in its `issue_watchlist.key_prefixes`, or by declaring none of those
+and inheriting the global `team_prefix`. Bare numbers and
+keys no profile claims still spawn on a single `Enter`.
 
 ### Slash-command autocomplete
 
@@ -159,7 +168,7 @@ When you create a workspace, Pappardelle runs through these steps:
 
 1. **Profile selection** — Your input is keyword-matched against a profile in `.pappardelle.yml`, and you confirm (or override) the match in the picker.
 
-2. **Issue creation/fetch** — For new descriptions, a Linear (or Jira) issue is created with a WIP title. For existing issue keys, the issue is fetched.
+2. **Issue creation/fetch** — For new descriptions, a Linear (or Jira, or beads) issue is created with a WIP title. For existing issue keys, the issue is fetched.
 
 3. **Git worktree** — An isolated worktree is created at `~/.worktrees/{repo-name}/{issue-key}/`. This is a full working copy of your repo on a new branch, completely isolated from your main checkout.
 
@@ -183,7 +192,7 @@ A one-line prompt like "add dark mode to settings" leaves a lot of questions ope
 
 ### Automatic Q&A documentation
 
-Every `AskUserQuestion` exchange is automatically posted as a comment on the Linear or Jira issue by the [`comment-question-answered.py`](hooks/comment-question-answered.py) hook. This means:
+Every `AskUserQuestion` exchange is automatically posted as a comment on the Linear, Jira or beads issue by the [`comment-question-answered.py`](hooks/comment-question-answered.py) hook. This means:
 
 - **The issue becomes the single source of truth.** The original prompt, every clarifying question, and every answer are all captured in one place — not scattered across chat windows or terminal scrollback.
 - **Anyone reviewing the PR can see the full context.** The issue thread shows exactly what the agent asked, what the developer decided, and why.
@@ -201,11 +210,11 @@ Pappardelle is configured via a `.pappardelle.yml` file at your repo root. The k
 - **Auto-remove when done** — Opt-in flag (`auto_remove_when_done: true`) that drops a space from the rail as soon as the tracker reports its issue as completed or canceled. Same teardown as pressing `d`; the on-disk worktree is left untouched. Leave the flag off and press `K` instead to clear the finished spaces on demand, behind a confirm dialog.
 - **Issue status colors** — Optional `state_colors:` map that overrides the ticket-rail color for named issue statuses (hex or an ink color name). Off by default, so the rail keeps the tracker's own colors. Most useful on Jira, where one color often covers both "In Progress" and "In Review".
 - **Companion pane command** — The right pane runs `companion_command` (defaults to `gitui`). Set it to any shell command — a different git UI (`companion_command: lazygit`), a dev server, a log tailer — or `""` to leave a plain shell. A profile can override the top-level value, so per-project profiles can each launch their own process.
-- **Profiles** — Per-project-type config (keywords, setup commands, VCS labels, optional `emoji:` shown in the ticket rail). Pappardelle keyword-matches your input to auto-select the right profile. Each profile's `tracker_projects` list both routes existing issues to the right profile (Linear project names; Jira project names or keys) and (Linear only) lands brand-new issues in `tracker_projects[0]`.
-- **Claude model and effort** — `claude.model` and `claude.effort` are passed straight through to `claude --model` / `--effort` when a workspace's session is created. Set them globally, per-profile, or both — the profile wins, and an explicit `""` on a profile clears an inherited global value. Omit them entirely and nothing changes: no flag is passed and Claude picks its own default.
+- **Profiles** — Per-project-type config (keywords, setup commands, VCS labels, optional `emoji:` shown in the ticket rail). Pappardelle keyword-matches your input to auto-select the right profile. Each profile's `tracker_projects` list both routes existing issues to the right profile (Linear project names; Jira project names or keys; beads ID prefixes) and (Linear only) lands brand-new issues in `tracker_projects[0]`.
+- **Claude model and effort** — `claude.model` and `claude.effort` are passed straight through to `claude --model` / `--effort` when a workspace's session is created. Set them globally, per-profile, or both; the profile wins, and an explicit `""` on a profile clears an inherited global value. Omit them entirely and nothing changes: no flag is passed and Claude picks its own default.
 - **Template variables** — All string values support `${VAR_NAME}` expansion (`${ISSUE_KEY}`, `${WORKTREE_PATH}`, `${PR_URL}`, profile `vars`, env vars, etc.).
 - **Custom keybindings** — Bind single keys to bash commands (`run`) or Claude directives (`send_to_claude`).
-- **Providers** — Pluggable issue trackers (Linear, Jira) and VCS hosts (GitHub, GitLab). Defaults to Linear + GitHub.
+- **Providers** — Pluggable issue trackers (Linear, Jira, beads) and VCS hosts (GitHub, GitLab). Defaults to Linear + GitHub.
 - **Built-in file copies** — `.pappardelle.local.yml` and `.claude/settings.local.json` are automatically copied from the main repo to new worktrees (if they exist).
 - **Workspace lifecycle hooks** — `post_workspace_init` commands run after worktree creation (e.g., copying `.env` files, installing dependencies). `pre_workspace_deinit` commands run before workspace deletion (e.g., closing issues, removing worktrees).
 
@@ -365,6 +374,7 @@ Note the fallback to `${REPO_ROOT}/repo-a` here ensures this shortcut works in t
 | [gh](https://cli.github.com/)                                          | Optional | `brew install gh` (for GitHub)                                     |
 | [glab](https://gitlab.com/gitlab-org/cli)                              | Optional | `brew install glab` (for GitLab)                                   |
 | [acli](https://developer.atlassian.com/)                               | Optional | `brew tap atlassian/homebrew-acli && brew install acli` (for Jira) |
+| [bd](https://github.com/gastownhall/beads)                             | Optional | See the beads install docs (for Beads)                             |
 
 ### Manual installation
 
@@ -425,7 +435,7 @@ Pappardelle installs three Claude Code hooks that provide integration between Cl
 | Hook                           | Trigger                             | What it does                                                                  |
 | ------------------------------ | ----------------------------------- | ----------------------------------------------------------------------------- |
 | `update-status.py`             | `PreToolUse`, `PostToolUse`, `Stop` | Writes session status to `~/.pappardelle/claude-status/` for live TUI updates |
-| `comment-question-answered.py` | `PostToolUse` (AskUserQuestion)     | Posts Q&A exchanges as comments on the issue (Linear or Jira)                 |
+| `comment-question-answered.py` | `PostToolUse` (AskUserQuestion)     | Posts Q&A exchanges as comments on the issue (Linear, Jira, or beads)         |
 | `zap-notification.py`          | `PreToolUse`, `PermissionRequest`   | Sends push notifications via ntfy when Claude needs user input                |
 
 ### Versioning and updates
@@ -493,6 +503,7 @@ Standalone scripts in `integration-tests/` verify providers against real instanc
 ```bash
 npx tsx integration-tests/verify-linear.ts     # Linear provider (linctl)
 npx tsx integration-tests/verify-jira.ts       # Jira provider (acli)
+npx tsx integration-tests/verify-beads.ts      # Beads provider (bd, read-only by default)
 npx tsx integration-tests/verify-github.ts     # GitHub PR detection (gh)
 npx tsx integration-tests/verify-gitlab.ts     # GitLab MR detection (glab)
 npx tsx integration-tests/verify-config.ts     # Config loading + validation

--- a/README.md
+++ b/README.md
@@ -120,17 +120,6 @@ what the keyword would have chosen on its own. Arrow (or `j`/`k`) to any other
 profile to override it without rewording your prompt, and `Esc` to go back to
 editing.
 
-An issue key or Linear URL has no keywords to match, but its prefix still says
-which profiles could own it, so the picker opens for those too — ranked by
-prefix, behind a leading **Determined by issue project** row that names no
-profile and lets the issue's own tracker project decide. That row is
-preselected, so `Enter`, `Enter` on a key behaves exactly as a single `Enter`
-used to. A profile claims a prefix by setting its own `team_prefix`, by listing
-the prefix in `tracker_projects` (Jira issue keys are their project key), by
-listing it in its `issue_watchlist.key_prefixes`, or by declaring none of those
-and inheriting the global `team_prefix`. Bare numbers and
-keys no profile claims still spawn on a single `Enter`.
-
 ### Slash-command autocomplete
 
 Start the prompt with `/` and the **Profile** box gives way to a **Skills** box

--- a/hooks/comment-question-answered.py
+++ b/hooks/comment-question-answered.py
@@ -9,6 +9,7 @@ documentation.
 Supports:
 - Linear (linctl): default provider
 - Jira (acli): when .pappardelle.yml has issue_tracker.provider: jira
+- Beads (bd): when .pappardelle.yml has issue_tracker.provider: beads
 
 Usage:
     Called automatically by Claude Code hooks when AskUserQuestion tool completes.
@@ -18,7 +19,6 @@ Usage:
 import importlib.util
 import json
 import os
-import re as _re_module
 import subprocess
 import sys
 import tempfile
@@ -46,28 +46,24 @@ if _acli_spec and _acli_spec.loader:
 else:
     raise ImportError(f"Could not load acli_helpers from {_acli_module_path}")
 
+_tracker_module_path = _hooks_dir / "tracker_config.py"
+_tracker_spec = importlib.util.spec_from_file_location("tracker_config", _tracker_module_path)
+if _tracker_spec and _tracker_spec.loader:
+    _tracker_mod = importlib.util.module_from_spec(_tracker_spec)
+    _tracker_spec.loader.exec_module(_tracker_mod)
+    find_issue_key = _tracker_mod.find_issue_key
+    get_main_repo_root = _tracker_mod.get_main_repo_root
+    get_tracker_provider = _tracker_mod.get_tracker_provider
+else:
+    raise ImportError(f"Could not load tracker_config from {_tracker_module_path}")
+
 
 def get_issue_key() -> Optional[str]:
-    """Get Linear issue key from cwd (assumes worktree naming convention).
+    """Get the issue key from cwd (assumes worktree naming convention).
 
     Expected path: ~/.worktrees/stardust-labs/STA-123/...
     """
-    try:
-        cwd = os.getcwd()
-    except OSError:
-        return None
-    parts = cwd.split("/")
-
-    # Look for Linear issue pattern (e.g., STA-123) in path components
-    for part in parts:
-        if part and "-" in part:
-            prefix = part.split("-")[0]
-            suffix = part.split("-", 1)[1] if "-" in part else ""
-            # Check if it looks like a Linear issue (e.g., STA-123, ABC-45)
-            if prefix.isupper() and prefix.isalpha() and suffix.isdigit():
-                return part
-
-    return None
+    return find_issue_key()
 
 
 def format_question_answer(tool_input: dict, tool_response: dict | str) -> str:
@@ -146,58 +142,15 @@ def format_question_answer(tool_input: dict, tool_response: dict | str) -> str:
     return "\n".join(lines)
 
 
-def get_tracker_provider() -> str:
-    """Get the issue tracker provider from .pappardelle.yml.
-
-    Uses regex-based parsing to avoid requiring PyYAML dependency.
-    Walks up from cwd to find the config file, then extracts the provider.
-
-    Returns:
-        "linear" (default) or "jira"
-    """
-    # Walk up directories to find .pappardelle.yml
-    try:
-        current = os.getcwd()
-    except OSError:
-        return "linear"
-    config_path = None
-    for _ in range(20):  # max depth to prevent infinite loop
-        candidate = os.path.join(current, ".pappardelle.yml")
-        if os.path.isfile(candidate):
-            config_path = candidate
-            break
-        parent = os.path.dirname(current)
-        if parent == current:
-            break
-        current = parent
-
-    if not config_path:
-        return "linear"
-
-    try:
-        with open(config_path) as f:
-            content = f.read()
-        # Look for issue_tracker.provider value using regex
-        # Matches patterns like:
-        #   issue_tracker:
-        #     provider: jira
-        match = _re_module.search(r"issue_tracker:\s*\n\s+provider:\s*(\w+)", content)
-        if match:
-            return match.group(1).strip()
-    except OSError:
-        pass
-
-    return "linear"
-
-
 def post_comment(issue_key: str, body: str) -> bool:
     """Post a comment to the configured issue tracker.
 
-    Dispatches to linctl (Linear) or acli (Jira) based on .pappardelle.yml config.
-    Uses ADF formatting for Jira comments via --body-file with ADF JSON.
+    Dispatches to linctl (Linear), acli (Jira), or bd (Beads) based on
+    .pappardelle.yml config. Uses ADF formatting for Jira comments via
+    --body-file with ADF JSON.
 
     Args:
-        issue_key: The issue key (e.g., STA-123 or PROJ-456)
+        issue_key: The issue key (e.g., STA-123, PROJ-456, or bd-a1b2)
         body: The comment body in markdown
 
     Returns:
@@ -205,7 +158,29 @@ def post_comment(issue_key: str, body: str) -> bool:
     """
     provider = get_tracker_provider()
 
-    if provider == "jira":
+    if provider == "beads":
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".md", prefix="pappardelle-comment-", delete=False
+            ) as f:
+                tmp_path = f.name
+                f.write(body)
+            cmd = ["bd"]
+            repo_root = get_main_repo_root()
+            if repo_root:
+                cmd += ["-C", repo_root]
+            cmd += ["comments", "add", issue_key, "-f", tmp_path]
+        except OSError as e:
+            if tmp_path:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+            print(f"Error creating temp file for beads comment: {e}", file=sys.stderr)
+            return False
+        not_found_msg = "bd not found - install beads (https://github.com/gastownhall/beads)"
+    elif provider == "jira":
         # Convert markdown to ADF and write to temp file for --body-file
         adf_json = markdown_to_adf_json(body)
         tmp_path = None

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -23,6 +23,7 @@ chmod +x "$HOOKS_DIR/zap-notification.py"
 # Copy helper modules (imported by hook scripts above)
 cp "$SCRIPT_DIR/markdown_to_adf.py" "$HOOKS_DIR/"
 cp "$SCRIPT_DIR/acli_helpers.py" "$HOOKS_DIR/"
+cp "$SCRIPT_DIR/tracker_config.py" "$HOOKS_DIR/"
 
 echo "Hook scripts installed to $HOOKS_DIR/"
 

--- a/hooks/test_comment_question_answered.py
+++ b/hooks/test_comment_question_answered.py
@@ -245,6 +245,97 @@ class TestPostCommentLinear:
             assert "Comment body" in cmd
 
 
+class TestPostCommentBeads:
+    def test_calls_bd_with_markdown_file(self):
+        with (
+            patch.object(mod, "get_tracker_provider", return_value="beads"),
+            patch.object(mod, "get_main_repo_root", return_value=None),
+            patch.object(mod, "subprocess") as mock_subprocess,
+        ):
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_subprocess.run.return_value = mock_result
+
+            result = post_comment("pap-a1b2", "## Q&A\n\nSome answer")
+
+            assert result is True
+            cmd = mock_subprocess.run.call_args[0][0]
+            assert cmd[:4] == ["bd", "comments", "add", "pap-a1b2"]
+            file_idx = cmd.index("-f") + 1
+            # Beads comments are plain markdown, with no ADF conversion.
+            assert cmd[file_idx].endswith(".md")
+
+    def test_pins_bd_to_the_main_repo_root(self):
+        # The hook's cwd is the worktree, which carries its own checked-out
+        # .beads/; without -C, bd writes into that copy and the comment never
+        # reaches the issue the rail is tracking.
+        with (
+            patch.object(mod, "get_tracker_provider", return_value="beads"),
+            patch.object(mod, "get_main_repo_root", return_value="/repos/myproj"),
+            patch.object(mod, "subprocess") as mock_subprocess,
+        ):
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_subprocess.run.return_value = mock_result
+
+            post_comment("pap-a1b2", "body")
+
+            cmd = mock_subprocess.run.call_args[0][0]
+            assert cmd[:3] == ["bd", "-C", "/repos/myproj"]
+            assert cmd[3:6] == ["comments", "add", "pap-a1b2"]
+
+    def test_body_file_holds_raw_markdown(self):
+        captured = {}
+
+        def capture(cmd, **_kwargs):
+            file_idx = cmd.index("-f") + 1
+            with open(cmd[file_idx]) as f:
+                captured["body"] = f.read()
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        with (
+            patch.object(mod, "get_tracker_provider", return_value="beads"),
+            patch.object(mod, "get_main_repo_root", return_value=None),
+            patch.object(mod, "subprocess") as mock_subprocess,
+        ):
+            mock_subprocess.run.side_effect = capture
+            post_comment("pap-a1b2", "### Heading\n\n**bold** text")
+
+        assert captured["body"] == "### Heading\n\n**bold** text"
+
+    def test_temp_file_cleaned_up_on_success(self):
+        seen = {}
+
+        def capture(cmd, **_kwargs):
+            seen["path"] = cmd[cmd.index("-f") + 1]
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        with (
+            patch.object(mod, "get_tracker_provider", return_value="beads"),
+            patch.object(mod, "get_main_repo_root", return_value=None),
+            patch.object(mod, "subprocess") as mock_subprocess,
+        ):
+            mock_subprocess.run.side_effect = capture
+            post_comment("pap-a1b2", "Comment body")
+
+        assert not os.path.exists(seen["path"])
+
+    def test_returns_false_when_bd_is_missing(self):
+        with (
+            patch.object(mod, "get_tracker_provider", return_value="beads"),
+            patch.object(mod, "get_main_repo_root", return_value=None),
+            patch.object(mod, "subprocess") as mock_subprocess,
+        ):
+            mock_subprocess.run.side_effect = FileNotFoundError
+            mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
+
+            assert post_comment("pap-a1b2", "Comment body") is False
+
+
 class TestMainExitsZero:
     def test_main_exits_zero_on_exception(self):
         """Top-level exception handler should always exit 0."""

--- a/hooks/test_install_sh.py
+++ b/hooks/test_install_sh.py
@@ -1,0 +1,38 @@
+"""The installer copies files by name, so a new sibling import is silent until a
+hook dies at runtime on a machine installed through hooks/install.sh."""
+
+import re
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).parent
+INSTALL_SH = (HOOKS_DIR / "install.sh").read_text()
+
+SIBLING_IMPORT = re.compile(r'spec_from_file_location\(\s*"[^"]+",\s*(\w+)')
+SIBLING_PATH = re.compile(r'^(\w+)\s*=\s*[^\n]*/\s*"([\w.-]+\.py)"', re.MULTILINE)
+
+
+def sibling_modules(source: str) -> set[str]:
+    paths = dict(SIBLING_PATH.findall(source))
+    return {paths[var] for var in SIBLING_IMPORT.findall(source) if var in paths}
+
+
+def test_installer_copies_every_sibling_module_the_hooks_import():
+    entrypoints = [
+        p
+        for p in HOOKS_DIR.glob("*.py")
+        if not p.name.startswith("test_") and "-" in p.name
+    ]
+    assert entrypoints, "no hook entrypoints found"
+
+    missing = {
+        (entrypoint.name, module)
+        for entrypoint in entrypoints
+        for module in sibling_modules(entrypoint.read_text())
+        if module not in INSTALL_SH
+    }
+    assert not missing, f"install.sh does not copy: {sorted(missing)}"
+
+
+def test_sibling_module_detection_finds_tracker_config():
+    modules = sibling_modules((HOOKS_DIR / "update-status.py").read_text())
+    assert "tracker_config.py" in modules

--- a/hooks/test_tracker_config.py
+++ b/hooks/test_tracker_config.py
@@ -344,5 +344,26 @@ def test_a_local_config_is_used_without_consulting_git(tmp_path, monkeypatch):
     assert tracker_config.get_tracker_provider(str(repo)) == "beads"
 
 
+def test_injected_main_repo_root_is_used_instead_of_git(monkeypatch):
+    def fail(*args, **kwargs):
+        raise AssertionError("git should not be forked when the root was injected")
+
+    monkeypatch.setattr(tracker_config.subprocess, "run", fail)
+    monkeypatch.setattr(tracker_config, "_MAIN_REPO_ROOT_CACHE", {})
+    monkeypatch.setenv("PAPPARDELLE_MAIN_REPO_ROOT", "/tmp/main-checkout")
+    assert tracker_config.get_main_repo_root() == "/tmp/main-checkout"
+
+
+def test_injected_main_repo_root_does_not_answer_for_another_directory(monkeypatch):
+    # An explicit start is a question about some other directory, not about the
+    # workspace whose root was injected.
+    monkeypatch.setattr(tracker_config, "_MAIN_REPO_ROOT_CACHE", {})
+    monkeypatch.setenv("PAPPARDELLE_MAIN_REPO_ROOT", "/tmp/main-checkout")
+    monkeypatch.setattr(
+        tracker_config, "_resolve_main_repo_root", lambda start: "/tmp/elsewhere"
+    )
+    assert tracker_config.get_main_repo_root("/tmp/elsewhere") == "/tmp/elsewhere"
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([os.path.abspath(__file__), "-v"]))

--- a/hooks/test_tracker_config.py
+++ b/hooks/test_tracker_config.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Tests for tracker_config.py — provider detection and issue-key recovery."""
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_module_path = Path(__file__).parent / "tracker_config.py"
+_spec = importlib.util.spec_from_file_location("tracker_config", _module_path)
+assert _spec and _spec.loader
+tracker_config = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(tracker_config)
+
+
+def write_repo(root: Path, pappardelle: str = "", beads: str | None = None) -> Path:
+    """Lay out a repo with a .pappardelle.yml and optionally a .beads/config.yaml."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / ".pappardelle.yml").write_text(pappardelle)
+    if beads is not None:
+        (root / ".beads").mkdir(exist_ok=True)
+        (root / ".beads" / "config.yaml").write_text(beads)
+    return root
+
+
+# ---------------------------------------------------------------------------
+# get_tracker_provider
+# ---------------------------------------------------------------------------
+
+
+def test_provider_defaults_to_linear_without_config(tmp_path):
+    assert tracker_config.get_tracker_provider(str(tmp_path)) == "linear"
+
+
+def test_provider_reads_beads(tmp_path):
+    repo = write_repo(tmp_path, "version: 1\nissue_tracker:\n  provider: beads\n")
+    assert tracker_config.get_tracker_provider(str(repo)) == "beads"
+
+
+def test_provider_reads_jira(tmp_path):
+    repo = write_repo(
+        tmp_path,
+        "version: 1\nissue_tracker:\n  provider: jira\n  base_url: https://x.atlassian.net\n",
+    )
+    assert tracker_config.get_tracker_provider(str(repo)) == "jira"
+
+
+def test_provider_skips_comment_lines_between_key_and_value(tmp_path):
+    repo = write_repo(
+        tmp_path,
+        "version: 1\nissue_tracker:\n  # which tracker\n  provider: beads\n",
+    )
+    assert tracker_config.get_tracker_provider(str(repo)) == "beads"
+
+
+def test_provider_found_from_a_subdirectory(tmp_path):
+    repo = write_repo(tmp_path, "version: 1\nissue_tracker:\n  provider: beads\n")
+    nested = repo / "src" / "deep"
+    nested.mkdir(parents=True)
+    assert tracker_config.get_tracker_provider(str(nested)) == "beads"
+
+
+# ---------------------------------------------------------------------------
+# get_beads_prefix
+# ---------------------------------------------------------------------------
+
+
+def test_beads_prefix_prefers_beads_config(tmp_path):
+    repo = write_repo(
+        tmp_path,
+        "version: 1\nteam_prefix: fallback\n",
+        beads='issue-prefix: "myproj"\n',
+    )
+    assert tracker_config.get_beads_prefix(str(repo)) == "myproj"
+
+
+def test_beads_prefix_falls_back_to_team_prefix(tmp_path):
+    # .beads/config.yaml ships with issue-prefix commented out, so team_prefix
+    # is what most repos will actually have set.
+    repo = write_repo(tmp_path, "version: 1\nteam_prefix: Pap\n", beads='# issue-prefix: ""\n')
+    assert tracker_config.get_beads_prefix(str(repo)) == "pap"
+
+
+def test_beads_prefix_is_none_when_unset(tmp_path):
+    repo = write_repo(tmp_path, "version: 1\n")
+    assert tracker_config.get_beads_prefix(str(repo)) is None
+
+
+# ---------------------------------------------------------------------------
+# get_beads_prefixes
+# ---------------------------------------------------------------------------
+
+
+_MULTI_PREFIX_CONFIG = """version: 1
+team_prefix: myproj
+issue_tracker:
+  provider: beads
+profiles:
+  backend:
+    keywords: [api]
+    team_prefix: my_service
+  vendor:
+    keywords: [sdk]
+    tracker_projects:
+      - 'vendor-sdk'
+      - "Other-Thing"
+"""
+
+
+def test_beads_prefixes_collects_every_configured_source(tmp_path):
+    repo = write_repo(tmp_path, _MULTI_PREFIX_CONFIG)
+    assert sorted(tracker_config.get_beads_prefixes(str(repo))) == [
+        "my_service",
+        "myproj",
+        "other-thing",
+        "vendor-sdk",
+    ]
+
+
+def test_beads_prefixes_reads_an_inline_tracker_projects_list(tmp_path):
+    repo = write_repo(
+        tmp_path,
+        "version: 1\nteam_prefix: myproj\nprofiles:\n"
+        "  vendor:\n    tracker_projects: [vendor-sdk, 'Other-Thing']\n",
+    )
+    assert sorted(tracker_config.get_beads_prefixes(str(repo))) == [
+        "myproj",
+        "other-thing",
+        "vendor-sdk",
+    ]
+
+
+def test_beads_prefixes_ignores_trailing_comments(tmp_path):
+    repo = write_repo(
+        tmp_path,
+        "version: 1\nteam_prefix: myproj  # the database prefix\nprofiles:\n"
+        "  vendor:\n    tracker_projects:\n      - vendor-sdk # current\n",
+    )
+    assert sorted(tracker_config.get_beads_prefixes(str(repo))) == [
+        "myproj",
+        "vendor-sdk",
+    ]
+
+
+def test_finds_beads_key_under_an_inline_tracker_project_prefix(tmp_path):
+    repo = write_repo(
+        tmp_path / "vendor-sdk-hic",
+        "version: 1\nteam_prefix: myproj\nissue_tracker:\n  provider: beads\n"
+        "profiles:\n  vendor:\n    tracker_projects: [vendor-sdk]\n",
+    )
+    assert tracker_config.find_issue_key(str(repo)) == "vendor-sdk-hic"
+
+
+def test_beads_prefixes_is_just_the_database_prefix_without_profiles(tmp_path):
+    repo = write_repo(tmp_path, "version: 1\nteam_prefix: solo\n")
+    assert tracker_config.get_beads_prefixes(str(repo)) == ["solo"]
+
+
+def test_beads_prefixes_is_empty_when_nothing_is_configured(tmp_path):
+    repo = write_repo(tmp_path, "version: 1\n")
+    assert tracker_config.get_beads_prefixes(str(repo)) == []
+
+
+def test_global_prefix_matches_workspaces_when_database_prefix_differs(tmp_path):
+    repo = write_repo(
+        tmp_path / "other-abc",
+        "team_prefix: Other\nissue_tracker:\n  provider: beads\n",
+        "issue-prefix: current\n",
+    )
+    assert tracker_config.get_beads_prefixes(str(repo)) == ["current", "other"]
+    assert tracker_config.find_issue_key(str(repo)) == "other-abc"
+
+
+def test_beads_prefixes_deduplicates_case_insensitively(tmp_path):
+    repo = write_repo(
+        tmp_path,
+        "version: 1\nteam_prefix: pap\nprofiles:\n  a:\n    team_prefix: PAP\n",
+    )
+    assert tracker_config.get_beads_prefixes(str(repo)) == ["pap"]
+
+
+# ---------------------------------------------------------------------------
+# find_issue_key
+# ---------------------------------------------------------------------------
+
+
+def test_finds_classic_issue_key(tmp_path):
+    repo = write_repo(tmp_path / "STA-123", "version: 1\n")
+    assert tracker_config.find_issue_key(str(repo)) == "STA-123"
+
+
+def test_ignores_ordinary_directory_names(tmp_path):
+    repo = write_repo(tmp_path / "my-app", "version: 1\n")
+    assert tracker_config.find_issue_key(str(repo)) is None
+
+
+def test_finds_beads_key_when_prefix_matches(tmp_path):
+    repo = write_repo(
+        tmp_path / "pap-a1b2",
+        "version: 1\nteam_prefix: pap\nissue_tracker:\n  provider: beads\n",
+    )
+    assert tracker_config.find_issue_key(str(repo)) == "pap-a1b2"
+
+
+def test_finds_beads_child_key(tmp_path):
+    repo = write_repo(
+        tmp_path / "pap-a1b2.1",
+        "version: 1\nteam_prefix: pap\nissue_tracker:\n  provider: beads\n",
+    )
+    assert tracker_config.find_issue_key(str(repo)) == "pap-a1b2.1"
+
+
+def test_beads_matching_is_anchored_to_the_configured_prefix(tmp_path):
+    # Without this anchor, any hyphenated path component would read as an issue.
+    repo = write_repo(
+        tmp_path / "some-dir",
+        "version: 1\nteam_prefix: pap\nissue_tracker:\n  provider: beads\n",
+    )
+    assert tracker_config.find_issue_key(str(repo)) is None
+
+
+def test_beads_key_ignored_when_no_prefix_is_configured(tmp_path):
+    repo = write_repo(tmp_path / "pap-a1b2", "version: 1\nissue_tracker:\n  provider: beads\n")
+    assert tracker_config.find_issue_key(str(repo)) is None
+
+
+def test_lowercase_key_ignored_under_a_non_beads_tracker(tmp_path):
+    repo = write_repo(tmp_path / "pap-a1b2", "version: 1\nteam_prefix: pap\n")
+    assert tracker_config.find_issue_key(str(repo)) is None
+
+
+def test_finds_beads_key_under_a_profile_tracker_project_prefix(tmp_path):
+    # A workspace minted under a profile's tracker_projects prefix is a real
+    # workspace; matching only the database prefix stranded it on the fallback
+    # branch key and silently skipped its comments.
+    repo = write_repo(tmp_path / "vendor-sdk-hic", _MULTI_PREFIX_CONFIG)
+    assert tracker_config.find_issue_key(str(repo)) == "vendor-sdk-hic"
+
+
+def test_finds_beads_key_under_a_profile_team_prefix(tmp_path):
+    repo = write_repo(tmp_path / "my_service-a1b2", _MULTI_PREFIX_CONFIG)
+    assert tracker_config.find_issue_key(str(repo)) == "my_service-a1b2"
+
+
+def test_workspace_directory_wins_over_a_key_shaped_parent(tmp_path):
+    # The repo directory sits above the workspace directory and is itself
+    # key-shaped whenever a configured prefix is a strict prefix of it. Scanning
+    # root-first returned "vendor-sdk" and filed status against no issue at all.
+    repo = write_repo(
+        tmp_path / "vendor-sdk" / "vendor-a1b2",
+        "version: 1\nteam_prefix: vendor\nissue_tracker:\n  provider: beads\n",
+    )
+    assert tracker_config.find_issue_key(str(repo)) == "vendor-a1b2"
+
+
+def test_main_checkout_is_not_its_own_issue_key(tmp_path, monkeypatch):
+    # A beads prefix defaults to the repo directory name and may be a strict
+    # prefix of it, so the main checkout's own directory is key-shaped. The
+    # worktree case is saved by deepest-first ordering; the main checkout has
+    # nothing deeper, and this returned "vendor-sdk" for the one path whose
+    # contract says there is no issue — filing status and comments against an
+    # issue that does not exist.
+    repo = write_repo(
+        tmp_path / "vendor-sdk",
+        "version: 1\nteam_prefix: vendor\nissue_tracker:\n  provider: beads\n",
+    )
+    monkeypatch.setattr(tracker_config, "get_main_repo_root", lambda start=None: str(repo))
+    assert tracker_config.find_issue_key(str(repo)) is None
+
+
+def test_workspace_under_a_key_shaped_main_checkout_still_resolves(tmp_path, monkeypatch):
+    # Dropping the main root must not cost us the real workspace below it.
+    checkout = write_repo(
+        tmp_path / "vendor-sdk",
+        "version: 1\nteam_prefix: vendor\nissue_tracker:\n  provider: beads\n",
+    )
+    workspace = checkout / "vendor-a1b2"
+    workspace.mkdir()
+    monkeypatch.setattr(tracker_config, "get_main_repo_root", lambda start=None: str(checkout))
+    assert tracker_config.find_issue_key(str(workspace)) == "vendor-a1b2"
+
+
+def test_multi_prefix_config_still_rejects_ordinary_directory_names(tmp_path):
+    repo = write_repo(tmp_path / "fix-crash", _MULTI_PREFIX_CONFIG)
+    assert tracker_config.find_issue_key(str(repo)) is None
+
+
+# ---------------------------------------------------------------------------
+# find_repo_config — worktree fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def worktree(tmp_path, monkeypatch):
+    """A linked worktree that carries no config, plus its main checkout.
+
+    Mirrors the machine setups that put .pappardelle.yml and .beads/ in
+    .git/info/exclude: the worktree is a real directory outside the main
+    checkout, so walking up from it can never reach the config.
+    """
+    checkout = tmp_path / "checkout"
+    linked = tmp_path / "worktrees" / "pap-a1b2"
+    linked.mkdir(parents=True)
+    monkeypatch.setattr(tracker_config, "get_main_repo_root", lambda start=None: str(checkout))
+    return checkout, linked
+
+
+def test_provider_resolves_from_the_main_checkout_in_a_worktree(worktree):
+    checkout, linked = worktree
+    write_repo(checkout, "version: 1\nissue_tracker:\n  provider: beads\n")
+    assert tracker_config.get_tracker_provider(str(linked)) == "beads"
+
+
+def test_beads_prefix_resolves_from_the_main_checkout_in_a_worktree(worktree):
+    checkout, linked = worktree
+    write_repo(checkout, "version: 1\n", beads="issue-prefix: pap\n")
+    assert tracker_config.get_beads_prefix(str(linked)) == "pap"
+
+
+def test_profile_prefixes_resolve_from_the_main_checkout_in_a_worktree(worktree):
+    checkout, linked = worktree
+    write_repo(checkout, _MULTI_PREFIX_CONFIG)
+    assert "vendor-sdk" in tracker_config.get_beads_prefixes(str(linked))
+
+
+def test_issue_key_recovered_from_a_worktree_with_no_config_of_its_own(worktree):
+    # The bug this fixes: the key was unrecoverable, so update-status.py fell
+    # through to its "<repo>-<branch>" fallback and wrote status under a name
+    # the sidebar never reads — "pappardelle-pap-a1b2.json" for "pap-a1b2".
+    checkout, linked = worktree
+    write_repo(checkout, "version: 1\nteam_prefix: pap\nissue_tracker:\n  provider: beads\n")
+    assert tracker_config.find_issue_key(str(linked)) == "pap-a1b2"
+
+
+def test_a_local_config_is_used_without_consulting_git(tmp_path, monkeypatch):
+    # The fallback forks git, and this runs on every tool use. The main checkout
+    # must never pay for it.
+    def fail(start=None):
+        raise AssertionError("git should not be consulted when the config is on the path")
+
+    monkeypatch.setattr(tracker_config, "get_main_repo_root", fail)
+    repo = write_repo(tmp_path, "version: 1\nissue_tracker:\n  provider: beads\n")
+    assert tracker_config.get_tracker_provider(str(repo)) == "beads"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([os.path.abspath(__file__), "-v"]))

--- a/hooks/test_update_status.py
+++ b/hooks/test_update_status.py
@@ -205,6 +205,51 @@ class TestGetWorkspaceName:
         unknown_file = tmp_path / "unknown.json"
         assert not unknown_file.exists(), "Should NOT write to unknown.json when branch is detected"
 
+    def test_recovers_beads_key_from_a_worktree_with_no_config_of_its_own(self, tmp_path):
+        """A beads worktree resolves its key through the main checkout's config.
+
+        .pappardelle.yml and .beads/ are commonly excluded rather than committed,
+        so a linked worktree has neither and used to fall through to the branch
+        fallback — writing 'pappardelle-pap-a1b2.json' for issue 'pap-a1b2',
+        which the sidebar never reads.
+        """
+        import update_status as us
+
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        (checkout / ".pappardelle.yml").write_text(
+            "version: 1\nteam_prefix: pap\nissue_tracker:\n  provider: beads\n"
+        )
+        linked = tmp_path / "worktrees" / "pap-a1b2"
+        linked.mkdir(parents=True)
+
+        with patch.object(us._tracker_mod, "get_main_repo_root", return_value=str(checkout)):
+            assert get_workspace_name(str(linked)) == "pap-a1b2"
+
+    def test_branch_fallback_asks_git_about_the_given_cwd(self):
+        """The fallback describes the workspace the hook was told about.
+
+        Without an explicit cwd, git answered for whatever directory the hook
+        process happened to inherit, which is not the workspace being reported.
+        """
+        seen = []
+
+        def mock_run(cmd, **kwargs):
+            seen.append(kwargs.get("cwd"))
+            if "--abbrev-ref" in cmd:
+                return type("Result", (), {"returncode": 0, "stdout": "feature-x\n"})()
+            if "--show-toplevel" in cmd:
+                return type("Result", (), {"returncode": 0, "stdout": "/Users/charlie/cs/myproj\n"})()
+            return type("Result", (), {"returncode": 1, "stdout": ""})()
+
+        with (
+            patch("os.getcwd", return_value="/somewhere/else"),
+            patch("subprocess.run", side_effect=mock_run),
+        ):
+            assert get_workspace_name("/Users/charlie/cs/myproj") == "myproj-feature-x"
+
+        assert seen == ["/Users/charlie/cs/myproj", "/Users/charlie/cs/myproj"]
+
 
 class TestStatusDetermination:
     """Tests for determining status from hook events.

--- a/hooks/tracker_config.py
+++ b/hooks/tracker_config.py
@@ -1,18 +1,5 @@
 #!/usr/bin/env python3
-"""Shared tracker detection for Pappardelle's Claude Code hooks.
-
-Hooks run on every tool use, so this module deliberately avoids PyYAML and any
-subprocess calls: config files are read with regexes and the results are cached
-per process.
-
-The workspace's issue key is recovered from the cwd, because pappardelle names
-each worktree after the issue it was created for. That is trivial for Linear and
-Jira (``STA-123``) but not for beads, whose IDs are lowercase with a content
-hash for a suffix (``bd-a1b2``) and therefore indistinguishable from an ordinary
-directory name like ``my-app``. For beads the match is anchored to the repo's
-configured issue prefixes so an arbitrary path component can never be mistaken
-for an issue.
-"""
+"""Shared tracker detection for Pappardelle's Claude Code hooks."""
 
 import os
 import re
@@ -103,18 +90,11 @@ def _read(path: Optional[str]) -> str:
 def find_repo_config(filename: str, start: Optional[str] = None) -> Optional[str]:
     """Locate a repo-level config file, resolving through linked worktrees.
 
-    `.pappardelle.yml` and `.beads/` are routinely listed in `.git/info/exclude`
-    rather than committed, so a linked worktree never receives a copy and only
-    the main checkout has one. `.pappardelle.local.yml` is the opposite:
-    workspace setup copies it *into* each worktree, so the worktree's own copy is
-    the one that should win. Resolving per file rather than per directory is what
-    lets both be true at once.
-
-    The working tree is searched first: it is pure filesystem work, it answers
-    for the main checkout, and it keeps `git` out of the common path on a hook
-    that runs on every tool use.
-
-    Mirrors `findRepoConfig` in source/config.ts.
+    `.pappardelle.yml` and `.beads/` are usually excluded rather than committed,
+    so only the main checkout has one; `.pappardelle.local.yml` is copied into
+    each worktree, so the worktree's copy wins. Resolving per file rather than
+    per directory lets both be true at once. Mirrors `findRepoConfig` in
+    source/config.ts.
     """
     try:
         origin = start if start is not None else os.getcwd()
@@ -221,6 +201,14 @@ def get_main_repo_root(start: Optional[str] = None) -> Optional[str]:
 
 
 def _resolve_main_repo_root(start: Optional[str]) -> Optional[str]:
+    # Set on the workspace's tmux session when pappardelle created it, so a hook
+    # running inside a worktree is told the main checkout instead of forking git
+    # for it on every tool use. An explicit `start` overrides: the caller is
+    # asking about some other directory, not this workspace.
+    injected = os.environ.get("PAPPARDELLE_MAIN_REPO_ROOT")
+    if start is None and injected:
+        return injected
+
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],

--- a/hooks/tracker_config.py
+++ b/hooks/tracker_config.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Shared tracker detection for Pappardelle's Claude Code hooks.
+
+Hooks run on every tool use, so this module deliberately avoids PyYAML and any
+subprocess calls: config files are read with regexes and the results are cached
+per process.
+
+The workspace's issue key is recovered from the cwd, because pappardelle names
+each worktree after the issue it was created for. That is trivial for Linear and
+Jira (``STA-123``) but not for beads, whose IDs are lowercase with a content
+hash for a suffix (``bd-a1b2``) and therefore indistinguishable from an ordinary
+directory name like ``my-app``. For beads the match is anchored to the repo's
+configured issue prefixes so an arbitrary path component can never be mistaken
+for an issue.
+"""
+
+import os
+import re
+import subprocess
+from typing import Optional
+
+_MAX_PARENT_WALK = 20
+
+_MAIN_REPO_ROOT_CACHE: dict[str, Optional[str]] = {}
+
+# Linear/Jira: uppercase alphabetic prefix, numeric suffix (STA-123).
+_CLASSIC_KEY_RE = re.compile(r"^[A-Z]+-\d+$")
+
+_PROVIDER_RE = re.compile(r"issue_tracker:\s*\n(?:\s*#[^\n]*\n)*\s+provider:\s*(\w+)")
+_TEAM_PREFIX_RE = re.compile(
+    r"^team_prefix:[ \t]*[\"']?([A-Za-z0-9_-]+)[\"']?[ \t]*(?:#[^\n]*)?$", re.MULTILINE
+)
+_BEADS_PREFIX_RE = re.compile(
+    r"^issue-prefix:[ \t]*[\"']?([A-Za-z0-9_-]+)[\"']?[ \t]*(?:#[^\n]*)?$", re.MULTILINE
+)
+
+# Per-profile prefix sources, which are indented and therefore missed by the
+# anchored top-level patterns above. `tracker_projects` entries name beads ID
+# prefixes the same way they name Linear/Jira projects for the other trackers.
+_PROFILE_TEAM_PREFIX_RE = re.compile(
+    r"^[ \t]+team_prefix:[ \t]*[\"']?([A-Za-z0-9_-]+)[\"']?[ \t]*(?:#[^\n]*)?$",
+    re.MULTILINE,
+)
+_TRACKER_PROJECTS_BLOCK_RE = re.compile(
+    r"^[ \t]+tracker_projects:[ \t]*(?:#[^\n]*)?$((?:\n[ \t]*-[^\n]*)+)", re.MULTILINE
+)
+# The flow-sequence spelling of the same list. YAML accepts both, config.ts goes
+# through a real parser and so accepts both, and a hook that understood only the
+# block form left those workspaces unmatched.
+_TRACKER_PROJECTS_INLINE_RE = re.compile(
+    r"^[ \t]+tracker_projects:[ \t]*\[([^\]\n]*)\]", re.MULTILINE
+)
+_LIST_ITEM_RE = re.compile(r"^[ \t]*-[ \t]*([^\n]*)$", re.MULTILINE)
+_TRAILING_COMMENT_RE = re.compile(r"(?:^|\s)#.*$")
+
+
+def _scalar(raw: str) -> str:
+    """A YAML scalar reduced to its value: trailing comment and quotes removed."""
+    value = _TRAILING_COMMENT_RE.sub("", raw.strip()).strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        value = value[1:-1].strip()
+    return value
+
+
+def find_up(filename: str, start: Optional[str] = None) -> Optional[str]:
+    """Walk up from `start` (default cwd) looking for `filename`.
+
+    The walk stops at the working tree it started in — the first ancestor
+    holding a `.git` entry — so a stray `.pappardelle.yml` in a parent of the
+    repo is never picked up. `findRepoConfig` in source/config.ts tests the
+    working-tree root and nothing above it, and a hook that read further would
+    resolve a different provider than the TUI for the same workspace.
+    """
+    try:
+        current = start if start is not None else os.getcwd()
+    except OSError:
+        return None
+
+    for _ in range(_MAX_PARENT_WALK):
+        candidate = os.path.join(current, filename)
+        if os.path.exists(candidate):
+            return candidate
+        if os.path.exists(os.path.join(current, ".git")):
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+
+    return None
+
+
+def _read(path: Optional[str]) -> str:
+    if not path:
+        return ""
+    try:
+        with open(path) as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def find_repo_config(filename: str, start: Optional[str] = None) -> Optional[str]:
+    """Locate a repo-level config file, resolving through linked worktrees.
+
+    `.pappardelle.yml` and `.beads/` are routinely listed in `.git/info/exclude`
+    rather than committed, so a linked worktree never receives a copy and only
+    the main checkout has one. `.pappardelle.local.yml` is the opposite:
+    workspace setup copies it *into* each worktree, so the worktree's own copy is
+    the one that should win. Resolving per file rather than per directory is what
+    lets both be true at once.
+
+    The working tree is searched first: it is pure filesystem work, it answers
+    for the main checkout, and it keeps `git` out of the common path on a hook
+    that runs on every tool use.
+
+    Mirrors `findRepoConfig` in source/config.ts.
+    """
+    try:
+        origin = start if start is not None else os.getcwd()
+    except OSError:
+        return None
+
+    found = find_up(filename, origin)
+    if found:
+        return found
+
+    main_root = get_main_repo_root(origin)
+    if not main_root or main_root == origin:
+        return None
+
+    return find_up(filename, main_root)
+
+
+def get_tracker_provider(start: Optional[str] = None) -> str:
+    """Read issue_tracker.provider from .pappardelle.yml. Defaults to "linear"."""
+    match = _PROVIDER_RE.search(_read(find_repo_config(".pappardelle.yml", start)))
+    return match.group(1).strip() if match else "linear"
+
+
+def get_beads_prefix(start: Optional[str] = None) -> Optional[str]:
+    """The beads ID prefix for this repo.
+
+    Prefers an explicit `issue-prefix` in .beads/config.yaml; falls back to
+    pappardelle's own `team_prefix`, which serves the same role for the other
+    trackers. Returns None when neither is set, in which case callers should
+    keep the strict Linear/Jira key matching rather than guess.
+    """
+    match = _BEADS_PREFIX_RE.search(
+        _read(find_repo_config(os.path.join(".beads", "config.yaml"), start))
+    )
+    if match:
+        return match.group(1).strip().lower()
+
+    match = _TEAM_PREFIX_RE.search(_read(find_repo_config(".pappardelle.yml", start)))
+    if match:
+        return match.group(1).strip().lower()
+
+    return None
+
+
+def get_beads_prefixes(start: Optional[str] = None) -> list[str]:
+    """Every beads ID prefix this repo can mint keys under.
+
+    A database is not limited to one prefix: profiles carry their own
+    `team_prefix`, and their `tracker_projects` name beads prefixes the way they
+    name Linear/Jira projects for the other trackers. A workspace created under
+    any of them is a real workspace, so matching only the database prefix leaves
+    those hooks publishing under the fallback branch key and skipping comments.
+
+    Mirrors `getBeadsPrefixes` in source/config.ts. Order is stable but not
+    meaningful; callers test membership.
+    """
+    prefixes: list[str] = []
+
+    def add(value: Optional[str]) -> None:
+        if not value:
+            return
+        cleaned = value.strip().lower()
+        if cleaned and cleaned not in prefixes:
+            prefixes.append(cleaned)
+
+    add(get_beads_prefix(start))
+
+    config = _read(find_repo_config(".pappardelle.yml", start))
+    for match in _TEAM_PREFIX_RE.finditer(config):
+        add(match.group(1))
+    for match in _PROFILE_TEAM_PREFIX_RE.finditer(config):
+        add(match.group(1))
+
+    for block in _TRACKER_PROJECTS_BLOCK_RE.finditer(config):
+        for item in _LIST_ITEM_RE.finditer(block.group(1)):
+            add(_scalar(item.group(1)))
+
+    for inline in _TRACKER_PROJECTS_INLINE_RE.finditer(config):
+        for item in inline.group(1).split(","):
+            add(_scalar(item))
+
+    return prefixes
+
+
+def get_main_repo_root(start: Optional[str] = None) -> Optional[str]:
+    """The main repository root, resolved through worktrees.
+
+    Every bd invocation must run here so all worktrees share one canonical
+    database. A worktree carries its own checked-out `.beads/` directory, so
+    running bd from inside one makes it auto-discover that copy and write the
+    comment somewhere the ticket rail never reads.
+
+    Memoized because config lookup falls back to it several times per hook
+    event — once each for the provider, the beads prefix, and the profile
+    prefixes — and each miss would otherwise fork git.
+    """
+    key = start if start is not None else ""
+    if key in _MAIN_REPO_ROOT_CACHE:
+        return _MAIN_REPO_ROOT_CACHE[key]
+
+    root = _resolve_main_repo_root(start)
+    _MAIN_REPO_ROOT_CACHE[key] = root
+    return root
+
+
+def _resolve_main_repo_root(start: Optional[str]) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=start,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return os.path.dirname(result.stdout.strip().rstrip("/"))
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+    return None
+
+
+def _looks_like_beads_key(part: str, prefix: str) -> bool:
+    return bool(re.fullmatch(re.escape(prefix) + r"-[a-z0-9_]+(\.\d+){0,3}", part.lower()))
+
+
+def _looks_like_classic_key(part: str) -> bool:
+    return bool(_CLASSIC_KEY_RE.fullmatch(part))
+
+
+def _key_candidates(cwd: str) -> list[tuple[str, str]]:
+    """Every path segment that could be an issue key, as (full path, segment).
+
+    Deepest first: the repo directory sits above the workspace directory and can
+    be key-shaped itself, since a beads prefix defaults to a repo directory name
+    and may be a strict prefix of it (`vendor` under
+    ~/.worktrees/vendor-sdk/vendor-sdk-a1b2). Scanning root-first returned the
+    repo directory and filed status and comments against a nonexistent issue.
+    """
+    segments = cwd.split("/")
+    return [
+        ("/".join(segments[: i + 1]), segments[i])
+        for i in reversed(range(len(segments)))
+        if "-" in segments[i]
+    ]
+
+
+def _find_beads_key(candidates: list[tuple[str, str]], cwd: str) -> Optional[str]:
+    beads_prefixes = get_beads_prefixes(cwd)
+    if not beads_prefixes:
+        return None
+
+    # Ordering only saves the key-shaped repo directory when something deeper
+    # outranks it. In the main checkout nothing does, so `vendor-sdk` under a
+    # `vendor` prefix matched itself and this returned a key for the one path
+    # the contract says has none. The main root is never a workspace, so drop
+    # it by identity rather than trying to out-rank it. get_beads_prefixes has
+    # already resolved and cached this, so it costs no extra git call.
+    main_root = get_main_repo_root(cwd)
+    main_real = os.path.realpath(main_root) if main_root else None
+
+    for candidate_path, part in candidates:
+        if main_real and os.path.realpath(candidate_path) == main_real:
+            continue
+        if any(_looks_like_beads_key(part, prefix) for prefix in beads_prefixes):
+            return part
+
+    return None
+
+
+def find_issue_key(cwd: Optional[str] = None) -> Optional[str]:
+    """Recover the workspace's issue key from a worktree path.
+
+    Expected shape: ~/.worktrees/<repo>/<issue-key>/...
+    Returns None for the main worktree or any path with no issue in it.
+
+    The Linear/Jira shape is checked first because it needs no file I/O, and
+    update-status.py calls this on every hook event. Only when nothing matches
+    does the beads path read config to learn the repo's issue prefixes.
+    """
+    if cwd is None:
+        try:
+            cwd = os.getcwd()
+        except OSError:
+            return None
+
+    candidates = _key_candidates(cwd)
+
+    for _, part in candidates:
+        if _looks_like_classic_key(part):
+            return part
+
+    if not candidates or get_tracker_provider(cwd) != "beads":
+        return None
+
+    return _find_beads_key(candidates, cwd)

--- a/hooks/tracker_config.py
+++ b/hooks/tracker_config.py
@@ -90,10 +90,11 @@ def _read(path: Optional[str]) -> str:
 def find_repo_config(filename: str, start: Optional[str] = None) -> Optional[str]:
     """Locate a repo-level config file, resolving through linked worktrees.
 
-    `.pappardelle.yml` and `.beads/` are usually excluded rather than committed,
-    so only the main checkout has one; `.pappardelle.local.yml` is copied into
-    each worktree, so the worktree's copy wins. Resolving per file rather than
-    per directory lets both be true at once. Mirrors `findRepoConfig` in
+    Working tree first, main checkout second, resolved per file. A committed
+    `.pappardelle.yml` is checked out into the worktree and found there; one kept
+    out of git, and `.beads/`, exist only in the main checkout.
+    `.pappardelle.local.yml` is gitignored but copied into each worktree by
+    workspace setup, so the worktree's copy wins. Mirrors `findRepoConfig` in
     source/config.ts.
     """
     try:

--- a/hooks/update-status.py
+++ b/hooks/update-status.py
@@ -18,6 +18,7 @@ Status values:
     - error: An error occurred
 """
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -25,6 +26,15 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
+
+_tracker_module_path = Path(__file__).parent / "tracker_config.py"
+_tracker_spec = importlib.util.spec_from_file_location("tracker_config", _tracker_module_path)
+if _tracker_spec and _tracker_spec.loader:
+    _tracker_mod = importlib.util.module_from_spec(_tracker_spec)
+    _tracker_spec.loader.exec_module(_tracker_mod)
+    find_issue_key = _tracker_mod.find_issue_key
+else:
+    raise ImportError(f"Could not load tracker_config from {_tracker_module_path}")
 
 # Debug mode - logs all hook events to a file
 # Set PAPPARDELLE_DEBUG=1 environment variable to enable logging
@@ -53,17 +63,10 @@ def get_workspace_name(cwd: Optional[str] = None) -> str:
             cwd = os.getcwd()
         except OSError:
             return "unknown"
-    parts = cwd.split("/")
-
-    # Look for Linear issue pattern (e.g., STA-123) in path components
     # Expected path: ~/.worktrees/stardust-labs/STA-123/...
-    for part in parts:
-        if part and "-" in part:
-            prefix = part.split("-")[0]
-            suffix = part.split("-", 1)[1] if "-" in part else ""
-            # Check if it looks like a Linear issue (e.g., STA-123, ABC-45)
-            if prefix.isupper() and prefix.isalpha() and suffix.isdigit():
-                return part
+    issue_key = find_issue_key(cwd)
+    if issue_key:
+        return issue_key
 
     # No issue key found — likely the main worktree. Detect branch name via git
     # and qualify with repo name to avoid collisions across repos
@@ -74,6 +77,7 @@ def get_workspace_name(cwd: Optional[str] = None) -> str:
             capture_output=True,
             text=True,
             timeout=5,
+            cwd=cwd,
         )
         if branch_result.returncode == 0:
             branch = branch_result.stdout.strip()
@@ -85,6 +89,7 @@ def get_workspace_name(cwd: Optional[str] = None) -> str:
                         capture_output=True,
                         text=True,
                         timeout=5,
+                        cwd=cwd,
                     )
                     if toplevel_result.returncode == 0:
                         repo_name = os.path.basename(toplevel_result.stdout.strip())

--- a/install.sh
+++ b/install.sh
@@ -145,6 +145,14 @@ else
     print_info "Install with: brew tap raegislabs/linctl && brew install linctl"
 fi
 
+# Optional: check bd
+if command -v bd &>/dev/null; then
+    print_status "bd installed (Beads integration)"
+else
+    print_info "bd not found (optional, for Beads integration)"
+    print_info "Install from: https://github.com/gastownhall/beads"
+fi
+
 # Optional: check gh
 if command -v gh &>/dev/null; then
     print_status "gh CLI installed (GitHub integration)"
@@ -250,6 +258,13 @@ if [[ -d "$HOOKS_SRC" ]]; then
         if [[ -f "$HOOKS_SRC/$hook" ]]; then
             cp "$HOOKS_SRC/$hook" "$HOOKS_DIR/"
             chmod +x "$HOOKS_DIR/$hook"
+        fi
+    done
+
+    # Helper modules imported by the hooks above
+    for module in markdown_to_adf.py acli_helpers.py tracker_config.py; do
+        if [[ -f "$HOOKS_SRC/$module" ]]; then
+            cp "$HOOKS_SRC/$module" "$HOOKS_DIR/"
         fi
     done
     print_status "Installed Claude Code hooks to $HOOKS_DIR/"

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -6,6 +6,7 @@ Standalone scripts that exercise pappardelle's providers and config against **re
 
 - **Linear**: `linctl` on your PATH, authenticated (`linctl auth login`)
 - **Jira**: `acli` on your PATH, authenticated, and `JIRA_BASE_URL` env var
+- **Beads**: `bd` on your PATH, run from a git repo whose `.beads` database has at least one issue
 - **GitHub**: `gh` on your PATH, authenticated, run from a repo with a GitHub remote
 - **GitLab**: `glab` on your PATH, authenticated, run from a repo with a GitLab remote
 - **Config**: run from a repo that has a `.pappardelle.yml`
@@ -18,6 +19,7 @@ Run from the `pappardelle/` directory:
 # Issue tracker providers
 npx tsx integration-tests/verify-linear.ts
 npx tsx integration-tests/verify-jira.ts
+npx tsx integration-tests/verify-beads.ts
 
 # VCS host providers
 npx tsx integration-tests/verify-github.ts
@@ -55,6 +57,7 @@ npx tsx integration-tests/verify-watchlist.ts
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `verify-linear.ts`                | getIssue, searchAssignedIssues, label parsing, caching, batch fetch, state colors                                                                            |
 | `verify-jira.ts`                  | Same as Linear but via acli CLI                                                                                                                              |
+| `verify-beads.ts`                 | Same as Linear but via the bd CLI; read-only unless `BEADS_WRITE=1`                                                                                          |
 | `verify-github.ts`                | PR detection by branch name, changedFiles count, buildPRUrl                                                                                                  |
 | `verify-gitlab.ts`                | MR detection by branch name, diff file count, buildPRUrl                                                                                                     |
 | `verify-config.ts`                | Config loading, validation, profiles, watchlist, keybindings, Claude config                                                                                  |
@@ -73,6 +76,10 @@ npx tsx integration-tests/verify-watchlist.ts
 | `JIRA_BASE_URL`   | verify-jira, verify-comments   | (required for Jira scripts) |
 | `JIRA_ISSUE`      | verify-jira, verify-comments   | (auto-detected or required) |
 | `JIRA_STATUSES`   | verify-jira                    | `To Do,In Progress`         |
+| `BEADS_ISSUE`     | verify-beads                   | (first result of `bd list`) |
+| `BEADS_STATUSES`  | verify-beads                   | (empty = all ready issues)  |
+| `BEADS_ASSIGNEE`  | verify-beads                   | (no assignee filter)        |
+| `BEADS_WRITE`     | verify-beads                   | unset (read-only)           |
 | `GITHUB_ISSUE`    | verify-github                  | `STA-683`                   |
 | `GITHUB_PR`       | verify-github                  | (auto-detected)             |
 | `GITLAB_HOST`     | verify-gitlab                  | `gitlab.com`                |

--- a/integration-tests/verify-beads.ts
+++ b/integration-tests/verify-beads.ts
@@ -1,0 +1,263 @@
+#!/usr/bin/env npx tsx
+/**
+ * Local verification script for BeadsProvider against a real beads database.
+ * NOT an ava test — run manually with `npx tsx integration-tests/verify-beads.ts`
+ *
+ * Read-only by default: nothing is created, updated, or commented on unless
+ * BEADS_WRITE=1 is set. Beads databases are real project data, and the global
+ * `~/.beads` fallback means a stray `bd create` can land in a database you did
+ * not mean to touch.
+ *
+ * Env vars:
+ *   BEADS_ISSUE     — issue ID to fetch (default: first result from `bd list`)
+ *   BEADS_STATUSES  — comma-separated statuses for the watchlist (default: none = all ready)
+ *   BEADS_ASSIGNEE  — assignee filter for the watchlist (default: none)
+ *   BEADS_WRITE     — set to 1 to also exercise createComment on BEADS_ISSUE
+ */
+
+import {execFile} from 'node:child_process';
+import {promisify} from 'node:util';
+import {BeadsProvider} from '../source/providers/beads-provider.ts';
+import {
+	getRepoRoot,
+	loadConfig,
+	matchProfileByProject,
+} from '../source/config.ts';
+
+const execFileAsync = promisify(execFile);
+
+const EXPLICIT_ISSUE = process.env['BEADS_ISSUE'];
+const STATUSES = (process.env['BEADS_STATUSES'] ?? '')
+	.split(',')
+	.map(s => s.trim())
+	.filter(s => s !== '');
+const ASSIGNEE = process.env['BEADS_ASSIGNEE'];
+const ALLOW_WRITES = process.env['BEADS_WRITE'] === '1';
+
+let failed = false;
+
+function header(title: string) {
+	console.log(`\n${'='.repeat(60)}`);
+	console.log(`  ${title}`);
+	console.log('='.repeat(60));
+}
+
+function pass(msg: string) {
+	console.log(`  ✅ ${msg}`);
+}
+
+function fail(msg: string) {
+	console.log(`  ❌ ${msg}`);
+	failed = true;
+}
+
+function skip(msg: string) {
+	console.log(`  ⏭️  ${msg}`);
+}
+
+function info(label: string, value: unknown) {
+	console.log(`  ${label}: ${JSON.stringify(value)}`);
+}
+
+async function firstIssueId(cwd: string): Promise<string | undefined> {
+	const {stdout} = await execFileAsync('bd', ['list', '--json', '-n', '5'], {
+		cwd,
+		env: {...process.env, BD_JSON_ENVELOPE: '1'},
+	});
+	const parsed = JSON.parse(stdout) as {data?: unknown} | unknown[];
+	const rows = Array.isArray(parsed) ? parsed : (parsed.data as unknown[]);
+	const first = rows?.[0] as {id?: string} | undefined;
+	return first?.id;
+}
+
+async function main() {
+	console.log('Beads Provider — Local Verification');
+
+	let repoRoot: string;
+	try {
+		repoRoot = getRepoRoot();
+	} catch {
+		console.error('❌ Not in a git repository — beads needs one.');
+		process.exit(1);
+	}
+
+	console.log(`Repo root: ${repoRoot}`);
+	console.log(`Writes: ${ALLOW_WRITES ? 'ENABLED' : 'disabled (read-only)'}`);
+
+	const provider = new BeadsProvider();
+
+	// ------------------------------------------------------------------
+	header('bd availability');
+	let issueId: string | undefined;
+	try {
+		issueId = EXPLICIT_ISSUE ?? (await firstIssueId(repoRoot));
+		pass('bd list succeeded');
+	} catch (error) {
+		fail(`bd is not usable from ${repoRoot}: ${String(error)}`);
+		process.exit(1);
+	}
+
+	if (!issueId) {
+		fail('No issues found — create one with `bd create` and re-run.');
+		process.exit(1);
+	}
+
+	info('Issue under test', issueId);
+
+	// ------------------------------------------------------------------
+	header('getIssue');
+	const issue = await provider.getIssue(issueId);
+	if (!issue) {
+		fail(`getIssue(${issueId}) returned null`);
+		process.exit(1);
+	}
+
+	info('identifier', issue.identifier);
+	info('title', issue.title);
+	info('state', issue.state);
+	info('project', issue.project);
+	info('labels', issue.labels);
+
+	if (issue.identifier === issueId) {
+		pass('identifier round-trips verbatim (no case mangling)');
+	} else {
+		fail(`identifier changed: asked ${issueId}, got ${issue.identifier}`);
+	}
+
+	if (issue.title.length > 0) {
+		pass('title is non-empty');
+	} else {
+		fail('title is empty');
+	}
+
+	// Copied from verify-linear, where states carry real hex colors. Beads has
+	// no per-status color of its own, so BEADS_STATUS_COLORS answers with ANSI
+	// names deliberately — they follow the user's terminal theme. Asserting hex
+	// here failed on every healthy database.
+	if (/^[a-z]+$/i.test(issue.state.color)) {
+		pass(`state color resolved (${issue.state.color})`);
+	} else {
+		fail(`state color is not an ANSI color name: ${issue.state.color}`);
+	}
+
+	const expectedPrefix = issueId
+		.split('.')[0]!
+		.slice(0, issueId.split('.')[0]!.lastIndexOf('-'));
+	if (issue.project?.key === expectedPrefix) {
+		pass(`project derived from the ID prefix (${expectedPrefix})`);
+	} else {
+		fail(
+			`project key ${String(issue.project?.key)} != prefix ${expectedPrefix}`,
+		);
+	}
+
+	// ------------------------------------------------------------------
+	header('Profile resolution from the ID prefix');
+	try {
+		const config = loadConfig();
+		const match = issue.project
+			? matchProfileByProject(config, issue.project.name, issue.project.key)
+			: null;
+		if (match) {
+			pass(`prefix routes to profile "${match.name}"`);
+		} else {
+			skip(
+				`no profile lists "${issue.project?.key}" in tracker_projects — the default profile will be used`,
+			);
+		}
+	} catch (error) {
+		skip(`config not loadable here: ${String(error)}`);
+	}
+
+	// ------------------------------------------------------------------
+	header('getIssueCached');
+	if (provider.getIssueCached(issueId)?.identifier === issueId) {
+		pass('cached read returns the fetched issue');
+	} else {
+		fail('cached read missed after a successful getIssue');
+	}
+
+	// ------------------------------------------------------------------
+	header('getIssues (batch)');
+	const batch = await provider.getIssues([issueId]);
+	if (batch.get(issueId)?.title === issue.title) {
+		pass('batch fetch agrees with the single fetch');
+	} else {
+		fail('batch fetch disagreed with the single fetch');
+	}
+
+	const missing = await provider.getIssues([`${issueId}-nonexistent`]);
+	if (missing.get(`${issueId}-nonexistent`) === null) {
+		pass('unknown key maps to null rather than throwing');
+	} else {
+		fail('unknown key did not map to null');
+	}
+
+	// ------------------------------------------------------------------
+	header('searchAssignedIssues (bd ready)');
+	const ready = await provider.searchAssignedIssues(ASSIGNEE, STATUSES);
+	info('ready count', ready.length);
+	for (const r of ready.slice(0, 5)) {
+		console.log(`    ${r.identifier}  [${r.state.name}]  ${r.title}`);
+	}
+
+	if (STATUSES.length > 0) {
+		const offList = ready.filter(
+			r =>
+				!STATUSES.some(
+					s =>
+						s.toLowerCase() === r.state.type.toLowerCase() ||
+						s.toLowerCase() === r.state.name.toLowerCase(),
+				),
+		);
+		if (offList.length === 0) {
+			pass(
+				`every result matches the configured statuses (${STATUSES.join(', ')})`,
+			);
+		} else {
+			fail(`${offList.length} results fall outside the configured statuses`);
+		}
+	} else {
+		pass('no status filter configured — every ready issue returned');
+	}
+
+	if (ready.every(r => r.state.type !== 'completed')) {
+		pass('no closed issues in the ready set');
+	} else {
+		fail('bd ready returned a closed issue');
+	}
+
+	// ------------------------------------------------------------------
+	header('buildIssueUrl');
+	if (provider.buildIssueUrl() === '') {
+		pass('no URL, as expected for a local tracker');
+	} else {
+		fail('buildIssueUrl returned something — beads issues have no web page');
+	}
+
+	// ------------------------------------------------------------------
+	header('createComment');
+	if (ALLOW_WRITES) {
+		const body = `Pappardelle verify-beads smoke test — ${new Date().toISOString()}`;
+		if (await provider.createComment(issueId, body)) {
+			pass(
+				`comment posted to ${issueId} (check with \`bd comments ${issueId}\`)`,
+			);
+		} else {
+			fail('createComment returned false');
+		}
+	} else {
+		skip('set BEADS_WRITE=1 to exercise createComment');
+	}
+
+	// ------------------------------------------------------------------
+	header('Summary');
+	if (failed) {
+		console.log('  ❌ Some checks failed');
+		process.exit(1);
+	}
+
+	console.log('  ✅ All checks passed');
+}
+
+await main();

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
 			"ts": "module",
 			"tsx": "module"
 		},
-		"nodeArguments": [
-			"--experimental-strip-types"
+		"require": [
+			"./test/helpers/register-tsx.cjs"
 		]
 	},
 	"xo": {

--- a/pappardelle-config.md
+++ b/pappardelle-config.md
@@ -12,7 +12,7 @@ The `.pappardelle.yml` file replaces the previous `.git` directory requirement. 
 - **Profile-based**: Different project types (iOS apps, backend services) have named profiles
 - **Required**: Pappardelle exits with an error if no layer provides a config file
 - **Templated**: Supports variable expansion for dynamic values
-- **Provider-agnostic**: Supports multiple issue trackers (Linear, Jira) and VCS hosts (GitHub, GitLab)
+- **Provider-agnostic**: Supports multiple issue trackers (Linear, Jira, Beads) and VCS hosts (GitHub, GitLab)
 
 ## File Location
 
@@ -34,7 +34,7 @@ version: 1
 
 # Issue tracker provider (optional, defaults to linear)
 issue_tracker:
-  provider: linear # "linear" or "jira"
+  provider: linear # "linear", "jira", or "beads"
   # base_url: https://mycompany.atlassian.net  # Required for jira
 
 # VCS host provider (optional, defaults to github)
@@ -121,7 +121,8 @@ profiles:
     # is checked against these entries to auto-select the profile. On Linear,
     # entries are project names; on Jira, an entry may be either the project's
     # display name ("Pappardelle Testing") or its key ("KAN") — both match
-    # (STA-1649).
+    # (STA-1649). Beads has no project field, so entries are ID prefixes:
+    # "myproj" matches myproj-a1b2.
     #
     # The FIRST entry doubles as the default project for newly-created issues:
     # `idow "add dark mode"` resolves the matched profile, takes
@@ -258,24 +259,25 @@ profiles:
 
 The following variables are available for use in templates:
 
-| Variable              | Description                                | Example                                                  |
-| --------------------- | ------------------------------------------ | -------------------------------------------------------- |
-| `${ISSUE_KEY}`        | Issue key                                  | `STA-361`                                                |
-| `${ISSUE_NUMBER}`     | Numeric part of issue key                  | `361`                                                    |
-| `${ISSUE_URL}`        | Full issue URL (tracker-specific)          | `https://linear.app/...` or `https://jira.../browse/...` |
-| `${TITLE}`            | Issue title                                | `Add dark mode`                                          |
-| `${DESCRIPTION}`      | Issue description                          | (full text)                                              |
-| `${WORKTREE_PATH}`    | Full path to worktree                      | `/Users/charlie/.worktrees/stardust-labs/STA-361`        |
-| `${REPO_ROOT}`        | Git repository root                        | `/Users/charlie/code/stardust-labs`                      |
-| `${REPO_NAME}`        | Repository directory name                  | `stardust-labs`                                          |
-| `${PR_URL}`           | GitHub PR URL (may be empty)               | `https://github.com/...`                                 |
-| `${MR_URL}`           | GitLab MR URL (may be empty)               | `https://gitlab.com/.../merge_requests/1`                |
-| `${SCRIPT_DIR}`       | Directory containing dow/idow scripts      | `/path/to/_dev/scripts/pappardelle/scripts`              |
-| `${HOME}`             | User home directory                        | `/Users/charlie`                                         |
-| `${VCS_LABEL}`        | VCS label from profile (provider-agnostic) | `stardust_jams`                                          |
-| `${GITHUB_LABEL}`     | Deprecated alias for `${VCS_LABEL}`        | `stardust_jams`                                          |
-| `${TRACKER_PROVIDER}` | Issue tracker provider name                | `linear` or `jira`                                       |
-| `${VCS_PROVIDER}`     | VCS host provider name                     | `github` or `gitlab`                                     |
+| Variable              | Description                                   | Example                                                  |
+| --------------------- | --------------------------------------------- | -------------------------------------------------------- |
+| `${ISSUE_KEY}`        | Issue key                                     | `STA-361`                                                |
+| `${ISSUE_NUMBER}`     | Numeric part of issue key                     | `361`                                                    |
+| `${ISSUE_URL}`        | Full issue URL (tracker-specific)             | `https://linear.app/...` or `https://jira.../browse/...` |
+| `${TITLE}`            | Issue title                                   | `Add dark mode`                                          |
+| `${DESCRIPTION}`      | Issue description                             | (full text)                                              |
+| `${WORKTREE_PATH}`    | Full path to worktree                         | `/Users/charlie/.worktrees/stardust-labs/STA-361`        |
+| `${REPO_ROOT}`        | Git working tree pappardelle is running in    | `/Users/charlie/code/stardust-labs`                      |
+| `${MAIN_REPO_ROOT}`   | Main checkout (differs only under a worktree) | `/Users/charlie/code/stardust-labs`                      |
+| `${REPO_NAME}`        | Repository directory name                     | `stardust-labs`                                          |
+| `${PR_URL}`           | GitHub PR URL (may be empty)                  | `https://github.com/...`                                 |
+| `${MR_URL}`           | GitLab MR URL (may be empty)                  | `https://gitlab.com/.../merge_requests/1`                |
+| `${SCRIPT_DIR}`       | Directory containing dow/idow scripts         | `/path/to/_dev/scripts/pappardelle/scripts`              |
+| `${HOME}`             | User home directory                           | `/Users/charlie`                                         |
+| `${VCS_LABEL}`        | VCS label from profile (provider-agnostic)    | `stardust_jams`                                          |
+| `${GITHUB_LABEL}`     | Deprecated alias for `${VCS_LABEL}`           | `stardust_jams`                                          |
+| `${TRACKER_PROVIDER}` | Issue tracker provider name                   | `linear`, `jira`, or `beads`                             |
+| `${VCS_PROVIDER}`     | VCS host provider name                        | `github` or `gitlab`                                     |
 
 Additionally, any keys defined in a profile's `vars` section become template variables. For example, `vars: { IOS_APP_DIR: "_ios/MyApp" }` makes `${IOS_APP_DIR}` available in all templates.
 
@@ -424,9 +426,9 @@ interface PappardelleConfig {
 	default_profile: string;
 	default_emoji?: string; // Fallback emoji for the ticket-rail prefix
 	issue_tracker?: {
-		provider: 'linear' | 'jira';
+		provider: 'linear' | 'jira' | 'beads';
 		base_url?: string; // Required for jira
-		default_issue_type?: string; // Jira-only. Default issue type for new issues. Defaults to "Task".
+		default_issue_type?: string; // Default issue type for new issues. Jira: "Task". Beads: "task".
 	};
 	vcs_host?: {
 		provider: 'github' | 'gitlab';
@@ -436,6 +438,9 @@ interface PappardelleConfig {
 	pre_workspace_deinit?: CommandConfig[]; // Commands to run before workspace deletion
 	terminal?: {
 		app?: string; // Terminal app name (default: iTerm)
+	};
+	list_view?: {
+		layout?: 'single_line' | 'two_line'; // TUI list row layout. Default: two_line for beads, single_line otherwise.
 	};
 	companion_command?: string; // Command run in the companion pane (default: gitui). Per-profile overridable. "" = plain shell.
 	claude?: {
@@ -588,6 +593,7 @@ Pappardelle supports multiple issue tracker backends. Configure with the top-lev
 | -------- | -------- | ------- |
 | `linear` | `linctl` | Yes     |
 | `jira`   | `acli`   | No      |
+| `beads`  | `bd`     | No      |
 
 **Linear** (default — no config needed):
 
@@ -623,6 +629,57 @@ profiles:
     jira:
       issue_type: Feature # DA project doesn't accept "Task"
 ```
+
+**Beads** ([beads](https://github.com/gastownhall/beads) — local, git-native
+issue tracking through the `bd` CLI). No `base_url`: there is no server.
+
+```yaml
+issue_tracker:
+  provider: beads
+
+team_prefix: myproj
+```
+
+`default_issue_type` works here too, lowercased to match beads' vocabulary
+(`task`, `bug`, `feature`, `epic`, `chore`, `decision`). It defaults to `task`.
+
+Three things behave differently under beads, all of them consequences of it
+being a local tracker rather than a hosted one:
+
+- **There is no web URL.** `o` in the ticket rail opens `bd show` in a tmux
+  popup instead of a browser, and `${ISSUE_URL}` is empty for beads
+  workspaces, so `links:` entries using it are skipped.
+- **`tracker_projects` matches the ID prefix.** A single database can hold
+  several prefixes:
+
+  ```yaml
+  profiles:
+    platform:
+      tracker_projects:
+        - myproj # matches myproj-a1b2
+    vendor:
+      tracker_projects:
+        - vendor-sdk # prefixes may contain hyphens; the split is on the last one
+  ```
+
+  New beads issues take their prefix from the database they land in, so
+  `tracker_projects[0]` does not steer issue _creation_ the way it does on
+  Linear.
+
+- **The watchlist reads `bd ready`**, beads' own notion of actionable work —
+  open issues whose blocking dependencies are all closed.
+
+  ```yaml
+  issue_watchlist:
+    statuses: [open] # every ready issue
+  ```
+
+  `bd ready` excludes `in_progress`, `blocked`, `deferred` and `hooked` by
+  construction, so `open` is the only status it can ever return.
+
+All `bd` commands run from the main repository root, so every worktree reads
+and writes the one canonical database rather than whatever copy its branch
+carries.
 
 ### VCS Host Providers
 
@@ -698,6 +755,7 @@ profiles:
 | -------- | -------- | -------------------------------------------------------------------------------------- |
 | Linear   | `linctl` | `brew tap raegislabs/linctl && brew install linctl`                                    |
 | Jira     | `acli`   | See [Atlassian CLI docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/) |
+| Beads    | `bd`     | See [beads install docs](https://github.com/gastownhall/beads)                         |
 | GitHub   | `gh`     | `brew install gh`                                                                      |
 | GitLab   | `glab`   | `brew install glab`                                                                    |
 
@@ -733,7 +791,7 @@ The initialization command is combined with the issue key: `<command> <issue-key
 
 **Per-profile overrides**: When a profile defines `claude.initialization_command`, it takes precedence over the global value. This allows different profiles to use different initialization skills (e.g., `/do-stardust` for profiles that use a TODO.md checklist workflow).
 
-**Model and effort** work the same way — a profile's value wins over the global one — with one extra rule: an explicit empty string at the profile level _clears_ an inherited global value rather than falling through to it.
+**Model and effort** work the same way, a profile's value winning over the global one, with one extra rule: an explicit empty string at the profile level _clears_ an inherited global value rather than falling through to it.
 
 ```yaml
 claude:
@@ -747,7 +805,7 @@ profiles:
       model: ''
 ```
 
-`model` and `effort` are deliberately not validated against a list of known values — model aliases and effort levels ship on Claude Code's schedule, not Pappardelle's — so a typo surfaces when Claude Code rejects the flag at launch rather than at config load. Both fields apply everywhere a workspace's Claude session is created: `idow`, the TUI's session-create path, and the iTerm launcher.
+`model` and `effort` are not validated against a list of known values, since model aliases and effort levels ship on Claude Code's schedule rather than Pappardelle's, so a typo surfaces when Claude Code rejects the flag at launch rather than at config load. Both fields apply everywhere a workspace's Claude session is created: `idow`, the TUI's session-create path, and the iTerm launcher.
 
 Omitting both fields leaves the launch command byte-identical to a config that predates them; nothing is passed to `claude` unless you ask for it.
 
@@ -864,6 +922,32 @@ state_colors?: Record<string, string>;
 - **The main-worktree row is not affected.** That row derives its color from the tracker's "In Progress" (dirty) and "Done" (clean) colors, and it keeps doing so.
 - **Config layers merge key by key**, so `.pappardelle.local.yml` can override one status without restating the whole map.
 - There is **no per-profile `state_colors`**. The tracker workflow is a property of the repo, not of a profile.
+
+## List Layout
+
+Each space in the TUI list normally occupies one row: status icon, issue key, then the title filling whatever width is left. `list_view.layout` can instead give the title a row of its own, indented to line up under the issue key.
+
+```yaml
+list_view:
+  layout: two_line # 'single_line' | 'two_line'
+```
+
+```typescript
+list_view?: {
+	layout?: 'single_line' | 'two_line';
+};
+```
+
+**Default is per-tracker.** With `list_view` absent, beads gets `two_line` and every other tracker gets `single_line`.
+
+```
+single_line:
+🍝 ● pappardelle-29r Residual TUI flicker: rapid typing in the new-worksp…  (2) ✓
+
+two_line:
+🍝 ● pappardelle-29r                                                       (2) ✓
+     Residual TUI flicker: rapid typing in the new-workspace issue field r…
+```
 
 ## Companion Pane Command
 

--- a/pappardelle-config.md
+++ b/pappardelle-config.md
@@ -631,7 +631,7 @@ profiles:
 ```
 
 **Beads** ([beads](https://github.com/gastownhall/beads) — local, git-native
-issue tracking through the `bd` CLI). No `base_url`: there is no server.
+issue tracking through the `bd` CLI).
 
 ```yaml
 issue_tracker:
@@ -640,42 +640,8 @@ issue_tracker:
 team_prefix: myproj
 ```
 
-`default_issue_type` works here too, lowercased to match beads' vocabulary
-(`task`, `bug`, `feature`, `epic`, `chore`, `decision`). It defaults to `task`.
-
-Three things behave differently under beads, all of them consequences of it
-being a local tracker rather than a hosted one:
-
-- **There is no web URL.** `o` in the ticket rail opens `bd show` in a tmux
-  popup instead of a browser, and `${ISSUE_URL}` is empty for beads
-  workspaces, so `links:` entries using it are skipped.
-- **`tracker_projects` matches the ID prefix.** A single database can hold
-  several prefixes:
-
-  ```yaml
-  profiles:
-    platform:
-      tracker_projects:
-        - myproj # matches myproj-a1b2
-    vendor:
-      tracker_projects:
-        - vendor-sdk # prefixes may contain hyphens; the split is on the last one
-  ```
-
-  New beads issues take their prefix from the database they land in, so
-  `tracker_projects[0]` does not steer issue _creation_ the way it does on
-  Linear.
-
-- **The watchlist reads `bd ready`**, beads' own notion of actionable work —
-  open issues whose blocking dependencies are all closed.
-
-  ```yaml
-  issue_watchlist:
-    statuses: [open] # every ready issue
-  ```
-
-  `bd ready` excludes `in_progress`, `blocked`, `deferred` and `hooked` by
-  construction, so `open` is the only status it can ever return.
+`default_issue_type` accepts `task`, `bug`, `feature`, `epic`, `chore` and
+`decision`, and defaults to `task`.
 
 All `bd` commands run from the main repository root, so every worktree reads
 and writes the one canonical database rather than whatever copy its branch

--- a/pappardelle.example.yml
+++ b/pappardelle.example.yml
@@ -17,7 +17,8 @@ default_profile: backend
 # pre-emoji Pappardelle (no slot rendered).
 default_emoji: ''
 
-# Team prefix for Linear issues (e.g., 'ENG' for 'ENG-123')
+# Team prefix for Linear issues (e.g., 'ENG' for 'ENG-123').
+# For beads this is the database's issue prefix (e.g. 'myproj').
 team_prefix: ENG
 
 # Issue tracker (optional). Linear is assumed when omitted.
@@ -27,6 +28,12 @@ team_prefix: ENG
 #   provider: jira
 #   base_url: https://mycompany.atlassian.net
 #   default_issue_type: Task
+
+# Beads (https://github.com/gastownhall/beads) — local, git-native issue
+# tracking via the `bd` CLI. No base_url: there is no server to point at.
+# `default_issue_type` applies here too, lowercased (task, bug, feature, …).
+# issue_tracker:
+#   provider: beads
 
 # Claude configuration (optional)
 # claude:
@@ -50,6 +57,14 @@ team_prefix: ENG
 # usually share one color.
 # state_colors:
 #   In Review: cyan
+
+# TUI list row layout. `two_line` gives the issue title its own row, indented
+# under the issue key, instead of sharing one row with it.
+# Defaults per tracker: two_line for beads (whose keys are wide enough to crowd
+# the title off a shared row), single_line for Linear/Jira. Set it explicitly to
+# override that either way.
+# list_view:
+#   layout: two_line        # 'single_line' | 'two_line'
 
 # Issue watchlist (optional): poll the tracker every 30s and auto-spawn a
 # workspace for each assigned, matching issue that doesn't already have one.

--- a/plugins/pappardelle/skills/configure-pappardelle/SKILL.md
+++ b/plugins/pappardelle/skills/configure-pappardelle/SKILL.md
@@ -52,7 +52,7 @@ Profiles define project-specific workspace behavior. Ask these questions with `A
 3. **Keywords**: words that auto-select this profile when creating workspaces (e.g., `ios`, `app`, `swift`). Include the issue prefix with hyphen if applicable (e.g., `MOB-`). Keywords only _preselect_ — since STA-1837 the TUI shows every profile in a picker on the first Enter, so the list doesn't have to be exhaustive; cover the words the user actually types and let the arrow keys handle the rest
 4. **Emoji** (optional): suggest one via the resolution flow in _Configuring Profile Emojis_ below. If the user already has emojis on other profiles, always ask — otherwise skip unless they express interest.
 5. **Team prefix override**: if this profile uses a different issue key prefix than the global `team_prefix`
-6. **Tracker project routing** (`tracker_projects`, optional): a list of tracker projects that map to this profile — Linear project names, or Jira project names/keys (an entry like `KAN` matches the same as `Pappardelle Testing`, STA-1649). Pappardelle uses it for two things — (a) when an existing issue is fetched, its project is matched against the list to auto-select the profile (both providers), and (b) when a _new_ issue is created under this profile via `idow`, `tracker_projects[0]` is resolved to a Linear project UUID and assigned automatically (STA-959; Linear-only — `team_prefix` controls which Jira project new issues land in). Order so the active project for new work is first; re-order when the active project rotates (e.g., once `Foo MVP` ships, move `Foo Quality` to position 0).
+6. **Tracker project routing** (`tracker_projects`, optional): a list of tracker projects that map to this profile — Linear project names, Jira project names/keys (an entry like `KAN` matches the same as `Pappardelle Testing`, STA-1649), or beads ID prefixes (`myproj` matches `myproj-a1b2`). Pappardelle uses it for two things: (a) when an existing issue is fetched, its project is matched against the list to auto-select the profile (both providers), and (b) when a _new_ issue is created under this profile via `idow`, `tracker_projects[0]` is resolved to a Linear project UUID and assigned automatically (STA-959; Linear-only, since `team_prefix` controls which Jira project new issues land in, and a new beads issue takes its prefix from the database it lands in). Order so the active project for new work is first; re-order when the active project rotates (e.g., once `Foo MVP` ships, move `Foo Quality` to position 0).
 7. **Project type**: ask what kind of project to generate sensible defaults:
    - **iOS app**: ask for app directory, bundle ID, Xcode scheme. Generate `vars` and `commands` for xcodegen/xcodebuild
    - **Backend/API**: generate dependency install commands
@@ -65,8 +65,8 @@ Profiles define project-specific workspace behavior. Ask these questions with `A
 profiles:
   my-profile:
     keywords: [keyword1, keyword2]
-    tracker_projects: # Optional — Linear project names, or Jira project
-      - 'My Project Quality' # names/keys (STA-1649). On Linear, [0] is the
+    tracker_projects: # Optional — Linear project names, Jira project
+      - 'My Project Quality' # names/keys, or beads ID prefixes. On Linear, [0] is the
       - 'My Project MVP' # default project for new issues (STA-959).
     display_name: 'My Profile'
     emoji: '🎸' # Optional — shown in the ticket rail (STA-924)
@@ -258,9 +258,26 @@ Ask with `AskUserQuestion`:
 
 ```yaml
 issue_tracker:
-  provider: linear # or 'jira'
+  provider: linear # or 'jira' or 'beads'
   # base_url: https://mycompany.atlassian.net  # Required for Jira
 ```
+
+**Beads** ([beads](https://github.com/gastownhall/beads), local and git-native
+via the `bd` CLI) needs no `base_url` — there is no server. Set `team_prefix` to
+the database's issue prefix so the Claude Code hooks can tell a beads workspace
+directory (`myproj-a1b2`) from an ordinary one (`my-app`):
+
+```yaml
+issue_tracker:
+  provider: beads
+team_prefix: myproj
+```
+
+Under beads: IDs stay lowercase (`myproj-a1b2`, children `myproj-a1b2.1`);
+`${ISSUE_URL}` is empty and the rail's `o` key opens `bd show` in a tmux popup;
+`tracker_projects` matches the ID prefix; and the watchlist reads `bd ready`,
+with `issue_watchlist.statuses` narrowing further (leave it empty for every
+ready issue).
 
 ### VCS host
 
@@ -348,7 +365,7 @@ Available in all command templates, link URLs, and app paths:
 | `${MR_URL}`           | GitLab MR URL (may be empty) | `https://gitlab.com/...`   |
 | `${SCRIPT_DIR}`       | Pappardelle scripts dir      | `/path/to/scripts`         |
 | `${VCS_LABEL}`        | VCS label from profile       | `stardust_jams`            |
-| `${TRACKER_PROVIDER}` | Issue tracker                | `linear` or `jira`         |
+| `${TRACKER_PROVIDER}` | Issue tracker                | `linear`, `jira`, `beads`  |
 | `${VCS_PROVIDER}`     | VCS host                     | `github` or `gitlab`       |
 
 Profile `vars` keys also become template variables (e.g., `vars: { APP_DIR: "src" }` → `${APP_DIR}`).

--- a/plugins/pappardelle/skills/configure-pappardelle/SKILL.md
+++ b/plugins/pappardelle/skills/configure-pappardelle/SKILL.md
@@ -273,9 +273,6 @@ issue_tracker:
 team_prefix: myproj
 ```
 
-Beads IDs stay lowercase (`myproj-a1b2`, children `myproj-a1b2.1`), so any
-`tracker_projects` entry has to match that lowercase prefix.
-
 ### VCS host
 
 ```yaml

--- a/plugins/pappardelle/skills/configure-pappardelle/SKILL.md
+++ b/plugins/pappardelle/skills/configure-pappardelle/SKILL.md
@@ -273,11 +273,8 @@ issue_tracker:
 team_prefix: myproj
 ```
 
-Under beads: IDs stay lowercase (`myproj-a1b2`, children `myproj-a1b2.1`);
-`${ISSUE_URL}` is empty and the rail's `o` key opens `bd show` in a tmux popup;
-`tracker_projects` matches the ID prefix; and the watchlist reads `bd ready`,
-with `issue_watchlist.statuses` narrowing further (leave it empty for every
-ready issue).
+Beads IDs stay lowercase (`myproj-a1b2`, children `myproj-a1b2.1`), so any
+`tracker_projects` entry has to match that lowercase prefix.
 
 ### VCS host
 

--- a/plugins/pappardelle/skills/init-pappardelle/SKILL.md
+++ b/plugins/pappardelle/skills/init-pappardelle/SKILL.md
@@ -17,7 +17,7 @@ This skill must satisfy **every** item below before printing the final summary. 
 3. **`.pappardelle.local.yml` exists if local overrides were chosen.** Only when Step 1 collected per-machine overrides (default profile, yolo mode, etc.).
 4. **Pappardelle CLI is installed.** `command -v pappardelle` succeeds.
 5. **Required prerequisites are installed.** `node`, `npm`, `git`, `tmux`, `jq`, `yq`, `claude` are all on PATH.
-6. **Provider CLIs are checked.** `gh` or `glab` for VCS, `linctl` or `acli` for tracker, plus `gitui` (the default companion-pane command — skip if the user set `companion_command` to something else). Warn about missing ones but do not block on them.
+6. **Provider CLIs are checked.** `gh` or `glab` for VCS, `linctl`, `acli` or `bd` for tracker, plus `gitui` (the default companion-pane command — skip if the user set `companion_command` to something else). Warn about missing ones but do not block on them.
 7. **Recommended `~/.tmux.conf` settings are in place** or the user has explicitly declined them.
 8. **Terminal capabilities are configured** — offered and accepted, declined, or skipped because the terminal or tmux version does not support them. Never skip the detection itself.
 
@@ -30,7 +30,7 @@ Before any other output, print the "What is a Workspace?" section verbatim so th
 A **workspace** in Pappardelle is the per-issue environment Pappardelle creates for you when you start work on a ticket. Each workspace bundles together:
 
 - A dedicated **git worktree** at `~/.worktrees/{repo}/{issue-key}/` — an isolated checkout on a fresh branch, so you can have many in-flight tickets without stashing or switching branches.
-- A tracked **issue** in your issue tracker (Linear or Jira) — Pappardelle either creates one from your prompt or uses an existing key like `STA-123`.
+- A tracked **issue** in your issue tracker (Linear, Jira or beads) — Pappardelle either creates one from your prompt or uses an existing key like `STA-123` (or `myproj-a1b2` on beads).
 - A **PR/MR** against the main branch — opened by the agent once it has a real diff, not at provisioning time. A fresh workspace legitimately has none.
 - Its own **Claude Code session** (a named tmux session: `claude-{repo}-{issue-key}`) where you drive the work.
 - Its own **companion session** (tmux session: `companion-{repo}-{issue-key}`) pointed at that worktree, running the `companion_command` (gitui by default).
@@ -76,7 +76,8 @@ Options:
 
 - **Linear** (default) — requires `linctl` CLI
 - **Jira** — requires `acli` CLI. If selected, follow up asking for their Jira base URL (e.g., `https://mycompany.atlassian.net`).
-- **Neither / Other** — Pappardelle requires Linear or Jira. Let the user know and stop.
+- **Beads** — requires the `bd` CLI and a `.beads` database in the repo (`bd init <prefix>`). Local and git-native, so there is no base URL to ask for. Use the database's issue prefix as the team prefix in the next step.
+- **Neither / Other** — Pappardelle requires Linear, Jira or beads. Let the user know and stop.
 
 #### 1A.iii. Team Prefix & Profiles
 
@@ -98,7 +99,7 @@ Ask: "What are your issue key prefixes? For example, if your issues look like PR
   - `team_prefix`: set per-profile to override the global prefix for issue creation
   - `commands`: reasonable setup commands based on project type (e.g., `npm install` for Node.js, `xcodegen generate` for iOS)
   - `emoji`: optional — suggest one via `/configure-pappardelle`'s emoji flow. With 3+ profiles, offer to bulk-assign now.
-  - `tracker_projects`: the tracker project(s) this profile lives in — Linear project names, or Jira project names/keys (either matches, STA-1649). Routes existing issues to the profile; on Linear the first entry also doubles as the default project for issues created under this profile (STA-959). Defer to `/configure-pappardelle` if the user doesn't already know their project names.
+  - `tracker_projects`: the tracker project(s) this profile lives in — Linear project names, Jira project names/keys (either matches, STA-1649), or beads ID prefixes. Routes existing issues to the profile; on Linear the first entry also doubles as the default project for issues created under this profile (STA-959). Defer to `/configure-pappardelle` if the user doesn't already know their project names.
 - Set `default_profile` to the most common one
 
 #### 1A.iv. Claude Initialization Command
@@ -260,7 +261,7 @@ echo "=== Provider CLIs ===" && \
 for cmd in <VCS_CLI> <TRACKER_CLI> gitui; do printf "%-10s %s\n" "$cmd" "$(command -v $cmd >/dev/null 2>&1 && echo '✓' || echo '✗ MISSING')"; done
 ```
 
-Replace `<VCS_CLI>` with `gh` (GitHub) or `glab` (GitLab), and `<TRACKER_CLI>` with `linctl` (Linear) or `acli` (Jira). `gitui` is the default companion-pane command — if `.pappardelle.yml` sets `companion_command` to a different tool, check that instead. When you took the existing-config path in Step 1B, read these values straight out of the parsed `.pappardelle.yml`.
+Replace `<VCS_CLI>` with `gh` (GitHub) or `glab` (GitLab), and `<TRACKER_CLI>` with `linctl` (Linear), `acli` (Jira) or `bd` (Beads). `gitui` is the default companion-pane command — if `.pappardelle.yml` sets `companion_command` to a different tool, check that instead. When you took the existing-config path in Step 1B, read these values straight out of the parsed `.pappardelle.yml`.
 
 - If any **required** tools are missing, **stop and do not proceed** to Step 4. Tell the user which ones are missing and offer to install them via `brew install <tool>` (or the appropriate install command for Claude Code: `curl -fsSL https://claude.ai/install.sh | bash`). Use `AskUserQuestion` to confirm before installing. Re-run the check after installation and only proceed once all required tools pass.
 - If any **provider CLIs** are missing, warn the user but allow proceeding — Pappardelle will work but some features will be degraded.
@@ -341,7 +342,7 @@ Format it like this, filling in the real values from what you just collected:
 ✅ Pappardelle is configured.
 
 Wrote /path/to/repo/.pappardelle.yml:
-  • Issue tracker: {linear | jira (<base_url>)}
+  • Issue tracker: {linear | jira (<base_url>) | beads}
   • VCS host:      {github | gitlab (<host>)}
   • Team prefix:   {PROJ}
   • Profiles:      {default} (or list each one with its keywords)

--- a/plugins/pappardelle/skills/init-pappardelle/SKILL.md
+++ b/plugins/pappardelle/skills/init-pappardelle/SKILL.md
@@ -77,7 +77,7 @@ Options:
 - **Linear** (default) — requires `linctl` CLI
 - **Jira** — requires `acli` CLI. If selected, follow up asking for their Jira base URL (e.g., `https://mycompany.atlassian.net`).
 - **Beads** — requires the `bd` CLI and a `.beads` database in the repo (`bd init <prefix>`). Local and git-native, so there is no base URL to ask for. Use the database's issue prefix as the team prefix in the next step.
-- **Neither / Other** — Pappardelle requires Linear, Jira or beads. Let the user know and stop.
+- **None of these / Other** — Pappardelle requires Linear, Jira or beads. Let the user know and stop.
 
 #### 1A.iii. Team Prefix & Profiles
 

--- a/scripts/idow
+++ b/scripts/idow
@@ -115,8 +115,15 @@ if [[ -n "${PAPPARDELLE_PROJECT_ROOT:-}" ]]; then
 else
     REPO_ROOT=$(git rev-parse --show-toplevel)
 fi
-GIT_COMMON_DIR=$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir)
-MAIN_REPO_ROOT=$(dirname "$GIT_COMMON_DIR")
+if [[ -n "${PAPPARDELLE_MAIN_REPO_ROOT:-}" ]]; then
+    MAIN_REPO_ROOT="$PAPPARDELLE_MAIN_REPO_ROOT"
+else
+    GIT_COMMON_DIR=$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir)
+    MAIN_REPO_ROOT=$(dirname "$GIT_COMMON_DIR")
+fi
+# Handed to the workspace's tmux sessions so the hooks running inside them read
+# it instead of walking back out to the main checkout on every tool use.
+export PAPPARDELLE_MAIN_REPO_ROOT="$MAIN_REPO_ROOT"
 
 # Untracked project config may exist only in the main checkout, while a linked
 # worktree can carry its own local overrides. Resolve each file independently.
@@ -588,15 +595,13 @@ else
     fi
 fi
 
-# Extract issue number for template variable expansion (e.g., STA-595 → 595).
-if [[ "$TRACKER_PROVIDER" == "beads" ]]; then
-    ISSUE_NUMBER=""
-else
-    # Everything after the last hyphen, not the first digit run: Jira project
-    # keys may carry digits of their own, and scanning left-to-right turned
-    # A1B-234 into the plausible-looking but wrong "1".
-    ISSUE_NUMBER="${ISSUE_KEY##*-}"
-fi
+# Extract issue number for template variable expansion (e.g., STA-595 → 595,
+# pappardelle-wx0 → wx0).
+#
+# Everything after the last hyphen, not the first digit run: Jira project keys
+# may carry digits of their own, and scanning left-to-right turned A1B-234 into
+# the plausible-looking but wrong "1".
+ISSUE_NUMBER="${ISSUE_KEY##*-}"
 
 # Template expansion helpers for profile-driven steps
 # Defined here (before Step 5) because worktree config may use template variables.

--- a/scripts/idow
+++ b/scripts/idow
@@ -4,7 +4,7 @@
 #
 # A command-line tool that sets up a development workspace.
 #
-# Usage: idow [--resume] [--open] [--profile <name>] <input>
+# Usage: idow [--resume] [--open] [--profile <name>] [--existing-issue] <input>
 #   Input can be:
 #     - Issue key:   idow STA-123 | idow 123
 #     - Linear URL:  idow https://linear.app/stardust-labs/issue/STA-123
@@ -56,7 +56,7 @@ NC='\033[0m'
 
 TOTAL_STEPS=11
 print_step() {
-    echo -e "${BLUE}[$(printf '%2d' $1)/$TOTAL_STEPS]${NC} $2"
+    echo -e "${BLUE}[$(printf '%2d' "$1")/$TOTAL_STEPS]${NC} $2"
     log "Step $1: $2"
 }
 
@@ -103,6 +103,7 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
     echo "  --resume          Open workspace without prompting Claude (for continuing work)"
     echo "  --open            Also open apps, links, iTerm, and run commands (skipped by default)"
     echo "  --profile <name>  Force a specific profile from .pappardelle.yml"
+    echo "  --existing-issue  Input is an issue key the caller already fetched; skip input detection"
     exit 0
 fi
 
@@ -114,7 +115,21 @@ if [[ -n "${PAPPARDELLE_PROJECT_ROOT:-}" ]]; then
 else
     REPO_ROOT=$(git rev-parse --show-toplevel)
 fi
-CONFIG_PATH="$REPO_ROOT/.pappardelle.yml"
+GIT_COMMON_DIR=$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir)
+MAIN_REPO_ROOT=$(dirname "$GIT_COMMON_DIR")
+
+# Untracked project config may exist only in the main checkout, while a linked
+# worktree can carry its own local overrides. Resolve each file independently.
+resolve_repo_config() {
+    local filename="$1"
+    if [[ -f "$REPO_ROOT/$filename" ]]; then
+        echo "$REPO_ROOT/$filename"
+    else
+        echo "$MAIN_REPO_ROOT/$filename"
+    fi
+}
+
+CONFIG_PATH=$(resolve_repo_config .pappardelle.yml)
 # Personal defaults shared across every repo. Must stay in step with
 # getDefaultHomeConfigDir() in source/config.ts, which is what the TUI reads.
 HOME_CONFIG_PATH="$HOME/.pappardelle/.pappardelle.yml"
@@ -151,7 +166,7 @@ fi
 # model, effort) with local override support from .pappardelle.local.yml.
 # These are the top-level values; once a profile is selected, the launch flags
 # are re-resolved profile-first via resolve_claude_launch_flags below.
-LOCAL_CONFIG_PATH="$REPO_ROOT/.pappardelle.local.yml"
+LOCAL_CONFIG_PATH=$(resolve_repo_config .pappardelle.local.yml)
 CLAUDE_CONFIG_JSON=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH" --home-config "$HOME_CONFIG_PATH")
 INIT_CMD=$(echo "$CLAUDE_CONFIG_JSON" | jq -r '.init_cmd')
 SKIP_PERMISSIONS=$(echo "$CLAUDE_CONFIG_JSON" | jq -r '.skip_permissions')
@@ -344,12 +359,18 @@ if [[ "$1" == "--profile" ]]; then
         echo "" >&2
         echo "Available profiles:" >&2
         for profile in $(list_profiles); do
-            local display_name
             display_name=$(get_profile_display_name "$profile")
             echo "  - $profile: $display_name" >&2
         done
         exit 1
     fi
+fi
+
+# Check for --existing-issue flag
+EXISTING_ISSUE=false
+if [[ "$1" == "--existing-issue" ]]; then
+    EXISTING_ISSUE=true
+    shift
 fi
 
 # Collect input from all arguments
@@ -380,17 +401,27 @@ ISSUE_KEY=""
 DESCRIPTION=""
 IS_NEW_ISSUE=false
 
-if [[ "$INPUT" =~ ^https://linear\.app/.*/issue/([A-Z][A-Z0-9]*-[0-9]+) ]]; then
+if [[ "$EXISTING_ISSUE" == "true" ]]; then
+    ISSUE_KEY="$INPUT"
+    log "Caller-supplied issue key: $ISSUE_KEY"
+elif [[ "$INPUT" =~ ^https://linear\.app/.*/issue/([A-Z][A-Z0-9]*-[0-9]+) ]]; then
     # Linear URL
     ISSUE_KEY="${BASH_REMATCH[1]}"
     log "Detected Linear URL, issue key: $ISSUE_KEY"
+elif [[ "$TRACKER_PROVIDER" == "beads" ]] && is_beads_issue_key "$INPUT" "$CONFIG_PATH"; then
+    ISSUE_KEY=$(echo "$INPUT" | tr '[:upper:]' '[:lower:]')
+    log "Detected beads issue ID: $ISSUE_KEY"
 elif [[ "$INPUT" =~ ^[A-Z][A-Z0-9]*-[0-9]+$ ]]; then
     # Full issue key (e.g., STA-123)
     ISSUE_KEY="$INPUT"
     log "Detected full issue key: $ISSUE_KEY"
 elif [[ "$INPUT" =~ ^[0-9]+$ ]]; then
     # Just a number (e.g., 123) - use configured team prefix
-    ISSUE_KEY="${TEAM_PREFIX}-$INPUT"
+    if [[ "$TRACKER_PROVIDER" == "beads" ]]; then
+        ISSUE_KEY="$(echo "$TEAM_PREFIX" | tr '[:upper:]' '[:lower:]')-$INPUT"
+    else
+        ISSUE_KEY="${TEAM_PREFIX}-$INPUT"
+    fi
     log "Detected number, assuming issue key: $ISSUE_KEY"
 else
     # It's a description - we'll create a new issue
@@ -557,8 +588,15 @@ else
     fi
 fi
 
-# Extract issue number for template variable expansion (e.g., STA-595 → 595)
-ISSUE_NUMBER=$(echo "$ISSUE_KEY" | grep -oE '[0-9]+' || echo "")
+# Extract issue number for template variable expansion (e.g., STA-595 → 595).
+if [[ "$TRACKER_PROVIDER" == "beads" ]]; then
+    ISSUE_NUMBER=""
+else
+    # Everything after the last hyphen, not the first digit run: Jira project
+    # keys may carry digits of their own, and scanning left-to-right turned
+    # A1B-234 into the plausible-looking but wrong "1".
+    ISSUE_NUMBER="${ISSUE_KEY##*-}"
+fi
 
 # Template expansion helpers for profile-driven steps
 # Defined here (before Step 5) because worktree config may use template variables.
@@ -570,6 +608,7 @@ expand_var() {
     result="${result//\$\{ISSUE_NUMBER\}/$ISSUE_NUMBER}"
     result="${result//\$\{ISSUE_URL\}/$ISSUE_URL}"
     result="${result//\$\{REPO_ROOT\}/$REPO_ROOT}"
+    result="${result//\$\{MAIN_REPO_ROOT\}/$MAIN_REPO_ROOT}"
     result="${result//\$\{REPO_NAME\}/$REPO_NAME}"
     result="${result//\$\{PR_URL\}/$PR_URL}"
     result="${result//\$\{MR_URL\}/$PR_URL}"
@@ -648,7 +687,7 @@ else
     fi
 
     # Copy .pappardelle.local.yml to the new worktree (gitignored personal overrides)
-    LOCAL_CONFIG="$REPO_ROOT/.pappardelle.local.yml"
+    LOCAL_CONFIG="$LOCAL_CONFIG_PATH"
     if [[ -f "$LOCAL_CONFIG" ]]; then
         cp -n "$LOCAL_CONFIG" "$WORKTREE_PATH/.pappardelle.local.yml" 2>/dev/null || true
         print_success "Copied .pappardelle.local.yml"
@@ -672,10 +711,10 @@ else
     if [[ "$POST_INIT_COUNT" -gt 0 ]]; then
         log "Running $POST_INIT_COUNT $POST_INIT_KEY command(s)..."
         for (( i=0; i<POST_INIT_COUNT; i++ )); do
-            CMD_NAME=$(yq -r ".$POST_INIT_KEY[$i].name // \"$POST_INIT_KEY[$i]\"" "$CONFIG_PATH")
-            CMD_RUN_TMPL=$(yq -r ".$POST_INIT_KEY[$i].run // \"\"" "$CONFIG_PATH")
-            CMD_CONTINUE=$(yq -r ".$POST_INIT_KEY[$i].continue_on_error // false" "$CONFIG_PATH")
-            CMD_BG=$(yq -r ".$POST_INIT_KEY[$i].background // false" "$CONFIG_PATH")
+            CMD_NAME=$(yq -r ".${POST_INIT_KEY}[$i].name // \"${POST_INIT_KEY}[$i]\"" "$CONFIG_PATH")
+            CMD_RUN_TMPL=$(yq -r ".${POST_INIT_KEY}[$i].run // \"\"" "$CONFIG_PATH")
+            CMD_CONTINUE=$(yq -r ".${POST_INIT_KEY}[$i].continue_on_error // false" "$CONFIG_PATH")
+            CMD_BG=$(yq -r ".${POST_INIT_KEY}[$i].background // false" "$CONFIG_PATH")
             CMD_RUN=$(expand_var "$CMD_RUN_TMPL")
             log "  $POST_INIT_KEY: $CMD_NAME -> $CMD_RUN"
             run_command "$CMD_NAME" "$CMD_RUN" "$CMD_CONTINUE" "$CMD_BG"
@@ -692,10 +731,10 @@ else
     if [[ "$PROFILE_POST_INIT_COUNT" -gt 0 ]]; then
         log "Running $PROFILE_POST_INIT_COUNT profile $PROFILE_POST_INIT_KEY command(s)..."
         for (( i=0; i<PROFILE_POST_INIT_COUNT; i++ )); do
-            CMD_NAME=$(yq -r ".profiles.$SELECTED_PROFILE.$PROFILE_POST_INIT_KEY[$i].name // \"profile_post_init[$i]\"" "$CONFIG_PATH")
-            CMD_RUN_TMPL=$(yq -r ".profiles.$SELECTED_PROFILE.$PROFILE_POST_INIT_KEY[$i].run // \"\"" "$CONFIG_PATH")
-            CMD_CONTINUE=$(yq -r ".profiles.$SELECTED_PROFILE.$PROFILE_POST_INIT_KEY[$i].continue_on_error // false" "$CONFIG_PATH")
-            CMD_BG=$(yq -r ".profiles.$SELECTED_PROFILE.$PROFILE_POST_INIT_KEY[$i].background // false" "$CONFIG_PATH")
+            CMD_NAME=$(yq -r ".profiles.$SELECTED_PROFILE.${PROFILE_POST_INIT_KEY}[$i].name // \"profile_post_init[$i]\"" "$CONFIG_PATH")
+            CMD_RUN_TMPL=$(yq -r ".profiles.$SELECTED_PROFILE.${PROFILE_POST_INIT_KEY}[$i].run // \"\"" "$CONFIG_PATH")
+            CMD_CONTINUE=$(yq -r ".profiles.$SELECTED_PROFILE.${PROFILE_POST_INIT_KEY}[$i].continue_on_error // false" "$CONFIG_PATH")
+            CMD_BG=$(yq -r ".profiles.$SELECTED_PROFILE.${PROFILE_POST_INIT_KEY}[$i].background // false" "$CONFIG_PATH")
             CMD_RUN=$(expand_var "$CMD_RUN_TMPL")
             log "  profile $PROFILE_POST_INIT_KEY: $CMD_NAME -> $CMD_RUN"
             run_command "$CMD_NAME" "$CMD_RUN" "$CMD_CONTINUE" "$CMD_BG"
@@ -739,7 +778,11 @@ fi
 if [[ -n "$CLAUDE_EFFORT" ]]; then
     CLAUDE_SESSION_ARGS+=(--effort "$CLAUDE_EFFORT")
 fi
-CLAUDE_SESSION_NAME="claude-${REPO_NAME}-${ISSUE_KEY}"
+# Matches the '.' → '_' encoding in start-claude-session.sh and
+# getSessionNames(); see the comment there.
+SESSION_KEY="${ISSUE_KEY//_/__}"
+SESSION_KEY="${SESSION_KEY//./_}"
+CLAUDE_SESSION_NAME="claude-${REPO_NAME}-${SESSION_KEY}"
 # Per-issue claude/companion sessions live on a dedicated tmux socket so the
 # Pappardelle viewer pane can attach without TMUX=. See STA-860.
 PAPPARDELLE_TMUX_SOCKET="${PAPPARDELLE_TMUX_SOCKET:-pappardelle_inner}"

--- a/scripts/idow
+++ b/scripts/idow
@@ -4,7 +4,7 @@
 #
 # A command-line tool that sets up a development workspace.
 #
-# Usage: idow [--resume] [--open] [--profile <name>] [--existing-issue] <input>
+# Usage: idow [--resume] [--open] [--profile <name>] [--issue-key <key>] <input>
 #   Input can be:
 #     - Issue key:   idow STA-123 | idow 123
 #     - Linear URL:  idow https://linear.app/stardust-labs/issue/STA-123
@@ -103,7 +103,7 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
     echo "  --resume          Open workspace without prompting Claude (for continuing work)"
     echo "  --open            Also open apps, links, iTerm, and run commands (skipped by default)"
     echo "  --profile <name>  Force a specific profile from .pappardelle.yml"
-    echo "  --existing-issue  Input is an issue key the caller already fetched; skip input detection"
+    echo "  --issue-key <key> Use this issue key verbatim, skipping input-type detection"
     exit 0
 fi
 
@@ -373,10 +373,12 @@ if [[ "$1" == "--profile" ]]; then
     fi
 fi
 
-# Check for --existing-issue flag
-EXISTING_ISSUE=false
-if [[ "$1" == "--existing-issue" ]]; then
-    EXISTING_ISSUE=true
+# A beads ID is a content hash, so `myproj-a1b2` and the description `fix-crash`
+# are the same shape. Callers that already hold a resolved key say so rather than
+# leaving the detection below to guess.
+INPUT_IS_ISSUE_KEY=false
+if [[ "$1" == "--issue-key" ]]; then
+    INPUT_IS_ISSUE_KEY=true
     shift
 fi
 
@@ -408,7 +410,7 @@ ISSUE_KEY=""
 DESCRIPTION=""
 IS_NEW_ISSUE=false
 
-if [[ "$EXISTING_ISSUE" == "true" ]]; then
+if [[ "$INPUT_IS_ISSUE_KEY" == "true" ]]; then
     ISSUE_KEY="$INPUT"
     log "Caller-supplied issue key: $ISSUE_KEY"
 elif [[ "$INPUT" =~ ^https://linear\.app/.*/issue/([A-Z][A-Z0-9]*-[0-9]+) ]]; then

--- a/scripts/open-iterm-claude.sh
+++ b/scripts/open-iterm-claude.sh
@@ -231,13 +231,6 @@ on run argv
     -- quote (e.g. DESTDIR='/tmp') can't break out. send-keys then receives the
     -- value as one double-quoted arg, matching the safe pattern in
     -- start-claude-session.sh.
-    --
-    -- The name is derived from tmuxSession rather than rebuilt from issueKey:
-    -- start-claude-session.sh created both sessions from the encoded key, and a
-    -- second derivation here is a second chance to drift from that encoding.
-    -- Swapping the "claude-" prefix keeps the two suffixes identical by
-    -- construction. Getting this wrong is silent — new-session -d -s just
-    -- creates the name we ask for, orphaning the companion that already exists.
     set companionSession to "companion-" & (text 8 thru -1 of tmuxSession)
     set sendPart to ""
     if companionCommand is not equal to "" then

--- a/scripts/open-iterm-claude.sh
+++ b/scripts/open-iterm-claude.sh
@@ -118,8 +118,11 @@ if [[ -z "$REPO_NAME" ]]; then
     exit 1
 fi
 
-# Create the tmux session name based on repo and issue key
-TMUX_SESSION="claude-${REPO_NAME}-${ISSUE_KEY}"
+# Create the tmux session name based on repo and issue key. The '.' → '_'
+# encoding matches start-claude-session.sh; see the comment there.
+SESSION_KEY="${ISSUE_KEY//_/__}"
+SESSION_KEY="${SESSION_KEY//./_}"
+TMUX_SESSION="claude-${REPO_NAME}-${SESSION_KEY}"
 
 # Per-issue claude/companion sessions live on a dedicated tmux socket so the
 # nested viewer pane in Pappardelle can attach without `TMUX=`. See STA-860.
@@ -131,16 +134,16 @@ PAPPARDELLE_TMUX_SOCKET="${PAPPARDELLE_TMUX_SOCKET:-pappardelle_inner}"
 CLAUDE_PROMPT="$PROMPT"
 
 # Build the launch-flag string appended to every `claude` invocation below
-# (--dangerously-skip-permissions, --model, --effort — in that order, matching
+# (--dangerously-skip-permissions, --model, --effort, in that order, matching
 # start-claude-session.sh and buildClaudeResumeCommand() in source/tmux.ts).
-# Leading spaces are intentional — the value is concatenated onto the claude
+# Leading spaces are intentional: the value is concatenated onto the claude
 # command word, so each space separates its flag cleanly.
 #
 # Two layers of quoting, because the string crosses two shells:
 #   1. printf %q here makes each config-supplied value safe for the INNER shell
 #      (tmux runs the new-session command through sh -c).
 #   2. `quoted form of` in the AppleScript makes the whole string safe for the
-#      OUTER shell iTerm types it into — see the CLAUDE_FLAGS assignment below.
+#      OUTER shell iTerm types it into. See the CLAUDE_FLAGS assignment below.
 # That pairing is what lets any value through unharmed, so there's no charset
 # restriction and nothing is ever silently dropped; the tmux path
 # (start-claude-session.sh) reaches the same place with printf %q alone.
@@ -228,7 +231,14 @@ on run argv
     -- quote (e.g. DESTDIR='/tmp') can't break out. send-keys then receives the
     -- value as one double-quoted arg, matching the safe pattern in
     -- start-claude-session.sh.
-    set companionSession to "companion-" & repoName & "-" & issueKey
+    --
+    -- The name is derived from tmuxSession rather than rebuilt from issueKey:
+    -- start-claude-session.sh created both sessions from the encoded key, and a
+    -- second derivation here is a second chance to drift from that encoding.
+    -- Swapping the "claude-" prefix keeps the two suffixes identical by
+    -- construction. Getting this wrong is silent — new-session -d -s just
+    -- creates the name we ask for, orphaning the companion that already exists.
+    set companionSession to "companion-" & (text 8 thru -1 of tmuxSession)
     set sendPart to ""
     if companionCommand is not equal to "" then
         set sendPart to "COMPANION_CMD=" & quoted form of companionCommand & "; " & tmuxL & " send-keys -t '" & companionSession & "' \"$COMPANION_CMD\" Enter 2>/dev/null; "

--- a/scripts/provider-helpers.sh
+++ b/scripts/provider-helpers.sh
@@ -8,12 +8,90 @@
 # Requires: yq, jq, and the relevant CLI tools (linctl/acli, gh/glab)
 
 # Get the issue tracker provider from .pappardelle.yml
-# Returns: "linear" (default) or "jira"
+# Returns: "linear" (default), "jira", or "beads"
 get_issue_tracker_provider() {
     local config_path="$1"
     local provider
     provider=$(yq -r '.issue_tracker.provider // "linear"' "$config_path" 2>/dev/null)
     echo "$provider"
+}
+
+# The main repository root, resolved through worktrees. Every bd invocation runs
+# here so each worktree reads and writes the one canonical beads database
+# instead of whatever copy its branch happens to carry.
+beads_repo_root() {
+    local common_dir
+    common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+        git rev-parse --show-toplevel 2>/dev/null
+        return
+    }
+    dirname "$common_dir"
+}
+
+run_bd() {
+    (cd "$(beads_repo_root)" && BD_JSON_ENVELOPE=1 bd "$@")
+}
+
+# Every beads ID prefix this repo can mint keys under, one per line, lowercased.
+# Sources are the database's own issue-prefix, the global team_prefix, each
+# profile's team_prefix override, and each profile's tracker_projects (which
+# name beads prefixes the way they name Linear/Jira projects for the other
+# trackers).
+#
+# The database's issue-prefix is the one bd actually mints IDs under and need
+# not match team_prefix: a repo migrating off Linear keeps the old team prefix
+# while beads names issues after the repo directory.
+#
+# Mirrors getBeadsPrefixes in source/config.ts and get_beads_prefixes in
+# hooks/tracker_config.py; all three have to agree or the same input is a key in
+# one place and prose in another.
+#
+# $2 overrides the .beads/config.yaml path; exposed for tests, which must not
+# pick up the prefix of whatever repo they happen to run in.
+beads_id_prefixes() {
+    local config_path="$1" beads_config="${2-}"
+    [[ -n "$beads_config" ]] || beads_config="$(beads_repo_root)/.beads/config.yaml"
+    {
+        [[ -f "$beads_config" ]] &&
+            yq -r '.["issue-prefix"] | select(. != null and . != "")' \
+                "$beads_config" 2>/dev/null
+        yq -r '[.team_prefix, .profiles[].team_prefix, .profiles[].tracker_projects[]]
+               | .[] | select(. != null and . != "")' \
+            "$config_path" 2>/dev/null
+    } | tr '[:upper:]' '[:lower:]' | sort -u
+}
+
+# Whether $1 is a beads issue ID belonging to a prefix configured in $2.
+#
+# A beads suffix is a content hash, so it can be pure letters, and nothing about
+# the shape of `fix-crash` distinguishes it from an ID. Without anchoring to the
+# configured prefixes, every hyphenated description would be routed as an
+# existing issue and die on the bd lookup instead of creating one.
+is_beads_issue_key() {
+    local input="$1" config_path="$2" beads_config="${3-}" prefix input_prefix
+
+    [[ "$input" =~ ^[a-zA-Z0-9_]+(-[a-zA-Z0-9_]+)+(\.[0-9]+){0,3}$ ]] || return 1
+
+    # Split on the LAST hyphen: a beads prefix may contain hyphens of its own,
+    # since it defaults to the repo directory name.
+    input_prefix="${input%%.*}"
+    input_prefix="${input_prefix%-*}"
+    input_prefix=$(echo "$input_prefix" | tr '[:upper:]' '[:lower:]')
+
+    while IFS= read -r prefix; do
+        [[ -n "$prefix" ]] || continue
+        [[ "$prefix" == "$input_prefix" ]] && return 0
+    done < <(beads_id_prefixes "$config_path" "$beads_config")
+
+    return 1
+}
+
+# Reduce any bd JSON payload to a single issue object. Handles the envelope
+# ({schema_version, data}) and the fact that bd show returns a one-element array
+# rather than the bare object its schema doc describes.
+beads_first_issue() {
+    jq -r 'if type == "object" and has("data") then .data else . end
+           | if type == "array" then (.[0] // {}) else . end'
 }
 
 # Get the VCS host provider from .pappardelle.yml
@@ -58,6 +136,11 @@ fetch_issue_json() {
             # omits `project`, which profile matching needs (STA-1649).
             acli jira workitem view "$issue_key" --fields '*all' --json 2>/dev/null
             ;;
+        beads)
+            # --id= rather than a positional: beads IDs can start with a run of
+            # characters the flag parser would otherwise claim.
+            run_bd show --id="$issue_key" --json 2>/dev/null | beads_first_issue
+            ;;
         *)
             echo "Error: Unknown issue tracker provider: $provider" >&2
             return 1
@@ -65,87 +148,76 @@ fetch_issue_json() {
     esac
 }
 
-# Extract issue title from tracker JSON
-# Args: $1=json, $2=config_path
-extract_issue_title() {
-    local json="$1"
-    local config_path="$2"
-    local provider
-    provider=$(get_issue_tracker_provider "$config_path")
-
-    case "$provider" in
-        linear)
-            echo "$json" | jq -r '.title // empty'
-            ;;
-        jira)
-            echo "$json" | jq -r '.fields.summary // empty'
-            ;;
+# The jq expression that reads $2 out of $1's issue JSON. One table rather than
+# a provider case inside each extractor: every tracker shapes the same handful
+# of fields differently, so a new tracker is one block here instead of an arm in
+# four functions that have to be kept in step.
+#
+# Empty output means the field has no meaning for that provider.
+issue_field_jq() {
+    case "$1:$2" in
+        linear:title|beads:title)             echo '.title // empty' ;;
+        jira:title)                           echo '.fields.summary // empty' ;;
+        linear:description|beads:description) echo '.description // ""' ;;
+        jira:description)                     echo '.fields.description // ""' ;;
+        # Beads issues are local; there is no page to link to. idow already
+        # skips the ISSUE_URL template var when it's empty.
+        linear:url)                           echo '.url // ""' ;;
+        beads:url)                            echo '""' ;;
+        # Linear projects have only a name; Jira issues carry a display name AND
+        # a project key ("Pappardelle Testing" / "KAN"), and a profile's
+        # tracker_projects may list either (STA-1649). Beads has no project
+        # field, so the ID prefix stands in for one.
+        linear:project)                       echo '.project.name // empty' ;;
+        jira:project)                         echo '(.fields.project.name // empty), (.fields.project.key // empty)' ;;
+        beads:project)                        echo '(.id // "") | split(".")[0] | split("-") | if length > 1 then .[0:-1] | join("-") else empty end' ;;
     esac
 }
 
-# Extract issue description from tracker JSON
+# Read one field out of tracker JSON, in the configured provider's shape.
+# Args: $1=json, $2=config_path, $3=field
+extract_issue_field() {
+    local json="$1" config_path="$2" field="$3"
+    local expression
+    expression=$(issue_field_jq "$(get_issue_tracker_provider "$config_path")" "$field")
+    [[ -n "$expression" ]] || return 0
+    echo "$json" | jq -r "$expression"
+}
+
+# Args: $1=json, $2=config_path
+extract_issue_title() {
+    extract_issue_field "$1" "$2" title
+}
+
 # Args: $1=json, $2=config_path
 extract_issue_description() {
-    local json="$1"
-    local config_path="$2"
-    local provider
-    provider=$(get_issue_tracker_provider "$config_path")
-
-    case "$provider" in
-        linear)
-            echo "$json" | jq -r '.description // ""'
-            ;;
-        jira)
-            echo "$json" | jq -r '.fields.description // ""'
-            ;;
-    esac
+    extract_issue_field "$1" "$2" description
 }
 
 # Extract the issue's canonical web URL from tracker JSON.
-# For Linear, prefers the API-provided `.url` so the slug matches the actual
-# workspace (was previously hardcoded to "stardust-labs", breaking issues in
-# any other Linear workspace). For Jira, reconstructs from the configured
-# base URL since the API response doesn't include a browse URL.
+# Linear's own `.url` is preferred over reconstructing one, so the slug matches
+# the actual workspace (it was previously hardcoded to "stardust-labs", breaking
+# issues in any other Linear workspace).
 # Args: $1=json, $2=config_path, $3=issue_key (only used by Jira)
 extract_issue_url() {
-    local json="$1"
-    local config_path="$2"
-    local issue_key="$3"
-    local provider
-    provider=$(get_issue_tracker_provider "$config_path")
+    local json="$1" config_path="$2" issue_key="$3"
 
-    case "$provider" in
-        linear)
-            echo "$json" | jq -r '.url // ""'
-            ;;
-        jira)
-            local base_url
-            base_url=$(get_jira_base_url "$config_path")
-            echo "${base_url}/browse/$issue_key"
-            ;;
-    esac
+    # Jira alone has no URL in its payload to read, so it is the one field that
+    # cannot come from the jq table.
+    if [[ "$(get_issue_tracker_provider "$config_path")" == "jira" ]]; then
+        echo "$(get_jira_base_url "$config_path")/browse/$issue_key"
+        return 0
+    fi
+
+    extract_issue_field "$json" "$config_path" url
 }
 
 # Extract the issue's tracker-project identifiers for profile matching.
-# Emits one candidate per line, most-specific display value first: Linear
-# projects have only a name; Jira issues carry a display name AND a project
-# key ("Pappardelle Testing" / "KAN"), and a profile's tracker_projects may
-# list either (STA-1649). Empty output when the issue has no project.
+# Emits one candidate per line, most-specific display value first. Empty output
+# when the issue has no project.
 # Args: $1=json, $2=config_path
 extract_issue_project_candidates() {
-    local json="$1"
-    local config_path="$2"
-    local provider
-    provider=$(get_issue_tracker_provider "$config_path")
-
-    case "$provider" in
-        linear)
-            echo "$json" | jq -r '.project.name // empty'
-            ;;
-        jira)
-            echo "$json" | jq -r '(.fields.project.name // empty), (.fields.project.key // empty)'
-            ;;
-    esac
+    extract_issue_field "$1" "$2" project
 }
 
 # Resolve a profile from tracker-project candidates (newline-separated, as
@@ -317,6 +389,50 @@ $quoted_prompt"
             base_url=$(get_jira_base_url "$config_path")
             local issue_url="${base_url}/browse/$issue_key"
             echo "{\"issue_key\":\"$issue_key\",\"issue_url\":\"$issue_url\"}"
+            ;;
+        beads)
+            local quoted_prompt
+            quoted_prompt=$(echo "$prompt" | sed 's/^/> /')
+            local description="👨‍🍳🍝 More details coming soon...
+
+---
+
+_Original prompt:_
+
+$quoted_prompt"
+            # --body-file rather than -d: the prompt is arbitrary user prose and
+            # can outgrow a comfortable argv entry.
+            local desc_tmp
+            desc_tmp=$(mktemp /tmp/pappardelle-beads-desc-XXXXXX)
+            printf '%s' "$description" > "$desc_tmp"
+
+            # The beads issue type shares issue_tracker.default_issue_type with
+            # Jira, but beads spells its types lowercase and rejects "Task".
+            local beads_type
+            beads_type=$(echo "$issue_type" | tr '[:upper:]' '[:lower:]')
+
+            local err_tmp out_tmp issue_key bd_rc
+            err_tmp=$(mktemp /tmp/pappardelle-beads-err-XXXXXX)
+            out_tmp=$(mktemp /tmp/pappardelle-beads-out-XXXXXX)
+            # No project assignment: a beads issue's prefix comes from the
+            # database it lands in, not from anything the caller can choose.
+            run_bd create "$title" --type "$beads_type" --body-file "$desc_tmp" --json \
+                >"$out_tmp" 2>"$err_tmp" && bd_rc=0 || bd_rc=$?
+            rm -f "$desc_tmp"
+            issue_key=$(beads_first_issue <"$out_tmp" 2>/dev/null | jq -r '.id // empty' 2>/dev/null)
+
+            if [[ "$bd_rc" -ne 0 || -z "$issue_key" ]]; then
+                # Report rc and raw stdout alongside stderr: bd can fail with a
+                # silent stdout, and a bare "Failed to create" hides whether the
+                # issue was actually committed.
+                echo "Error: Failed to create beads issue (bd exit $bd_rc)" >&2
+                echo "  stderr: $(tr '\n' ' ' <"$err_tmp")" >&2
+                echo "  stdout: $(tr '\n' ' ' <"$out_tmp")" >&2
+                rm -f "$err_tmp" "$out_tmp"
+                return 1
+            fi
+            rm -f "$err_tmp" "$out_tmp"
+            echo "{\"issue_key\":\"$issue_key\",\"issue_url\":\"\"}"
             ;;
     esac
 }

--- a/scripts/provider-helpers.sh
+++ b/scripts/provider-helpers.sh
@@ -21,6 +21,10 @@ get_issue_tracker_provider() {
 # instead of whatever copy its branch happens to carry.
 beads_repo_root() {
     local common_dir
+    if [[ -n "${PAPPARDELLE_MAIN_REPO_ROOT:-}" ]]; then
+        echo "$PAPPARDELLE_MAIN_REPO_ROOT"
+        return
+    fi
     common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
         git rev-parse --show-toplevel 2>/dev/null
         return
@@ -32,22 +36,6 @@ run_bd() {
     (cd "$(beads_repo_root)" && BD_JSON_ENVELOPE=1 bd "$@")
 }
 
-# Every beads ID prefix this repo can mint keys under, one per line, lowercased.
-# Sources are the database's own issue-prefix, the global team_prefix, each
-# profile's team_prefix override, and each profile's tracker_projects (which
-# name beads prefixes the way they name Linear/Jira projects for the other
-# trackers).
-#
-# The database's issue-prefix is the one bd actually mints IDs under and need
-# not match team_prefix: a repo migrating off Linear keeps the old team prefix
-# while beads names issues after the repo directory.
-#
-# Mirrors getBeadsPrefixes in source/config.ts and get_beads_prefixes in
-# hooks/tracker_config.py; all three have to agree or the same input is a key in
-# one place and prose in another.
-#
-# $2 overrides the .beads/config.yaml path; exposed for tests, which must not
-# pick up the prefix of whatever repo they happen to run in.
 beads_id_prefixes() {
     local config_path="$1" beads_config="${2-}"
     [[ -n "$beads_config" ]] || beads_config="$(beads_repo_root)/.beads/config.yaml"
@@ -61,12 +49,6 @@ beads_id_prefixes() {
     } | tr '[:upper:]' '[:lower:]' | sort -u
 }
 
-# Whether $1 is a beads issue ID belonging to a prefix configured in $2.
-#
-# A beads suffix is a content hash, so it can be pure letters, and nothing about
-# the shape of `fix-crash` distinguishes it from an ID. Without anchoring to the
-# configured prefixes, every hyphenated description would be routed as an
-# existing issue and die on the bd lookup instead of creating one.
 is_beads_issue_key() {
     local input="$1" config_path="$2" beads_config="${3-}" prefix input_prefix
 
@@ -148,12 +130,6 @@ fetch_issue_json() {
     esac
 }
 
-# The jq expression that reads $2 out of $1's issue JSON. One table rather than
-# a provider case inside each extractor: every tracker shapes the same handful
-# of fields differently, so a new tracker is one block here instead of an arm in
-# four functions that have to be kept in step.
-#
-# Empty output means the field has no meaning for that provider.
 issue_field_jq() {
     case "$1:$2" in
         linear:title|beads:title)             echo '.title // empty' ;;

--- a/scripts/start-claude-session.sh
+++ b/scripts/start-claude-session.sh
@@ -105,6 +105,15 @@ COMPANION_SESSION="companion-${REPO_NAME}-${SESSION_KEY}"
 # INNER_SOCKET constant in pappardelle/source/tmux.ts.
 PAPPARDELLE_TMUX_SOCKET="${PAPPARDELLE_TMUX_SOCKET:-pappardelle_inner}"
 
+# Set on the tmux session rather than exported here: these sessions are created
+# on a long-lived server that inherited its environment from whatever started
+# it, so a plain export would never reach the panes. Claude Code's hooks read
+# it to find the main checkout without walking back out of the worktree.
+SESSION_ENV=()
+if [[ -n "${PAPPARDELLE_MAIN_REPO_ROOT:-}" ]]; then
+    SESSION_ENV=(-e "PAPPARDELLE_MAIN_REPO_ROOT=$PAPPARDELLE_MAIN_REPO_ROOT")
+fi
+
 # Pre-trust the worktree directory for Claude Code
 # Claude Code stores workspace trust in ~/.claude.json under projects.<path>.hasTrustDialogAccepted
 # Without this, every new worktree triggers a "do you trust this folder?" prompt
@@ -130,7 +139,7 @@ if not projects[path].get('hasTrustDialogAccepted'):
 
 # Ensure Claude tmux session
 if ! tmux -L "$PAPPARDELLE_TMUX_SOCKET" has-session -t "$CLAUDE_SESSION" 2>/dev/null; then
-    tmux -L "$PAPPARDELLE_TMUX_SOCKET" new-session -d -s "$CLAUDE_SESSION" -c "$WORKTREE_PATH"
+    tmux -L "$PAPPARDELLE_TMUX_SOCKET" new-session -d -s "$CLAUDE_SESSION" -c "$WORKTREE_PATH" "${SESSION_ENV[@]}"
     if [[ "$NO_CLAUDE" != true ]]; then
         # Build the Claude command with optional --dangerously-skip-permissions,
         # --model / --effort, and --name set to the issue key so the session is
@@ -168,7 +177,7 @@ fi
 # A shell-based session is created first so the pane persists even if the
 # command exits; an empty command leaves that plain shell untouched.
 if ! tmux -L "$PAPPARDELLE_TMUX_SOCKET" has-session -t "$COMPANION_SESSION" 2>/dev/null; then
-    tmux -L "$PAPPARDELLE_TMUX_SOCKET" new-session -d -s "$COMPANION_SESSION" -c "$WORKTREE_PATH"
+    tmux -L "$PAPPARDELLE_TMUX_SOCKET" new-session -d -s "$COMPANION_SESSION" -c "$WORKTREE_PATH" "${SESSION_ENV[@]}"
     if [[ "$NO_CLAUDE" != true && -n "$COMPANION_COMMAND" ]]; then
         tmux -L "$PAPPARDELLE_TMUX_SOCKET" send-keys -t "$COMPANION_SESSION" "$COMPANION_COMMAND" Enter
     fi

--- a/scripts/start-claude-session.sh
+++ b/scripts/start-claude-session.sh
@@ -93,8 +93,10 @@ if [[ -z "$WORKTREE_PATH" ]]; then
     exit 1
 fi
 
-CLAUDE_SESSION="claude-${REPO_NAME}-${ISSUE_KEY}"
-COMPANION_SESSION="companion-${REPO_NAME}-${ISSUE_KEY}"
+SESSION_KEY="${ISSUE_KEY//_/__}"
+SESSION_KEY="${SESSION_KEY//./_}"
+CLAUDE_SESSION="claude-${REPO_NAME}-${SESSION_KEY}"
+COMPANION_SESSION="companion-${REPO_NAME}-${SESSION_KEY}"
 
 # Per-issue claude/companion sessions live on a dedicated tmux socket so the
 # nested viewer pane in Pappardelle can attach without `TMUX=` (which would

--- a/scripts/test-beads-id-prefixes.sh
+++ b/scripts/test-beads-id-prefixes.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+
+# Test: beads ID recognition is anchored to the repo's configured prefixes
+#
+# A beads suffix is a content hash, so it can be pure letters, and nothing about
+# the shape of `fix-crash` or `dark-mode` distinguishes it from a real ID. idow
+# used to route any hyphenated input to the existing-issue branch, so those
+# descriptions died on a `bd show` lookup instead of creating an issue.
+#
+# What this exercises:
+# - beads_id_prefixes (global team_prefix, per-profile team_prefix, and each
+#   profile's tracker_projects, lowercased and deduplicated)
+# - is_beads_issue_key (prefix anchoring, last-hyphen split so hyphenated
+#   prefixes survive, underscores, hierarchical .N children)
+#
+# The prefix set must agree with getBeadsPrefixes in source/config.ts and
+# get_beads_prefixes in hooks/tracker_config.py.
+#
+# Usage: ./test-beads-id-prefixes.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/provider-helpers.sh"
+
+PASS=0
+FAIL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+TMPDIR_ROOT=$(mktemp -d)
+# shellcheck disable=SC2329  # invoked via trap
+cleanup() {
+    if [[ -n "${TMPDIR_ROOT:-}" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local test_name="$1"
+    local expected="$2"
+    local actual="$3"
+
+    if [[ "$actual" == "$expected" ]]; then
+        echo -e "  ${GREEN}PASS${RESET} $test_name"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${RESET} $test_name"
+        echo "    Expected: \"$expected\""
+        echo "    Actual:   \"$actual\""
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_key() {
+    local test_name="$1"
+    local input="$2"
+    local config="$3"
+
+    if is_beads_issue_key "$input" "$config" "$NO_BEADS_CONFIG"; then
+        echo -e "  ${GREEN}PASS${RESET} $test_name"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${RESET} $test_name"
+        echo "    Expected \"$input\" to be recognized as a beads ID"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_key() {
+    local test_name="$1"
+    local input="$2"
+    local config="$3"
+
+    if is_beads_issue_key "$input" "$config" "$NO_BEADS_CONFIG"; then
+        echo -e "  ${RED}FAIL${RESET} $test_name"
+        echo "    Expected \"$input\" to be treated as a description"
+        FAIL=$((FAIL + 1))
+    else
+        echo -e "  ${GREEN}PASS${RESET} $test_name"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# Every assertion pins the beads config explicitly: the default is the config of
+# whatever repo the suite runs in, whose prefix would leak into the expected sets.
+NO_BEADS_CONFIG="$TMPDIR_ROOT/absent/config.yaml"
+
+BEADS_CONFIG="$TMPDIR_ROOT/beads-config.yaml"
+printf 'issue-prefix: dbprefix\n' > "$BEADS_CONFIG"
+
+MULTI="$TMPDIR_ROOT/multi.yml"
+cat > "$MULTI" <<'YAML'
+version: 1
+team_prefix: myproj
+issue_tracker:
+  provider: beads
+profiles:
+  backend:
+    keywords: [api]
+    team_prefix: my_service
+  vendor:
+    keywords: [sdk]
+    tracker_projects:
+      - 'vendor-sdk'
+      - "Other-Thing"
+YAML
+
+SOLO="$TMPDIR_ROOT/solo.yml"
+printf 'version: 1\nteam_prefix: solo\n' > "$SOLO"
+
+BARE="$TMPDIR_ROOT/bare.yml"
+printf 'version: 1\n' > "$BARE"
+
+echo ""
+echo -e "${BOLD}beads_id_prefixes${RESET}"
+
+assert_eq "collects every configured source, lowercased and sorted" \
+    "my_service
+myproj
+other-thing
+vendor-sdk" \
+    "$(beads_id_prefixes "$MULTI" "$NO_BEADS_CONFIG")"
+
+assert_eq "just the global prefix when there are no profiles" \
+    "solo" "$(beads_id_prefixes "$SOLO" "$NO_BEADS_CONFIG")"
+
+assert_eq "empty when nothing is configured" \
+    "" "$(beads_id_prefixes "$BARE" "$NO_BEADS_CONFIG")"
+
+# bd mints IDs under the database's own issue-prefix, which need not match
+# team_prefix. Omitting it made those IDs read as prose and file a duplicate.
+assert_eq "includes the database issue-prefix" \
+    "dbprefix
+solo" \
+    "$(beads_id_prefixes "$SOLO" "$BEADS_CONFIG")"
+
+assert_eq "just the database issue-prefix when the config sets nothing" \
+    "dbprefix" "$(beads_id_prefixes "$BARE" "$BEADS_CONFIG")"
+
+echo ""
+echo -e "${BOLD}is_beads_issue_key${RESET}"
+
+assert_key "global prefix" "myproj-a1b2" "$MULTI"
+assert_key "hierarchical child" "myproj-a3f8e9.1" "$MULTI"
+assert_key "hyphenated tracker_projects prefix" "vendor-sdk-a1b2" "$MULTI"
+assert_key "hyphenated prefix with a child suffix" "vendor-sdk-a1b2.2" "$MULTI"
+assert_key "underscored per-profile prefix" "my_service-a1b2" "$MULTI"
+assert_key "tracker_projects entry matched case-insensitively" "other-thing-hic" "$MULTI"
+assert_key "uppercase input of a known prefix" "MYPROJ-A1B2" "$MULTI"
+
+assert_not_key "hyphenated description" "fix-crash" "$MULTI"
+assert_not_key "two-word description" "dark-mode" "$MULTI"
+assert_not_key "long description" "add-dark-mode-to-settings" "$MULTI"
+assert_not_key "known prefix word but not a key shape" "vendor" "$MULTI"
+assert_not_key "unknown prefix" "nope-x1" "$MULTI"
+assert_not_key "nesting deeper than beads allows" "myproj-a1b2.1.2.3.4" "$MULTI"
+assert_not_key "anything at all when no prefix is configured" "solo-a1b2" "$BARE"
+
+if is_beads_issue_key "dbprefix-a1b2" "$BARE" "$BEADS_CONFIG"; then
+    echo -e "  ${GREEN}PASS${RESET} database issue-prefix alone recognizes a key"
+    PASS=$((PASS + 1))
+else
+    echo -e "  ${RED}FAIL${RESET} database issue-prefix alone recognizes a key"
+    FAIL=$((FAIL + 1))
+fi
+
+echo ""
+TOTAL=$((PASS + FAIL))
+if [[ "$FAIL" -eq 0 ]]; then
+    echo -e "${GREEN}${BOLD}All $TOTAL tests passed${RESET}"
+    exit 0
+else
+    echo -e "${RED}${BOLD}$FAIL of $TOTAL tests failed${RESET}"
+    exit 1
+fi

--- a/scripts/test-beads-id-prefixes.sh
+++ b/scripts/test-beads-id-prefixes.sh
@@ -4,7 +4,7 @@
 #
 # A beads suffix is a content hash, so it can be pure letters, and nothing about
 # the shape of `fix-crash` or `dark-mode` distinguishes it from a real ID. idow
-# used to route any hyphenated input to the existing-issue branch, so those
+# used to route any hyphenated input to the --issue-key branch, so those
 # descriptions died on a `bd show` lookup instead of creating an issue.
 #
 # What this exercises:

--- a/scripts/test-extract-issue-project.sh
+++ b/scripts/test-extract-issue-project.sh
@@ -118,6 +118,28 @@ profiles:
     tracker_projects:
       - "SHOP"
 EOF
+
+    cat > "$TMPDIR_ROOT/.pappardelle-beads.yml" <<'EOF'
+version: 1
+team_prefix: pap
+default_profile: first-profile
+issue_tracker:
+  provider: beads
+profiles:
+  first-profile:
+    display_name: First Profile
+    keywords: [first]
+  by-prefix:
+    display_name: Matched By Prefix
+    keywords: [prefix]
+    tracker_projects:
+      - "pap"
+  long-prefix:
+    display_name: Long Prefix
+    keywords: [long]
+    tracker_projects:
+      - "seatgeek-ticket-management-cli"
+EOF
 }
 setup_configs
 
@@ -128,6 +150,11 @@ LINEAR_NO_PROJECT_JSON='{"identifier":"STA-124","title":"Projectless","project":
 JIRA_ISSUE_JSON='{"key":"KAN-9","fields":{"summary":"A Jira issue","project":{"key":"KAN","name":"Pappardelle Testing"}}}'
 JIRA_KEY_ONLY_MATCH_JSON='{"key":"SHOP-313","fields":{"summary":"Cart bug","project":{"key":"SHOP","name":"Shopping Cart"}}}'
 JIRA_NO_PROJECT_JSON='{"key":"KAN-10","fields":{"summary":"No project field"}}'
+# Beads has no project field at all; the ID prefix stands in for it.
+BEADS_ISSUE_JSON='{"id":"pap-a1b2","title":"A beads issue","status":"open"}'
+BEADS_LONG_PREFIX_JSON='{"id":"seatgeek-ticket-management-cli-bqm","title":"Hyphenated prefix","status":"open"}'
+BEADS_CHILD_JSON='{"id":"pap-a3f8e9.1","title":"A child issue","status":"open"}'
+BEADS_NO_PREFIX_JSON='{"id":"nohyphen","title":"Prefixless","status":"open"}'
 
 # ==========================================================================
 
@@ -201,6 +228,142 @@ assert_contains "fetch returns acli stdout" '"key":"KAN-9"' "$result"
 argv=$(cat "$TMPDIR_ROOT/acli-argv.txt" 2>/dev/null || echo "MISSING")
 assert_contains "acli argv includes --fields" "--fields" "$argv"
 assert_contains "acli argv includes *all" "*all" "$argv"
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: extract_issue_project_candidates — beads uses the ID prefix${RESET}"
+BEADS_CONFIG="$TMPDIR_ROOT/.pappardelle-beads.yml"
+
+result=$(extract_issue_project_candidates "$BEADS_ISSUE_JSON" "$BEADS_CONFIG")
+assert_eq "beads issue → ID prefix" "pap" "$result"
+
+result=$(extract_issue_project_candidates "$BEADS_LONG_PREFIX_JSON" "$BEADS_CONFIG")
+assert_eq "hyphenated prefix splits on the last hyphen" \
+    "seatgeek-ticket-management-cli" "$result"
+
+result=$(extract_issue_project_candidates "$BEADS_CHILD_JSON" "$BEADS_CONFIG")
+assert_eq "child ID drops its .N suffix" "pap" "$result"
+
+result=$(extract_issue_project_candidates "$BEADS_NO_PREFIX_JSON" "$BEADS_CONFIG")
+assert_eq "prefixless ID → empty" "" "$result"
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: match_profile_by_tracker_project — beads prefix routing${RESET}"
+candidates=$(extract_issue_project_candidates "$BEADS_ISSUE_JSON" "$BEADS_CONFIG")
+result=$(match_profile_by_tracker_project "$candidates" "$BEADS_CONFIG")
+assert_eq "prefix pap → by-prefix profile" "by-prefix" "$result"
+
+candidates=$(extract_issue_project_candidates "$BEADS_LONG_PREFIX_JSON" "$BEADS_CONFIG")
+result=$(match_profile_by_tracker_project "$candidates" "$BEADS_CONFIG")
+assert_eq "hyphenated prefix → long-prefix profile" "long-prefix" "$result"
+
+candidates=$(extract_issue_project_candidates "$BEADS_NO_PREFIX_JSON" "$BEADS_CONFIG")
+result=$(match_profile_by_tracker_project "$candidates" "$BEADS_CONFIG")
+assert_eq "no prefix → no profile match" "" "$result"
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: extract_issue_url — beads issues have no web page${RESET}"
+result=$(extract_issue_url "$BEADS_ISSUE_JSON" "$BEADS_CONFIG" "pap-a1b2")
+assert_eq "beads issue → empty URL" "" "$result"
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: extract_issue_title/description — beads shape${RESET}"
+result=$(extract_issue_title "$BEADS_ISSUE_JSON" "$BEADS_CONFIG")
+assert_eq "beads title read from .title" "A beads issue" "$result"
+
+result=$(extract_issue_description '{"id":"pap-a1b2","description":"the body"}' "$BEADS_CONFIG")
+assert_eq "beads description read from .description" "the body" "$result"
+
+result=$(extract_issue_description "$BEADS_ISSUE_JSON" "$BEADS_CONFIG")
+assert_eq "beads issue without description → empty" "" "$result"
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: beads_first_issue — every payload shape bd emits${RESET}"
+# bd show returns a one-element array, not the bare object its schema doc
+# describes, and BD_JSON_ENVELOPE=1 wraps whatever it returns.
+result=$(echo '[{"id":"pap-a1b2","title":"From array"}]' | beads_first_issue | jq -r '.title')
+assert_eq "bare array → first element" "From array" "$result"
+
+result=$(echo '{"schema_version":1,"data":[{"id":"pap-a1b2","title":"Enveloped"}]}' | beads_first_issue | jq -r '.title')
+assert_eq "envelope around array → first element" "Enveloped" "$result"
+
+result=$(echo '{"schema_version":1,"data":{"id":"pap-a1b2","title":"Enveloped object"}}' | beads_first_issue | jq -r '.title')
+assert_eq "envelope around object → the object" "Enveloped object" "$result"
+
+result=$(echo '{"id":"pap-a1b2","title":"Bare object"}' | beads_first_issue | jq -r '.title')
+assert_eq "bare object → itself" "Bare object" "$result"
+
+result=$(echo '[]' | beads_first_issue | jq -r '.title // "none"')
+assert_eq "empty array → empty object" "none" "$result"
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: create_issue — beads argv and output${RESET}"
+# Shadow bd so the test never touches a real database. create_issue asks for
+# --json and reduces the payload with beads_first_issue, so the fake answers in
+# the envelope shape beads 2.0 makes its default.
+cat > "$FAKE_BIN/bd" <<EOF
+#!/bin/bash
+printf '%s\n' "\$@" > "$TMPDIR_ROOT/bd-argv.txt"
+for arg in "\$@"; do
+    case "\$prev" in
+        --body-file) cp "\$arg" "$TMPDIR_ROOT/bd-body.txt" ;;
+    esac
+    prev="\$arg"
+done
+echo "Warning: multiple 'bd' binaries found in PATH" >&2
+echo '{"schema_version":1,"data":[{"id":"pap-a1b2"}]}'
+EOF
+chmod +x "$FAKE_BIN/bd"
+
+result=$(PATH="$FAKE_BIN:$PATH" create_issue \
+    --title "Add dark mode" \
+    --prompt "add dark mode to settings" \
+    --config "$BEADS_CONFIG" \
+    --profile by-prefix)
+assert_eq "create_issue emits the new key" '{"issue_key":"pap-a1b2","issue_url":""}' "$result"
+
+argv=$(cat "$TMPDIR_ROOT/bd-argv.txt" 2>/dev/null || echo "MISSING")
+assert_contains "bd argv uses create" "create" "$argv"
+assert_contains "bd argv passes the title" "Add dark mode" "$argv"
+assert_contains "bd argv passes --json" "--json" "$argv"
+# Beads spells its types lowercase and rejects Jira's "Task".
+assert_contains "bd argv lowercases the issue type" "task" "$argv"
+assert_contains "bd argv sends the description via a file" "--body-file" "$argv"
+
+body=$(cat "$TMPDIR_ROOT/bd-body.txt" 2>/dev/null || echo "MISSING")
+assert_contains "description body quotes the original prompt" \
+    "> add dark mode to settings" "$body"
+
+# stderr advisories must not leak into the parsed issue key.
+assert_eq "warning on stderr stays out of the key" \
+    '{"issue_key":"pap-a1b2","issue_url":""}' "$result"
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: ISSUE_NUMBER derivation from an issue key${RESET}"
+# idow's `grep -oE '[0-9]+'` emits one line per digit run. Classic keys have
+# exactly one; beads IDs carry a content hash, so "bd-a1b2" yields "1\n2" and
+# any ${ISSUE_NUMBER} template it feeds becomes a broken multi-line command.
+issue_number_for() {
+    local provider="$1" key="$2"
+    if [[ "$provider" == "beads" ]]; then
+        echo ""
+    else
+        echo "$key" | grep -oE '[0-9]+' | head -1 || echo ""
+    fi
+}
+
+assert_eq "classic key → its number" "595" "$(issue_number_for linear STA-595)"
+assert_eq "beads hash ID → empty" "" "$(issue_number_for beads bd-a1b2)"
+assert_eq "beads child ID → empty" "" "$(issue_number_for beads bd-a3f8e9.1)"
+
+raw=$(echo "bd-a1b2" | grep -oE '[0-9]+' | tr '\n' '|')
+assert_eq "raw grep on a beads ID is multi-line (the bug this guards)" "1|2|" "$raw"
 
 # ==========================================================================
 

--- a/scripts/test-extract-issue-project.sh
+++ b/scripts/test-extract-issue-project.sh
@@ -346,24 +346,20 @@ assert_eq "warning on stderr stays out of the key" \
 # ==========================================================================
 
 echo -e "\n${BOLD}Test: ISSUE_NUMBER derivation from an issue key${RESET}"
-# idow's `grep -oE '[0-9]+'` emits one line per digit run. Classic keys have
-# exactly one; beads IDs carry a content hash, so "bd-a1b2" yields "1\n2" and
-# any ${ISSUE_NUMBER} template it feeds becomes a broken multi-line command.
+# Everything after the last hyphen. Scanning left-to-right for the first digit
+# run instead turns the Jira key A1B-234 into "1", and emits one line per digit
+# run for a beads content hash, which makes any ${ISSUE_NUMBER} template it
+# feeds a broken multi-line command.
 issue_number_for() {
-    local provider="$1" key="$2"
-    if [[ "$provider" == "beads" ]]; then
-        echo ""
-    else
-        echo "$key" | grep -oE '[0-9]+' | head -1 || echo ""
-    fi
+    local key="$1"
+    echo "${key##*-}"
 }
 
-assert_eq "classic key → its number" "595" "$(issue_number_for linear STA-595)"
-assert_eq "beads hash ID → empty" "" "$(issue_number_for beads bd-a1b2)"
-assert_eq "beads child ID → empty" "" "$(issue_number_for beads bd-a3f8e9.1)"
-
-raw=$(echo "bd-a1b2" | grep -oE '[0-9]+' | tr '\n' '|')
-assert_eq "raw grep on a beads ID is multi-line (the bug this guards)" "1|2|" "$raw"
+assert_eq "classic key → its number" "595" "$(issue_number_for STA-595)"
+assert_eq "Jira key with digits in the project" "234" "$(issue_number_for A1B-234)"
+assert_eq "beads hash ID → its hash" "a1b2" "$(issue_number_for bd-a1b2)"
+assert_eq "beads child ID → hash and child" "a3f8e9.1" "$(issue_number_for bd-a3f8e9.1)"
+assert_eq "hyphenated beads prefix splits on the last hyphen" "wx0" "$(issue_number_for pappardelle-wx0)"
 
 # ==========================================================================
 

--- a/scripts/test-session-name-encoding.sh
+++ b/scripts/test-session-name-encoding.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# Test: the claude and companion tmux session names carry the same encoded key
+#
+# start-claude-session.sh creates both sessions from an encoded key ('_' -> '__',
+# then '.' -> '_') so beads IDs survive tmux's target grammar. open-iterm-claude.sh
+# has to attach to those exact names. It used to rebuild the companion name from
+# the raw issue key, which diverged for every key carrying a '_' or a '.' —
+# silently, because `new-session -d -s` just creates whatever name it is handed,
+# orphaning the companion session that already existed.
+#
+# Contrary to a natural assumption, tmux does not normalize '.' in a session
+# name: `new-session -s 'bd-a3f8e9.1'` reports back 'bd-a3f8e9.1' (verified on
+# tmux 3.7b), so beads child issues diverged too.
+#
+# The command lines are assembled inside open-iterm-claude.sh's AppleScript, so
+# this runs that AppleScript directly. Its `tell application "iTerm"` block is
+# stripped first: AppleScript resolves an application's dictionary at compile
+# time, so on a machine without iTerm2 installed the whole script fails to
+# compile and even --print-command (which returns well before iTerm) cannot run.
+# Everything this test cares about lives above that block.
+#
+# Usage: ./test-session-name-encoding.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PASS=0
+FAIL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+TMPDIR_ROOT=$(mktemp -d)
+# shellcheck disable=SC2329  # invoked via trap
+cleanup() {
+    if [[ -n "${TMPDIR_ROOT:-}" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+trap cleanup EXIT
+
+HARNESS="$TMPDIR_ROOT/assemble.applescript"
+awk '/^cat > "\$APPLESCRIPT" << .APPLESCRIPT_END.$/{f=1;next} /^APPLESCRIPT_END$/{f=0} f' \
+    "$SCRIPT_DIR/open-iterm-claude.sh" \
+    | awk '/^    tell application "iTerm"$/{skip=1} skip && /^end run$/{skip=0} !skip' \
+    > "$HARNESS"
+
+if ! grep -q '^end run$' "$HARNESS"; then
+    echo -e "${RED}Could not extract the AppleScript from open-iterm-claude.sh${RESET}" >&2
+    exit 1
+fi
+
+# The encoding under test, mirroring start-claude-session.sh.
+encode_key() {
+    local key="${1//_/__}"
+    printf '%s' "${key//./_}"
+}
+
+# Pull the session name out of a `tmux ... -s 'NAME'` or `-t 'NAME'` command line.
+session_from() {
+    sed -E "s/.*$1 '([^']*)'.*/\1/" <<< "$2"
+}
+
+assert_sessions() {
+    local test_name="$1"
+    local issue_key="$2"
+    local repo_name="testrepo"
+
+    local session_key expected_claude expected_companion
+    session_key=$(encode_key "$issue_key")
+    expected_claude="claude-${repo_name}-${session_key}"
+    expected_companion="companion-${repo_name}-${session_key}"
+
+    local out claude_line companion_line actual_claude actual_companion
+    out=$(osascript "$HARNESS" \
+        "$issue_key" /tmp/wt "$expected_claude" '' "$repo_name" '' sock 'gitui' true)
+    claude_line=$(sed -n '1p' <<< "$out")
+    companion_line=$(sed -n '2p' <<< "$out")
+    actual_claude=$(session_from '-s' "$claude_line")
+    actual_companion=$(session_from '-s' "$companion_line")
+
+    if [[ "$actual_claude" == "$expected_claude" && "$actual_companion" == "$expected_companion" ]]; then
+        echo -e "  ${GREEN}PASS${RESET} $test_name"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${RESET} $test_name"
+        echo "    claude    expected: \"$expected_claude\"  actual: \"$actual_claude\""
+        echo "    companion expected: \"$expected_companion\"  actual: \"$actual_companion\""
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# The companion pane sends its command to one session and attaches to another;
+# a name that only half-matches would still orphan the real session.
+assert_companion_self_consistent() {
+    local test_name="$1"
+    local issue_key="$2"
+
+    local session_key out companion_line created sent attached
+    session_key=$(encode_key "$issue_key")
+    out=$(osascript "$HARNESS" \
+        "$issue_key" /tmp/wt "claude-testrepo-${session_key}" '' testrepo '' sock 'gitui' true)
+    companion_line=$(sed -n '2p' <<< "$out")
+    created=$(session_from '-s' "$companion_line")
+    sent=$(sed -E "s/.*send-keys -t '([^']*)'.*/\1/" <<< "$companion_line")
+    attached=$(sed -E "s/.*attach -t '([^']*)'.*/\1/" <<< "$companion_line")
+
+    if [[ "$created" == "$sent" && "$sent" == "$attached" ]]; then
+        echo -e "  ${GREEN}PASS${RESET} $test_name"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${RESET} $test_name"
+        echo "    created: \"$created\"  sent: \"$sent\"  attached: \"$attached\""
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo -e "\n${BOLD}Test: claude and companion sessions share the encoded key${RESET}"
+
+assert_sessions "beads prefix carrying an underscore" "my_svc-a1b2"
+assert_sessions "beads child issue" "bd-a3f8e9.1"
+assert_sessions "beads child issue, three segments" "a_b-c.1.2"
+assert_sessions "beads prefix carrying hyphens" "seatgeek-ticket-management-cli-bqm"
+assert_sessions "Linear key is unchanged by the encoding" "STA-123"
+assert_sessions "Jira key carrying digits" "A1B-234"
+
+echo -e "\n${BOLD}Test: the companion line targets one session throughout${RESET}"
+
+assert_companion_self_consistent "underscore key" "my_svc-a1b2"
+assert_companion_self_consistent "child issue" "bd-a3f8e9.1"
+
+echo ""
+TOTAL=$((PASS + FAIL))
+if [[ "$FAIL" -eq 0 ]]; then
+    echo -e "${GREEN}${BOLD}All $TOTAL tests passed${RESET}"
+    exit 0
+else
+    echo -e "${RED}${BOLD}$FAIL of $TOTAL tests failed${RESET}"
+    exit 1
+fi

--- a/scripts/test-session-name-encoding.sh
+++ b/scripts/test-session-name-encoding.sh
@@ -34,6 +34,13 @@ GREEN='\033[0;32m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
+# osascript is macOS-only; the whole test is an AppleScript harness, so there is
+# nothing left to exercise elsewhere.
+if ! command -v osascript >/dev/null 2>&1; then
+    echo "SKIP: test-session-name-encoding (no osascript — macOS only)"
+    exit 0
+fi
+
 TMPDIR_ROOT=$(mktemp -d)
 # shellcheck disable=SC2329  # invoked via trap
 cleanup() {

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -29,7 +29,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const SCRIPTS_DIR = path.resolve(__dirname, '..', 'scripts');
 
-import {getIssueCached, getIssues, searchAssignedIssues} from './tracker.ts';
+import {
+	claimIssue,
+	getIssueCached,
+	getIssues,
+	searchAssignedIssues,
+} from './tracker.ts';
 import {initStateColorOverrides} from './state-color-override.ts';
 import {
 	filterByLabels,
@@ -44,6 +49,7 @@ import {
 	findSpaceByStatusKey,
 } from './claude-status.ts';
 import {normalizeIssueIdentifier} from './issue-checker.ts';
+import {openIssueForKey} from './open-issue.ts';
 import {
 	routeSession,
 	isPendingSessionResolved,
@@ -56,13 +62,17 @@ import {
 import {
 	loadConfig,
 	getStateColors,
+	getBeadsPrefixes,
+	readBeadsIssuePrefix,
 	getTeamPrefix,
 	getRepoRoot,
+	getMainRepoRoot,
 	getRepoName,
 	qualifyMainBranch,
 	getKeybindings,
 	getResolvedWatchlists,
 	getAutoRemoveWhenDone,
+	getListLayout,
 	expandTemplate,
 	buildWorkspaceTemplateVars,
 	matchProfiles,
@@ -126,6 +136,19 @@ import {
 	clearHighlightTarget,
 } from './highlight.ts';
 import type {SpaceData, PaneLayout} from './types.ts';
+
+/**
+ * Claim an issue without waiting for the answer. `claimIssue` resolves false on
+ * every failure path rather than rejecting, so a tracker that is slow, missing,
+ * or unable to claim at all cannot stall or break workspace creation — it only
+ * leaves the issue in the ready pool, which is how things behaved before
+ * claiming existed.
+ */
+function claimIssueInBackground(issueKey: string): void {
+	void claimIssue(issueKey).then(claimed => {
+		if (claimed) log.info(`Claimed ${issueKey} — removed from ready work`);
+	});
+}
 
 // Props passed from cli.tsx with pane layout info
 interface AppProps {
@@ -787,7 +810,8 @@ export default function App({
 		}
 	};
 
-	// Open the Linear/Jira issue in browser for the selected space
+	// Open the issue for the selected space — in a browser for trackers with a
+	// web UI, in a tmux popup for local-only ones (beads).
 	const handleOpenIssue = () => {
 		const space = spaces[selectedIndex];
 		if (!space || space.isPending || space.isMainWorktree) {
@@ -796,13 +820,7 @@ export default function App({
 			return;
 		}
 
-		try {
-			const url = createIssueTracker().buildIssueUrl(space.name);
-			spawn('open', [url], {detached: true, stdio: 'ignore'}).unref();
-			setHeaderWithTimeout(`Opened ${space.name}`, 3000);
-		} catch {
-			setHeaderWithTimeout('Failed to look up issue', 3000);
-		}
+		setHeaderWithTimeout(openIssueForKey(space.name).message, 3000);
 	};
 
 	// Open the IDE (Cursor) at the worktree path for the selected space
@@ -999,8 +1017,8 @@ export default function App({
 			} else if (input === 'n') {
 				// 'n' for new session
 				setShowPromptDialog(true);
-			} else if (key.delete) {
-				// Delete key to close selected space
+			} else if (key.delete || input === 'x') {
+				// Delete key (or 'x') to close selected space
 				const space = spaces[selectedIndex];
 				if (space?.isMainWorktree) {
 					setHeaderWithTimeout('Cannot close main worktree', 2000);
@@ -1147,9 +1165,27 @@ export default function App({
 	const spawnSession = (pending: PendingSession) => {
 		setPendingSession(pending);
 
+		// Move the issue out of the ready pool before idow starts, so opening
+		// several workspaces back to back stops re-offering the ones already in
+		// flight. Deliberately not awaited: setup is the user's critical path and
+		// the claim is advisory. Description routes have no key yet — they get
+		// claimed from the close handler once idow reports one.
+		//
+		// Gated on existingIssue, which means the key came out of `bd ready` (the
+		// watchlist poll or the ready picker) and is therefore open and claimable.
+		// A key the user typed says nothing about its status: `--claim` reassigns
+		// and reopens, so claiming those silently stole a teammate's in-progress
+		// issue and resurrected closed ones you only meant to re-enter.
+		if (pending.name && pending.existingIssue) {
+			claimIssueInBackground(pending.name);
+		}
+
 		const child = spawn(
 			path.join(SCRIPTS_DIR, 'idow'),
-			buildNewSessionArgs(pending.idowArg, {profileName: pending.profileName}),
+			buildNewSessionArgs(pending.idowArg, {
+				profileName: pending.profileName,
+				existingIssue: pending.existingIssue,
+			}),
 			{
 				detached: true,
 				stdio: ['ignore', 'pipe', 'pipe'],
@@ -1192,6 +1228,7 @@ export default function App({
 					pending.name || extractIssueKeyFromIdowOutput(stdoutData);
 				if (spaceKey && !pending.name) {
 					log.info(`Extracted issue key from idow output: ${spaceKey}`);
+					claimIssueInBackground(spaceKey);
 				}
 				if (spaceKey) {
 					addSpace(spaceKey);
@@ -1284,6 +1321,7 @@ export default function App({
 							type: 'issue',
 							name: issue.identifier,
 							idowArg: issue.identifier,
+							existingIssue: true,
 							pendingTitle: `Watchlist: ${issue.title}`,
 							prevSpaceCount: spacesLengthRef.current,
 							// Force the owning profile so idow runs the right
@@ -1376,6 +1414,7 @@ export default function App({
 						{
 							issueKey: space.name,
 							repoRoot: getRepoRoot(),
+							mainRepoRoot: getMainRepoRoot(),
 							repoName: getRepoName(),
 						},
 					);
@@ -1639,7 +1678,11 @@ export default function App({
 	// profileName is whatever the PromptDialog displayed — we forward
 	// it to idow via --profile so the runtime selection can't diverge from the
 	// UI preview.
-	const handleNewSession = (input: string, profileName: string | null) => {
+	const handleNewSession = (
+		input: string,
+		profileName: string | null,
+		existingIssue: boolean,
+	) => {
 		setShowPromptDialog(false);
 
 		// Try to normalize as an issue identifier (supports bare numbers like '400')
@@ -1652,7 +1695,14 @@ export default function App({
 		}
 
 		const teamPrefix = config ? getTeamPrefix(config) : 'STA';
-		const normalizedIssueKey = normalizeIssueIdentifier(input, teamPrefix);
+		const normalizedIssueKey = existingIssue
+			? input.trim()
+			: normalizeIssueIdentifier(
+					input,
+					teamPrefix,
+					createIssueTracker().name,
+					config ? getBeadsPrefixes(config, readBeadsIssuePrefix()) : [],
+				);
 
 		// Route the session: always pass just the issue key (or description) to idow.
 		// idow handles both new and existing issues correctly with a bare issue key.
@@ -1661,6 +1711,7 @@ export default function App({
 			type: route.type,
 			name: route.issueKey ?? '',
 			idowArg: route.issueKey ?? input,
+			existingIssue,
 			pendingTitle: route.pendingTitle,
 			prevSpaceCount: spaces.length,
 			profileName,
@@ -1828,6 +1879,11 @@ export default function App({
 		? searchSelectedIndex
 		: displaySelectedIndex;
 
+	// Two-line rows halve how many spaces fit on screen, so the layout has to
+	// feed the scroll math rather than being a purely cosmetic render choice.
+	const listLayout = getListLayout(configMemo);
+	const linesPerItem = listLayout === 'two_line' ? 2 : 1;
+
 	// Calculate scroll offset for large lists
 	const {
 		scrollOffset,
@@ -1837,6 +1893,7 @@ export default function App({
 		activeSelectedIndex,
 		activeSpaces.length,
 		termHeight,
+		linesPerItem,
 	);
 	const visibleDisplaySpaces = activeSpaces.slice(
 		scrollOffset,
@@ -1866,6 +1923,7 @@ export default function App({
 				y: event.y,
 				bannerHeight,
 				visibleRows: visibleDisplaySpaces.length,
+				linesPerItem,
 			});
 			if (clickedRow === null) return;
 
@@ -1898,6 +1956,7 @@ export default function App({
 			visibleDisplaySpaces.length,
 			pendingInsertIndex,
 			bannerHeight,
+			linesPerItem,
 		],
 	);
 
@@ -1935,6 +1994,7 @@ export default function App({
 						space={space}
 						isSelected={index === adjustedDisplayIndex}
 						width={termDimensions.cols}
+						layout={listLayout}
 					/>
 				))}
 			</Box>

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -137,13 +137,6 @@ import {
 } from './highlight.ts';
 import type {SpaceData, PaneLayout} from './types.ts';
 
-/**
- * Claim an issue without waiting for the answer. `claimIssue` resolves false on
- * every failure path rather than rejecting, so a tracker that is slow, missing,
- * or unable to claim at all cannot stall or break workspace creation — it only
- * leaves the issue in the ready pool, which is how things behaved before
- * claiming existed.
- */
 function claimIssueInBackground(issueKey: string): void {
 	void claimIssue(issueKey).then(claimed => {
 		if (claimed) log.info(`Claimed ${issueKey} — removed from ready work`);
@@ -1165,17 +1158,6 @@ export default function App({
 	const spawnSession = (pending: PendingSession) => {
 		setPendingSession(pending);
 
-		// Move the issue out of the ready pool before idow starts, so opening
-		// several workspaces back to back stops re-offering the ones already in
-		// flight. Deliberately not awaited: setup is the user's critical path and
-		// the claim is advisory. Description routes have no key yet — they get
-		// claimed from the close handler once idow reports one.
-		//
-		// Gated on existingIssue, which means the key came out of `bd ready` (the
-		// watchlist poll or the ready picker) and is therefore open and claimable.
-		// A key the user typed says nothing about its status: `--claim` reassigns
-		// and reopens, so claiming those silently stole a teammate's in-progress
-		// issue and resurrected closed ones you only meant to re-enter.
 		if (pending.name && pending.existingIssue) {
 			claimIssueInBackground(pending.name);
 		}
@@ -1190,7 +1172,7 @@ export default function App({
 				detached: true,
 				stdio: ['ignore', 'pipe', 'pipe'],
 				cwd: getRepoRoot(),
-				env: buildSpawnEnv(getRepoRoot()),
+				env: buildSpawnEnv(getRepoRoot(), getMainRepoRoot()),
 			},
 		);
 
@@ -1654,7 +1636,7 @@ export default function App({
 				detached: true,
 				stdio: ['ignore', 'pipe', 'pipe'],
 				cwd: getRepoRoot(),
-				env: buildSpawnEnv(getRepoRoot()),
+				env: buildSpawnEnv(getRepoRoot(), getMainRepoRoot()),
 			},
 		);
 
@@ -1879,8 +1861,6 @@ export default function App({
 		? searchSelectedIndex
 		: displaySelectedIndex;
 
-	// Two-line rows halve how many spaces fit on screen, so the layout has to
-	// feed the scroll math rather than being a purely cosmetic render choice.
 	const listLayout = getListLayout(configMemo);
 	const linesPerItem = listLayout === 'two_line' ? 2 : 1;
 

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -1158,7 +1158,7 @@ export default function App({
 	const spawnSession = (pending: PendingSession) => {
 		setPendingSession(pending);
 
-		if (pending.name && pending.existingIssue) {
+		if (pending.name && pending.inputIsIssueKey) {
 			claimIssueInBackground(pending.name);
 		}
 
@@ -1166,7 +1166,7 @@ export default function App({
 			path.join(SCRIPTS_DIR, 'idow'),
 			buildNewSessionArgs(pending.idowArg, {
 				profileName: pending.profileName,
-				existingIssue: pending.existingIssue,
+				inputIsIssueKey: pending.inputIsIssueKey,
 			}),
 			{
 				detached: true,
@@ -1303,7 +1303,7 @@ export default function App({
 							type: 'issue',
 							name: issue.identifier,
 							idowArg: issue.identifier,
-							existingIssue: true,
+							inputIsIssueKey: true,
 							pendingTitle: `Watchlist: ${issue.title}`,
 							prevSpaceCount: spacesLengthRef.current,
 							// Force the owning profile so idow runs the right
@@ -1663,7 +1663,7 @@ export default function App({
 	const handleNewSession = (
 		input: string,
 		profileName: string | null,
-		existingIssue: boolean,
+		inputIsIssueKey: boolean,
 	) => {
 		setShowPromptDialog(false);
 
@@ -1677,7 +1677,7 @@ export default function App({
 		}
 
 		const teamPrefix = config ? getTeamPrefix(config) : 'STA';
-		const normalizedIssueKey = existingIssue
+		const normalizedIssueKey = inputIsIssueKey
 			? input.trim()
 			: normalizeIssueIdentifier(
 					input,
@@ -1693,7 +1693,7 @@ export default function App({
 			type: route.type,
 			name: route.issueKey ?? '',
 			idowArg: route.issueKey ?? input,
-			existingIssue,
+			inputIsIssueKey,
 			pendingTitle: route.pendingTitle,
 			prevSpaceCount: spaces.length,
 			profileName,

--- a/source/beads-provider.test.ts
+++ b/source/beads-provider.test.ts
@@ -1,0 +1,801 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'ava';
+import {
+	BeadsProvider,
+	MAX_RETRIES,
+	beadsIssuePrefix,
+	buildIssuePopupArgv,
+	beadsStateName,
+	beadsStateType,
+	mapBeadsIssue,
+	normalizeBeadsStatus,
+	unreachableReadyStatuses,
+	unwrapBeadsJson,
+	type CliExecutor,
+	type SleepFn,
+} from './providers/beads-provider.ts';
+import {StateColorCache} from './providers/state-color-cache.ts';
+import {buildPopupCommand} from './tmux.ts';
+
+function makeEnoentError(): Error & {code: string} {
+	const err = new Error('spawn bd ENOENT') as Error & {code: string};
+	err.code = 'ENOENT';
+	return err;
+}
+
+// No-op sleep so tests don't wait
+const noopSleep: SleepFn = async () => {};
+
+let tempCounter = 0;
+function tempCachePath(): string {
+	return path.join(
+		os.tmpdir(),
+		`pappardelle-beads-test-${process.pid}-${Date.now()}-${tempCounter++}.json`,
+	);
+}
+
+function tempCache(): StateColorCache {
+	return new StateColorCache(tempCachePath());
+}
+
+const REPO_ROOT = '/tmp/pappardelle-beads-test-repo';
+const resolveCwd = () => REPO_ROOT;
+
+/** Build a provider whose CLI is a canned stdout string per invocation. */
+function providerReturning(...outputs: Array<string | Error>): {
+	provider: BeadsProvider;
+	calls: string[][];
+} {
+	const calls: string[][] = [];
+	let index = 0;
+	const exec: CliExecutor = async (_cmd, args) => {
+		calls.push(args);
+		const next = outputs[Math.min(index, outputs.length - 1)];
+		index++;
+		if (next instanceof Error) throw next;
+		return next ?? '[]';
+	};
+	return {
+		provider: new BeadsProvider(exec, noopSleep, tempCache(), resolveCwd),
+		calls,
+	};
+}
+
+const OPEN_ISSUE = {
+	id: 'sddamico-hic',
+	title: "better-sqlite3 can't build",
+	description: 'CLT libc++ headers missing',
+	status: 'open',
+	priority: 1,
+	issue_type: 'bug',
+	owner: 'stephen@example.com',
+	created_at: '2026-07-30T01:35:25Z',
+	updated_at: '2026-07-30T01:35:25Z',
+	dependency_count: 0,
+	comment_count: 0,
+};
+
+// unwrapBeadsJson — payload shapes bd can emit
+
+test('unwrapBeadsJson reads a bare array (legacy --json)', t => {
+	const rows = unwrapBeadsJson(JSON.stringify([OPEN_ISSUE]));
+	t.is(rows.length, 1);
+	t.is(rows[0]!['id'], 'sddamico-hic');
+});
+
+test('unwrapBeadsJson unwraps the schema envelope', t => {
+	// BD_JSON_ENVELOPE=1 today, the default from beads 2.0 on.
+	const rows = unwrapBeadsJson(
+		JSON.stringify({schema_version: 1, data: [OPEN_ISSUE]}),
+	);
+	t.is(rows.length, 1);
+	t.is(rows[0]!['id'], 'sddamico-hic');
+});
+
+test('unwrapBeadsJson wraps a lone object into a list', t => {
+	const rows = unwrapBeadsJson(JSON.stringify(OPEN_ISSUE));
+	t.is(rows.length, 1);
+	t.is(rows[0]!['title'], "better-sqlite3 can't build");
+});
+
+test('unwrapBeadsJson unwraps an enveloped lone object', t => {
+	const rows = unwrapBeadsJson(
+		JSON.stringify({schema_version: 1, data: OPEN_ISSUE}),
+	);
+	t.is(rows.length, 1);
+	t.is(rows[0]!['id'], 'sddamico-hic');
+});
+
+test('unwrapBeadsJson returns nothing for an empty or scalar payload', t => {
+	t.deepEqual(unwrapBeadsJson('[]'), []);
+	t.deepEqual(unwrapBeadsJson('null'), []);
+	t.deepEqual(unwrapBeadsJson('"nope"'), []);
+});
+
+test('unwrapBeadsJson drops non-object rows rather than mapping them', t => {
+	const rows = unwrapBeadsJson(JSON.stringify([OPEN_ISSUE, null, 3]));
+	t.is(rows.length, 1);
+});
+
+// beadsIssuePrefix — the stand-in for Linear/Jira's project field
+
+test('beadsIssuePrefix splits on the last hyphen', t => {
+	t.is(beadsIssuePrefix('bd-a1b2'), 'bd');
+	t.is(beadsIssuePrefix('sddamico-hic'), 'sddamico');
+});
+
+test('beadsIssuePrefix keeps hyphens inside the prefix', t => {
+	// The prefix defaults to the repo directory name, which routinely has them.
+	t.is(
+		beadsIssuePrefix('seatgeek-ticket-management-cli-bqm'),
+		'seatgeek-ticket-management-cli',
+	);
+});
+
+test('beadsIssuePrefix ignores hierarchical child suffixes', t => {
+	t.is(beadsIssuePrefix('bd-a3f8e9.1'), 'bd');
+	t.is(beadsIssuePrefix('bd-a3f8e9.1.2'), 'bd');
+});
+
+test('beadsIssuePrefix returns empty for an ID with no hyphen', t => {
+	t.is(beadsIssuePrefix('nohyphen'), '');
+});
+
+// Status mapping
+
+test('beadsStateType reports closed as completed for auto-remove', t => {
+	// auto-remove.ts keys off the Linear-flavored 'completed'/'canceled'.
+	t.is(beadsStateType('closed'), 'completed');
+});
+
+test('beadsStateType passes every other status through untouched', t => {
+	// Including user-defined ones, which beads allows via its status.custom key.
+	for (const status of ['open', 'in_progress', 'blocked', 'needs_review']) {
+		t.is(beadsStateType(status), status);
+	}
+});
+
+test('beadsStateName title-cases the snake_case status', t => {
+	t.is(beadsStateName('in_progress'), 'In Progress');
+	t.is(beadsStateName('open'), 'Open');
+});
+
+// mapBeadsIssue — pure parsing logic
+
+test('mapBeadsIssue maps a standard bd row', t => {
+	const issue = mapBeadsIssue(OPEN_ISSUE);
+	t.is(issue.identifier, 'sddamico-hic');
+	t.is(issue.title, "better-sqlite3 can't build");
+	t.is(issue.state.name, 'Open');
+	t.is(issue.state.type, 'open');
+	t.is(issue.state.color, 'gray');
+});
+
+test('mapBeadsIssue never uppercases the identifier', t => {
+	// A beads ID is case-sensitive; uppercasing yields one bd cannot resolve.
+	t.is(mapBeadsIssue({id: 'bd-a1b2', title: 'x'}).identifier, 'bd-a1b2');
+});
+
+test('mapBeadsIssue exposes the prefix as the project', t => {
+	const issue = mapBeadsIssue({id: 'sddamico-hic', title: 'x', status: 'open'});
+	t.deepEqual(issue.project, {name: 'sddamico', key: 'sddamico'});
+});
+
+test('mapBeadsIssue reports no project for a prefixless ID', t => {
+	t.is(mapBeadsIssue({id: 'nohyphen', title: 'x'}).project, null);
+});
+
+test('mapBeadsIssue maps a closed issue to the terminal state type', t => {
+	const issue = mapBeadsIssue({...OPEN_ISSUE, status: 'closed'});
+	t.is(issue.state.type, 'completed');
+	t.is(issue.state.name, 'Closed');
+	t.is(issue.state.color, 'green');
+});
+
+test('mapBeadsIssue gives an unknown status the fallback color', t => {
+	const issue = mapBeadsIssue({...OPEN_ISSUE, status: 'needs_review'});
+	t.is(issue.state.name, 'Needs Review');
+	t.is(issue.state.color, 'gray');
+});
+
+test('mapBeadsIssue keeps string labels and drops the rest', t => {
+	const issue = mapBeadsIssue({...OPEN_ISSUE, labels: ['bug', 7, 'infra']});
+	t.deepEqual(issue.labels, ['bug', 'infra']);
+});
+
+test('mapBeadsIssue omits labels when bd sent none', t => {
+	t.is(mapBeadsIssue(OPEN_ISSUE).labels, undefined);
+});
+
+test('mapBeadsIssue tolerates a row missing title and status', t => {
+	const issue = mapBeadsIssue({id: 'bd-a1b2'});
+	t.is(issue.title, '');
+	t.is(issue.state.type, 'open');
+});
+
+// getIssue
+
+test('getIssue fetches and maps an issue', async t => {
+	const {provider, calls} = providerReturning(JSON.stringify([OPEN_ISSUE]));
+	const issue = await provider.getIssue('sddamico-hic');
+	t.is(issue?.title, "better-sqlite3 can't build");
+	t.deepEqual(calls[0], ['show', '--id=sddamico-hic', '--json']);
+});
+
+test('getIssue picks the row whose id was asked for', async t => {
+	const other = {...OPEN_ISSUE, id: 'sddamico-zzz', title: 'Other'};
+	const {provider} = providerReturning(
+		JSON.stringify([other, {...OPEN_ISSUE, title: 'Wanted'}]),
+	);
+	const issue = await provider.getIssue('sddamico-hic');
+	t.is(issue?.title, 'Wanted');
+});
+
+test('getIssue returns null when bd reports no rows', async t => {
+	const {provider} = providerReturning('[]');
+	t.is(await provider.getIssue('sddamico-nope'), null);
+});
+
+test('getIssue serves a second call from cache', async t => {
+	const {provider, calls} = providerReturning(JSON.stringify([OPEN_ISSUE]));
+	await provider.getIssue('sddamico-hic');
+	await provider.getIssue('sddamico-hic');
+	t.is(calls.length, 1);
+});
+
+test('getIssue retries a failing bd call', async t => {
+	const {provider, calls} = providerReturning(
+		new Error('database locked'),
+		JSON.stringify([OPEN_ISSUE]),
+	);
+	const issue = await provider.getIssue('sddamico-hic');
+	t.is(issue?.title, "better-sqlite3 can't build");
+	t.is(calls.length, 2);
+});
+
+test('getIssue gives up after MAX_RETRIES', async t => {
+	const {provider, calls} = providerReturning(new Error('nope'));
+	t.is(await provider.getIssue('sddamico-hic'), null);
+	t.is(calls.length, MAX_RETRIES);
+});
+
+test('a missing bd binary disables the provider instead of retrying', async t => {
+	const {provider, calls} = providerReturning(makeEnoentError());
+	t.is(await provider.getIssue('sddamico-hic'), null);
+	t.is(await provider.getIssue('sddamico-other'), null);
+	// One attempt total: ENOENT is sticky, and no retry can fix it.
+	t.is(calls.length, 1);
+});
+
+// getIssues
+
+test('getIssues fetches a batch in one bd list call', async t => {
+	const second = {...OPEN_ISSUE, id: 'sddamico-ck8', title: 'Second'};
+	const {provider, calls} = providerReturning(
+		JSON.stringify([OPEN_ISSUE, second]),
+	);
+	const map = await provider.getIssues(['sddamico-hic', 'sddamico-ck8']);
+	t.is(map.get('sddamico-hic')?.title, "better-sqlite3 can't build");
+	t.is(map.get('sddamico-ck8')?.title, 'Second');
+	t.deepEqual(calls[0], [
+		'list',
+		'--id=sddamico-hic,sddamico-ck8',
+		'--json',
+		'-n',
+		'0',
+	]);
+});
+
+test('getIssues resolves keys the batch missed individually', async t => {
+	const {provider, calls} = providerReturning(
+		JSON.stringify([OPEN_ISSUE]),
+		JSON.stringify([{...OPEN_ISSUE, id: 'sddamico-ck8', title: 'Second'}]),
+	);
+	const map = await provider.getIssues(['sddamico-hic', 'sddamico-ck8']);
+	t.is(map.get('sddamico-ck8')?.title, 'Second');
+	t.is(calls[1]?.[0], 'show');
+});
+
+test('getIssues falls back to individual fetches when the batch errors', async t => {
+	let call = 0;
+	const exec: CliExecutor = async (_cmd, args) => {
+		call++;
+		if (args[0] === 'list') throw new Error('bad flag');
+		return JSON.stringify([OPEN_ISSUE]);
+	};
+	const provider = new BeadsProvider(exec, noopSleep, tempCache(), resolveCwd);
+	const map = await provider.getIssues(['sddamico-hic']);
+	t.is(map.get('sddamico-hic')?.title, "better-sqlite3 can't build");
+	t.true(call > 1);
+});
+
+test('getIssues short-circuits on an empty key list', async t => {
+	const {provider, calls} = providerReturning('[]');
+	const map = await provider.getIssues([]);
+	t.is(map.size, 0);
+	t.is(calls.length, 0);
+});
+
+// searchAssignedIssues — the watchlist, sourced from `bd ready`
+
+test('searchAssignedIssues reads bd ready', async t => {
+	const {provider, calls} = providerReturning(JSON.stringify([OPEN_ISSUE]));
+	const issues = await provider.searchAssignedIssues(undefined, []);
+	t.is(issues.length, 1);
+	t.deepEqual(calls[0], [
+		'ready',
+		'--json',
+		'-n',
+		'0',
+		'--exclude-type',
+		'epic,convoy,molecule,event,merge-request',
+	]);
+});
+
+test('searchAssignedIssues narrows bd ready by configured status', async t => {
+	const started = {...OPEN_ISSUE, id: 'sddamico-ck8', status: 'in_progress'};
+	const {provider} = providerReturning(JSON.stringify([OPEN_ISSUE, started]));
+	const issues = await provider.searchAssignedIssues(undefined, ['open']);
+	t.deepEqual(
+		issues.map(i => i.identifier),
+		['sddamico-hic'],
+	);
+});
+
+test('searchAssignedIssues matches a status by display name too', async t => {
+	const started = {...OPEN_ISSUE, id: 'sddamico-ck8', status: 'in_progress'};
+	const {provider} = providerReturning(JSON.stringify([OPEN_ISSUE, started]));
+	const issues = await provider.searchAssignedIssues(undefined, [
+		'In Progress',
+	]);
+	t.deepEqual(
+		issues.map(i => i.identifier),
+		['sddamico-ck8'],
+	);
+});
+
+test('searchAssignedIssues takes every ready issue when no status is set', async t => {
+	const started = {...OPEN_ISSUE, id: 'sddamico-ck8', status: 'in_progress'};
+	const {provider} = providerReturning(JSON.stringify([OPEN_ISSUE, started]));
+	const issues = await provider.searchAssignedIssues(undefined, []);
+	t.is(issues.length, 2);
+});
+
+test('searchAssignedIssues passes an explicit assignee through', async t => {
+	const {provider, calls} = providerReturning('[]');
+	await provider.searchAssignedIssues('alice@example.com', []);
+	t.deepEqual(calls[0], [
+		'ready',
+		'--json',
+		'-n',
+		'0',
+		'--exclude-type',
+		'epic,convoy,molecule,event,merge-request',
+		'--assignee',
+		'alice@example.com',
+	]);
+});
+
+// A watchlist match spawns a worktree with no one in the loop, so the container
+// and bookkeeping types have to be filtered at the query — bd accepts an
+// unknown --exclude-type silently, so this is the only place a typo shows up.
+test('the watchlist does not offer a container or a bookkeeping row', async t => {
+	const {provider, calls} = providerReturning('[]');
+	await provider.searchAssignedIssues(undefined, []);
+	const argv = calls[0]!;
+	const excluded = argv[argv.indexOf('--exclude-type') + 1]!.split(',');
+	t.deepEqual(excluded, [
+		'epic',
+		'convoy',
+		'molecule',
+		'event',
+		'merge-request',
+	]);
+});
+
+// A person is choosing in the picker, and opening a worktree against a
+// container to work through its children is a legitimate thing to want.
+test('the picker still offers a container row', async t => {
+	const {provider, calls} = providerReturning('[]');
+	await provider.listReadyIssues();
+	t.false(calls[0]!.includes('--exclude-type'));
+});
+
+// Writing an ADR produces a real diff, so a decision is work like any other.
+test('a decision is still offered to the watchlist', async t => {
+	const {provider, calls} = providerReturning('[]');
+	await provider.searchAssignedIssues(undefined, []);
+	const argv = calls[0]!;
+	t.false(
+		argv[argv.indexOf('--exclude-type') + 1]!.split(',').includes('decision'),
+	);
+});
+
+test('searchAssignedIssues resolves "me" from the environment', async t => {
+	const previous = process.env['BEADS_ACTOR'];
+	process.env['BEADS_ACTOR'] = 'charlie';
+	try {
+		const {provider, calls} = providerReturning('[]');
+		await provider.searchAssignedIssues('me', []);
+		t.true(calls[0]!.includes('charlie'));
+	} finally {
+		if (previous === undefined) {
+			delete process.env['BEADS_ACTOR'];
+		} else {
+			process.env['BEADS_ACTOR'] = previous;
+		}
+	}
+});
+
+/** Provider whose executor answers `git` and `bd` separately. */
+function providerWithGit(gitName: string | Error): {
+	provider: BeadsProvider;
+	calls: string[][];
+} {
+	const calls: string[][] = [];
+	const exec: CliExecutor = async (cmd, args) => {
+		if (cmd === 'git') {
+			if (gitName instanceof Error) throw gitName;
+			return `${gitName}\n`;
+		}
+
+		calls.push(args);
+		return '[]';
+	};
+	return {
+		provider: new BeadsProvider(exec, noopSleep, tempCache(), resolveCwd),
+		calls,
+	};
+}
+
+// `bd` stamps $BEADS_ACTOR, then git user.name, then $USER onto an issue it
+// claims. Resolving "me" straight to $USER matched nothing on the common setup
+// where a full name is configured but the OS login is a handle.
+test('searchAssignedIssues resolves "me" through git user.name', async t => {
+	const previousActor = process.env['BEADS_ACTOR'];
+	delete process.env['BEADS_ACTOR'];
+	try {
+		const {provider, calls} = providerWithGit('Ada Lovelace');
+		await provider.searchAssignedIssues('me', []);
+		t.true(calls[0]!.includes('Ada Lovelace'));
+	} finally {
+		if (previousActor !== undefined) {
+			process.env['BEADS_ACTOR'] = previousActor;
+		}
+	}
+});
+
+test('searchAssignedIssues falls back to $USER with no git identity', async t => {
+	const previousActor = process.env['BEADS_ACTOR'];
+	const previousUser = process.env['USER'];
+	delete process.env['BEADS_ACTOR'];
+	process.env['USER'] = 'ada';
+	try {
+		const {provider, calls} = providerWithGit(new Error('no user.name set'));
+		await provider.searchAssignedIssues('me', []);
+		t.true(calls[0]!.includes('ada'));
+	} finally {
+		if (previousActor !== undefined) {
+			process.env['BEADS_ACTOR'] = previousActor;
+		}
+
+		if (previousUser === undefined) {
+			delete process.env['USER'];
+		} else {
+			process.env['USER'] = previousUser;
+		}
+	}
+});
+
+test('a status bd ready cannot return yields an empty watchlist', async t => {
+	// `bd ready` excludes in_progress/blocked/deferred/hooked by construction,
+	// so it only ever hands back open issues. A watchlist config carried over
+	// from Linear ("In Progress") therefore matches nothing — the provider warns
+	// (see unreachableReadyStatuses) rather than failing.
+	const {provider} = providerReturning(JSON.stringify([OPEN_ISSUE]));
+	t.deepEqual(
+		await provider.searchAssignedIssues(undefined, ['in_progress']),
+		[],
+	);
+});
+
+test('unreachableReadyStatuses flags statuses bd ready never returns', t => {
+	t.deepEqual(unreachableReadyStatuses(['open']), []);
+	t.deepEqual(unreachableReadyStatuses(['in_progress']), ['in_progress']);
+	// Display-name spelling, as a Linear/Jira watchlist would write it.
+	t.deepEqual(unreachableReadyStatuses(['In Progress']), ['In Progress']);
+	t.deepEqual(unreachableReadyStatuses(['Open', 'blocked']), ['blocked']);
+	t.deepEqual(unreachableReadyStatuses([]), []);
+});
+
+test('searchAssignedIssues returns nothing when bd is missing', async t => {
+	const {provider} = providerReturning(makeEnoentError());
+	t.deepEqual(await provider.searchAssignedIssues(undefined, []), []);
+});
+
+// listReadyIssues
+
+test('listReadyIssues reads bd ready with no assignee filter', async t => {
+	const {provider, calls} = providerReturning(JSON.stringify([OPEN_ISSUE]));
+	const issues = await provider.listReadyIssues();
+	t.deepEqual(
+		issues.map(i => i.identifier),
+		['sddamico-hic'],
+	);
+	t.deepEqual(calls[0], ['ready', '--json', '-n', '0']);
+});
+
+// Unlike the watchlist, the picker keeps whatever bd ready hands back: beads
+// issues are usually unassigned until claimed, so any narrowing would empty it.
+test('listReadyIssues keeps every row bd ready returns', async t => {
+	const other = {...OPEN_ISSUE, id: 'sddamico-ck8', assignee: 'someone-else'};
+	const {provider} = providerReturning(JSON.stringify([OPEN_ISSUE, other]));
+	const issues = await provider.listReadyIssues();
+	t.deepEqual(
+		issues.map(i => i.identifier),
+		['sddamico-hic', 'sddamico-ck8'],
+	);
+});
+
+test('listReadyIssues returns nothing when bd is missing', async t => {
+	const {provider} = providerReturning(makeEnoentError());
+	t.deepEqual(await provider.listReadyIssues(), []);
+});
+
+test('listReadyIssues returns nothing when bd fails', async t => {
+	const {provider} = providerReturning(new Error('bd exploded'));
+	t.deepEqual(await provider.listReadyIssues(), []);
+});
+
+test('listReadyIssues skips malformed rows and keeps the valid ones', async t => {
+	const {provider} = providerReturning(
+		JSON.stringify([{nonsense: true}, OPEN_ISSUE]),
+	);
+	const issues = await provider.listReadyIssues();
+	t.deepEqual(
+		issues.map(i => i.identifier),
+		['sddamico-hic'],
+	);
+});
+
+// closeIssue
+
+test('closeIssue runs bd close', async t => {
+	const {provider, calls} = providerReturning('');
+	t.true(await provider.closeIssue('sddamico-hic'));
+	t.deepEqual(calls[0], ['close', '--', 'sddamico-hic']);
+});
+
+// The escape is not decoration: `bd show -weird-xyz` dies with "unknown
+// shorthand flag: 'e'". close/update/comments add have no --id of their own,
+// so `--` is the only thing standing between a dash-led prefix and the parser.
+test("the id is fenced off from bd's flag parser", async t => {
+	const {provider, calls} = providerReturning('', '', '');
+	await provider.closeIssue('-weird-xyz');
+	await provider.claimIssue('-weird-xyz');
+	for (const argv of calls) {
+		t.is(argv.at(-1), '-weird-xyz');
+		t.is(argv.at(-2), '--');
+	}
+});
+
+test('closeIssue drops the cached copy so the next read comes from bd', async t => {
+	const {provider} = providerReturning(
+		JSON.stringify([OPEN_ISSUE]),
+		'',
+		makeEnoentError(),
+	);
+	await provider.getIssue('sddamico-hic');
+	await provider.closeIssue('sddamico-hic');
+
+	// bd is gone by this point, so a surviving cache entry is the only way
+	// getIssue could still answer.
+	t.is(await provider.getIssue('sddamico-hic'), null);
+});
+
+test('closeIssue reports failure when bd fails', async t => {
+	const {provider} = providerReturning(new Error('bd exploded'));
+	t.false(await provider.closeIssue('sddamico-hic'));
+});
+
+test('closeIssue reports failure when bd is missing', async t => {
+	const {provider} = providerReturning(makeEnoentError());
+	t.false(await provider.closeIssue('sddamico-hic'));
+});
+
+// claimIssue
+
+test('claimIssue runs bd update --claim', async t => {
+	const {provider, calls} = providerReturning('');
+	t.true(await provider.claimIssue('sddamico-hic'));
+	t.deepEqual(calls[0], ['update', '--claim', '--', 'sddamico-hic']);
+});
+
+test('claimIssue runs from the main repo root, not the caller cwd', async t => {
+	// Regression: a claim that runs from a worktree lets bd auto-discover that
+	// worktree's own .beads and write the transition to the wrong database, so
+	// the issue never leaves the canonical ready pool.
+	let seenCwd = '';
+	const exec: CliExecutor = async (_cmd, _args, opts) => {
+		seenCwd = opts.cwd;
+		return '';
+	};
+	const provider = new BeadsProvider(exec, noopSleep, tempCache(), resolveCwd);
+	await provider.claimIssue('sddamico-hic');
+	t.is(seenCwd, REPO_ROOT);
+});
+
+test('claimIssue drops the cached copy so the next read sees in_progress', async t => {
+	const {provider} = providerReturning(
+		JSON.stringify([OPEN_ISSUE]),
+		'',
+		makeEnoentError(),
+	);
+	await provider.getIssue('sddamico-hic');
+	await provider.claimIssue('sddamico-hic');
+
+	// bd is gone by this point, so a surviving cache entry is the only way
+	// getIssue could still answer — and it would answer "open".
+	t.is(await provider.getIssue('sddamico-hic'), null);
+});
+
+test('claimIssue reports failure when bd fails', async t => {
+	const {provider} = providerReturning(new Error('bd exploded'));
+	t.false(await provider.claimIssue('sddamico-hic'));
+});
+
+test('claimIssue reports failure when bd is missing', async t => {
+	const {provider} = providerReturning(makeEnoentError());
+	t.false(await provider.claimIssue('sddamico-hic'));
+});
+
+// createComment
+
+test('createComment hands bd a file holding the body', async t => {
+	let bodyPath = '';
+	let seen = '';
+	const exec: CliExecutor = async (_cmd, args) => {
+		bodyPath = args[args.indexOf('-f') + 1]!;
+		seen = fs.readFileSync(bodyPath, 'utf-8');
+		return '';
+	};
+	const provider = new BeadsProvider(exec, noopSleep, tempCache(), resolveCwd);
+	t.true(await provider.createComment('bd-a1b2', '### Answered\n\nyes'));
+	t.is(seen, '### Answered\n\nyes');
+	// The staging file is cleaned up regardless of outcome.
+	t.false(fs.existsSync(bodyPath));
+});
+
+test('createComment retries then reports failure', async t => {
+	const {provider, calls} = providerReturning(new Error('locked'));
+	t.false(await provider.createComment('bd-a1b2', 'body'));
+	t.is(calls.length, MAX_RETRIES);
+});
+
+test('createComment gives up immediately when bd is missing', async t => {
+	const {provider, calls} = providerReturning(makeEnoentError());
+	t.false(await provider.createComment('bd-a1b2', 'body'));
+	t.is(calls.length, 1);
+});
+
+// Misc surface
+
+test('openIssue reports failure outside tmux', t => {
+	const previous = process.env['TMUX'];
+	delete process.env['TMUX'];
+	try {
+		const {provider} = providerReturning('[]');
+		t.false(provider.openIssue('bd-a1b2'));
+	} finally {
+		if (previous !== undefined) process.env['TMUX'] = previous;
+	}
+});
+
+test('openIssue popup is pinned to the main repo root', t => {
+	// A popup launched from a worktree pane would otherwise read that worktree's
+	// checked-out .beads/ copy instead of the database the rail is showing.
+	const argv = buildIssuePopupArgv(REPO_ROOT, 'bd-a1b2');
+	t.is(argv[argv.indexOf('-C') + 1], REPO_ROOT);
+});
+
+test('issue popup output goes through a pager', t => {
+	// display-popup -E tears the popup down the moment its command exits, and
+	// `bd show` prints and exits immediately — without the pager the popup
+	// flashes for a single frame and the issue is never readable.
+	const command = buildPopupCommand(buildIssuePopupArgv(REPO_ROOT, 'bd-a1b2'));
+	t.true(command.includes("'bd' '-C'"));
+	t.true(command.endsWith('| less -R'));
+	t.false(command.includes('-F'));
+});
+
+test('getWorkflowStateColor resolves a display name back to its color', async t => {
+	const {provider} = providerReturning(
+		JSON.stringify([{...OPEN_ISSUE, status: 'in_progress'}]),
+	);
+	await provider.getIssue('sddamico-hic');
+	t.is(provider.getWorkflowStateColor('In Progress'), 'blue');
+});
+
+test('getWorkflowStateColor answers for a state never fetched', t => {
+	const {provider} = providerReturning('[]');
+	t.is(provider.getWorkflowStateColor('Blocked'), 'yellow');
+	t.is(provider.getWorkflowStateColor('Nonsense'), null);
+});
+
+test('clearCache forces the next getIssue back to bd', async t => {
+	const {provider, calls} = providerReturning(JSON.stringify([OPEN_ISSUE]));
+	await provider.getIssue('sddamico-hic');
+	provider.clearCache();
+	await provider.getIssue('sddamico-hic');
+	t.is(calls.length, 2);
+});
+
+test('bd runs from the repo root with the JSON envelope requested', async t => {
+	let options: {cwd: string; env: NodeJS.ProcessEnv} | undefined;
+	const exec: CliExecutor = async (_cmd, _args, opts) => {
+		options = opts;
+		return '[]';
+	};
+	const provider = new BeadsProvider(exec, noopSleep, tempCache(), resolveCwd);
+	await provider.getIssue('sddamico-hic');
+	// Every worktree must read the one canonical database at the repo root.
+	t.is(options?.cwd, REPO_ROOT);
+	t.is(options?.env['BD_JSON_ENVELOPE'], '1');
+});
+
+// ---------------------------------------------------------------------------
+// Cache keying
+
+test('a row bd spells differently is cached under the key we asked for', async t => {
+	// getIssue deliberately accepts rows[0] when no id matches the request, so
+	// bd folding case (or resolving an alias) is a supported outcome. Caching
+	// only bd's spelling left the requested key permanently absent: every read
+	// re-forked bd, and getIssueCached — called on each render of the row —
+	// answered null forever, so the row never stopped saying "Loading…".
+	const {provider, calls} = providerReturning(
+		JSON.stringify([OPEN_ISSUE]),
+		makeEnoentError(),
+	);
+
+	const fetched = await provider.getIssue('SDDAMICO-HIC');
+	t.is(fetched?.identifier, 'sddamico-hic');
+	t.is(provider.getIssueCached('SDDAMICO-HIC')?.identifier, 'sddamico-hic');
+	t.is(provider.getIssueCached('sddamico-hic')?.identifier, 'sddamico-hic');
+
+	// bd is gone by now, so a second answer can only come from the cache.
+	const again = await provider.getIssue('SDDAMICO-HIC');
+	t.is(again?.identifier, 'sddamico-hic');
+	t.is(calls.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Status normalization
+
+test('normalizeBeadsStatus folds every spelling a watchlist arrives in', t => {
+	t.is(normalizeBeadsStatus('in_progress'), 'in_progress');
+	t.is(normalizeBeadsStatus('In Progress'), 'in_progress');
+	t.is(normalizeBeadsStatus('  IN   PROGRESS  '), 'in_progress');
+	t.is(normalizeBeadsStatus('Open'), 'open');
+	t.is(normalizeBeadsStatus(''), '');
+});
+
+test('the reachability warning and the watchlist filter read a status alike', async t => {
+	// These used to normalize differently — the warning folded whitespace to
+	// underscores, the filter did not — so one spelling could be reported as
+	// unreachable and still match, or the reverse.
+	for (const spelling of ['open', 'Open', ' OPEN ']) {
+		const {provider} = providerReturning(JSON.stringify([OPEN_ISSUE]));
+		t.deepEqual(unreachableReadyStatuses([spelling]), []);
+		const matched = await provider.searchAssignedIssues(undefined, [spelling]);
+		t.is(matched.length, 1);
+	}
+
+	for (const spelling of ['in_progress', 'In Progress', 'in progress']) {
+		const {provider} = providerReturning(JSON.stringify([OPEN_ISSUE]));
+		t.deepEqual(unreachableReadyStatuses([spelling]), [spelling]);
+		const matched = await provider.searchAssignedIssues(undefined, [spelling]);
+		t.is(matched.length, 0);
+	}
+});

--- a/source/claude-status.test.ts
+++ b/source/claude-status.test.ts
@@ -263,7 +263,12 @@ test('CLAUDE_STATUS_DISPLAY shows ? for unknown (fallback)', async t => {
 		'?',
 		'unknown should show ? icon as fallback',
 	);
-	t.is(CLAUDE_STATUS_DISPLAY.unknown.color, 'gray', 'unknown should be gray');
+	t.is(
+		CLAUDE_STATUS_DISPLAY.unknown.color,
+		undefined,
+		'unknown carries no color — bright black is the background on Solarized',
+	);
+	t.true(CLAUDE_STATUS_DISPLAY.unknown.dim, 'unknown should be dimmed instead');
 });
 
 test('CLAUDE_STATUS_DISPLAY has correct icon for error', async t => {

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -21,6 +21,8 @@ import {
 	getRepoName,
 	loadConfig,
 	loadProviderConfigs,
+	getBeadsPrefixes,
+	readBeadsIssuePrefix,
 	getTeamPrefix,
 	ConfigNotFoundError,
 	ConfigValidationError,
@@ -206,11 +208,21 @@ if (cli.input.length > 0) {
 	}
 
 	const teamPrefix = config ? getTeamPrefix(config) : 'STA';
-	const normalizedIssueKey = normalizeIssueIdentifier(prompt, teamPrefix);
+	const normalizedIssueKey = normalizeIssueIdentifier(
+		prompt,
+		teamPrefix,
+		createIssueTracker().name,
+		config ? getBeadsPrefixes(config, readBeadsIssuePrefix()) : [],
+	);
 	const finalPrompt = normalizedIssueKey ?? prompt;
 
 	console.log(`Starting new session with: "${finalPrompt}"`);
 
+	// No claim here, deliberately. The TUI claims only keys that came out of
+	// `bd ready` (see spawnSession): `--claim` reassigns and reopens, so
+	// claiming a key someone typed steals a teammate's in-progress issue and
+	// resurrects closed ones you only meant to re-enter. Every key on this path
+	// was typed on the command line, so none of them is claimable.
 	const result = spawnSync(path.join(SCRIPTS_DIR, 'idow'), [finalPrompt], {
 		stdio: 'inherit',
 		cwd: getRepoRoot(),

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -18,6 +18,7 @@ import type {PaneLayout} from './types.ts';
 import {
 	configExists,
 	getRepoRoot,
+	getMainRepoRoot,
 	getRepoName,
 	loadConfig,
 	loadProviderConfigs,
@@ -218,15 +219,10 @@ if (cli.input.length > 0) {
 
 	console.log(`Starting new session with: "${finalPrompt}"`);
 
-	// No claim here, deliberately. The TUI claims only keys that came out of
-	// `bd ready` (see spawnSession): `--claim` reassigns and reopens, so
-	// claiming a key someone typed steals a teammate's in-progress issue and
-	// resurrects closed ones you only meant to re-enter. Every key on this path
-	// was typed on the command line, so none of them is claimable.
 	const result = spawnSync(path.join(SCRIPTS_DIR, 'idow'), [finalPrompt], {
 		stdio: 'inherit',
 		cwd: getRepoRoot(),
-		env: buildSpawnEnv(getRepoRoot()),
+		env: buildSpawnEnv(getRepoRoot(), getMainRepoRoot()),
 	});
 
 	process.exit(result.status ?? 0);

--- a/source/components/HelpOverlay.tsx
+++ b/source/components/HelpOverlay.tsx
@@ -29,7 +29,7 @@ const fixedShortcuts = [
 	{key: 'k / ↑', description: 'Move up'},
 	{key: 'Enter', description: 'Focus Claude pane'},
 	{key: 'n', description: 'New space'},
-	{key: 'Del', description: 'Close space'},
+	{key: 'x / Del', description: 'Close space'},
 	{key: '/', description: 'Search spaces'},
 	{key: 'U', description: 'Update to latest release'},
 	{key: 'q', description: 'Quit'},

--- a/source/components/PromptDialog.tsx
+++ b/source/components/PromptDialog.tsx
@@ -3,6 +3,7 @@ import React, {useState, useMemo} from 'react';
 import {Box, Text, useInput, useStdout} from 'ink';
 import TextInput from './TextInput.tsx';
 import TitledBox from './TitledBox.tsx';
+import ConfirmDialog from './ConfirmDialog.tsx';
 import {dialogWidth} from './dialog-width.ts';
 import {resolveEmojiSlot} from '../emoji-rail-width.ts';
 import {
@@ -12,6 +13,8 @@ import {
 	type PappardelleConfig,
 	type ProfileSelection,
 } from '../config.ts';
+import {createIssueTracker} from '../providers/index.ts';
+import type {IssueTrackerProvider} from '../providers/types.ts';
 import {
 	applySkillCompletion,
 	clampSelection,
@@ -33,13 +36,22 @@ import {
 	PICKER_MAX_VISIBLE,
 	type ProfileOption,
 } from '../profile-picker.ts';
+import {ReadyWorkList, useReadyWork} from './ReadyWork.tsx';
+import {INPUT_INDEX, resolveSubmission} from './ready-picker.ts';
+
+/** React key for the profile-less row, which has no profile name to use. */
+const DEFERRED_ROW_KEY = '__deferred__';
 
 interface Props {
-	onSubmit: (prompt: string, profileName: string | null) => void;
+	onSubmit: (
+		prompt: string,
+		profileName: string | null,
+		existingIssue: boolean,
+	) => void;
 	onCancel: () => void;
 	/**
 	 * Columns available to the dialog. Callers inside tmux should pass the pane
-	 * width — `stdout.columns` can be a full terminal-width stale value right
+	 * width; `stdout.columns` can be a full terminal-width stale value right
 	 * after a split, which would run the hand-drawn top border past the pane
 	 * edge and wrap it onto its own line.
 	 */
@@ -65,6 +77,17 @@ export default function PromptDialog({
 	// and buys back `j`/`k` and Enter itself. Tab never needs this: it accepts
 	// from wherever you are.
 	const [isPickingSkill, setIsPickingSkill] = useState(false);
+
+	// Resolved once. `createIssueTracker` throws when no provider is configured,
+	// and every capability the dialog gates on — ready listing, closing — is a
+	// question about this one object, so it is the only place that has to ask.
+	const tracker = useMemo((): IssueTrackerProvider | null => {
+		try {
+			return createIssueTracker();
+		} catch {
+			return null;
+		}
+	}, []);
 
 	const {stdout} = useStdout();
 	const width = dialogWidth(availableWidth, stdout?.columns);
@@ -121,22 +144,38 @@ export default function PromptDialog({
 		}
 	}, []);
 
+	const ready = useReadyWork(
+		tracker,
+		!isPicking && !isCompleting && !isSkillFocused,
+	);
+	// The close confirmation takes over the whole dialog, so every other keymap
+	// stands down while it is up.
+	const isPromptStage = !isPicking && ready.closeTarget === null;
+
+	// What Enter would act on right now. Everything downstream (the profile
+	// preview and the option list) keys off this rather than the raw field, so
+	// arrowing into a suggestion re-aims them at the issue you are looking at.
+	const effectiveInput =
+		resolveSubmission(prompt, ready.identifiers, ready.index) ?? '';
+
 	// Live preview of what the first Enter will do. Deferred inputs (issue keys)
 	// still say so and still spawn on that one Enter; everything else advertises
 	// the profile the picker will preselect.
 	const preview = useMemo((): ProfileSelection | null => {
 		if (!config) return null;
-		return determineProfileForInput(config, prompt);
-	}, [config, prompt]);
-	const opensPicker = preview?.kind === 'resolved';
+		return determineProfileForInput(config, effectiveInput);
+	}, [config, effectiveInput]);
+	const opensPicker =
+		preview?.kind === 'resolved' ||
+		(preview?.kind === 'deferred' && preview.canPick);
 
 	// Derived from the current prompt rather than snapshotted on Enter, because
 	// the list is visible while you type and has to re-rank as you go. Once the
 	// picker takes focus the text input is frozen, so the list is stable for as
 	// long as a selection can move within it.
 	const options = useMemo(
-		() => (config ? buildProfileOptions(config, prompt) : []),
-		[config, prompt],
+		() => (config ? buildProfileOptions(config, effectiveInput) : []),
+		[config, effectiveInput],
 	);
 
 	// While typing, the preselected row IS the answer the old "Profile:" line
@@ -157,7 +196,7 @@ export default function PromptDialog({
 			}
 			onCancel();
 		},
-		{isActive: !isPicking && !isSkillFocused},
+		{isActive: isPromptStage && !isSkillFocused},
 	);
 
 	// Arrows and Tab. The text input keeps focus while the list is open, so
@@ -230,7 +269,7 @@ export default function PromptDialog({
 
 				case 'submit': {
 					const chosen = options[result.index];
-					if (chosen) onSubmit(prompt.trim(), chosen.name);
+					if (chosen) onSubmit(effectiveInput.trim(), chosen.name, ready.onRow);
 					break;
 				}
 
@@ -247,7 +286,7 @@ export default function PromptDialog({
 				}
 			}
 		},
-		{isActive: isPicking},
+		{isActive: isPicking && ready.closeTarget === null},
 	);
 
 	// The list re-ranks on every keystroke, so an index parked deep in a long
@@ -264,14 +303,17 @@ export default function PromptDialog({
 			return;
 		}
 
-		const decision = resolvePromptSubmit(config, value);
+		const resolved = resolveSubmission(value, ready.identifiers, ready.index);
+		if (resolved === null) return;
+
+		const decision = resolvePromptSubmit(config, resolved);
 		switch (decision.kind) {
 			case 'none': {
 				break;
 			}
 
 			case 'spawn': {
-				onSubmit(value.trim(), decision.profileName);
+				onSubmit(resolved, decision.profileName, ready.onRow);
 				break;
 			}
 
@@ -283,9 +325,25 @@ export default function PromptDialog({
 		}
 	};
 
+	if (ready.closeTarget) {
+		const {identifier, title} = ready.closeTarget.issue;
+		return (
+			<ConfirmDialog
+				title="Close Issue"
+				message={`Close ${identifier}?`}
+				detail={title}
+				processingMessage={`Closing ${identifier}…`}
+				onConfirm={ready.confirmClose}
+				onCancel={ready.cancelClose}
+			/>
+		);
+	}
+
 	// The heavy outline is the only thing saying where a keystroke lands, so the
 	// prompt gives it up to whichever picker took the focus from it.
-	const promptFrame = focusFrame(!isPicking && !isSkillFocused);
+	const promptFrame = focusFrame(
+		!isPicking && !isSkillFocused && ready.index === INPUT_INDEX,
+	);
 	const pickerFrame = focusFrame(isPicking);
 
 	return (
@@ -318,9 +376,16 @@ export default function PromptDialog({
 						onSubmit={handlePromptSubmit}
 						placeholder="STA-123, 123, or describe the task..."
 						isFocused={!isPicking && !isSkillFocused}
+						isShowingCursor={ready.index === INPUT_INDEX}
 						highlight={highlight}
 					/>
 				</Box>
+
+				{ready.errorMessage && (
+					<Box marginTop={1}>
+						<Text color="red">{ready.errorMessage}</Text>
+					</Box>
+				)}
 
 				{!isPicking && !isSkillFocused && (
 					<Box marginTop={1}>
@@ -343,6 +408,12 @@ export default function PromptDialog({
 				)}
 			</TitledBox>
 
+			<ReadyWorkList
+				ready={ready}
+				width={width}
+				isFocused={!isPicking && ready.index >= 0}
+				hasHints={!isPicking}
+			/>
 			{isCompleting ? (
 				<SkillPicker
 					entries={completions}
@@ -359,7 +430,9 @@ export default function PromptDialog({
 					frame={pickerFrame}
 					isFocused={isPicking}
 					deferredLabel={
-						preview?.kind === 'deferred' ? preview.displayName : undefined
+						preview?.kind === 'deferred' && !preview.canPick
+							? preview.displayName
+							: undefined
 					}
 				/>
 			)}
@@ -381,9 +454,10 @@ function ProfilePicker({
 	frame: {borderStyle: 'double' | 'round'; isDim: boolean};
 	isFocused: boolean;
 	/**
-	 * Set for issue-key / bare-number / Linear-URL inputs, where there is no
-	 * choice to make — the profile comes from the fetched issue's tracker
-	 * project. The box stays on screen (it always does) but shows a single
+	 * Set for bare numbers and for issue keys whose prefix no profile claims,
+	 * where there is no choice to make — the profile comes from the fetched
+	 * issue's tracker project. A claimed prefix gets the real list instead.
+	 * The box stays on screen (it always does) but shows a single
 	 * inert row instead of a list, so it's visibly not somewhere Enter stops.
 	 */
 	deferredLabel?: string;
@@ -423,7 +497,7 @@ function ProfilePicker({
 						// (which owns column 0 for every row) and left of the label.
 						const slot = resolveEmojiSlot(option.emoji);
 						return (
-							<Box key={option.name}>
+							<Box key={option.name ?? DEFERRED_ROW_KEY}>
 								<Text
 									color={isSelected ? 'green' : undefined}
 									bold={isSelected}
@@ -439,11 +513,15 @@ function ProfilePicker({
 								<Text
 									color={isSelected ? 'green' : undefined}
 									bold={isSelected}
+									italic={option.kind === 'deferred'}
 								>
 									{option.displayName}
 								</Text>
 								{option.matchedKeywords.length > 0 && (
 									<Text dimColor> ← {option.matchedKeywords.join(', ')}</Text>
+								)}
+								{option.matchedPrefix && (
+									<Text dimColor> ← {option.matchedPrefix}</Text>
 								)}
 								{option.enforced && <Text color="magenta"> (enforced)</Text>}
 								{option.isDefault && option.matchedKeywords.length === 0 && (

--- a/source/components/PromptDialog.tsx
+++ b/source/components/PromptDialog.tsx
@@ -152,9 +152,6 @@ export default function PromptDialog({
 	// stands down while it is up.
 	const isPromptStage = !isPicking && ready.closeTarget === null;
 
-	// What Enter would act on right now. Everything downstream (the profile
-	// preview and the option list) keys off this rather than the raw field, so
-	// arrowing into a suggestion re-aims them at the issue you are looking at.
 	const effectiveInput =
 		resolveSubmission(prompt, ready.identifiers, ready.index) ?? '';
 

--- a/source/components/PromptDialog.tsx
+++ b/source/components/PromptDialog.tsx
@@ -46,7 +46,7 @@ interface Props {
 	onSubmit: (
 		prompt: string,
 		profileName: string | null,
-		existingIssue: boolean,
+		inputIsIssueKey: boolean,
 	) => void;
 	onCancel: () => void;
 	/**

--- a/source/components/ReadyWork.tsx
+++ b/source/components/ReadyWork.tsx
@@ -1,0 +1,280 @@
+import React, {useEffect, useMemo, useState} from 'react';
+import {Box, Text, useInput} from 'ink';
+import widestLine from 'widest-line';
+import TitledBox from './TitledBox.tsx';
+import {truncateToWidth} from '../truncate-to-width.ts';
+import {focusFrame} from '../profile-picker.ts';
+import {openIssueForKey} from '../open-issue.ts';
+import type {IssueTrackerProvider, TrackerIssue} from '../providers/types.ts';
+import {
+	INPUT_INDEX,
+	canCloseHighlightedRow,
+	hasHighlightedRow,
+	moveSelection,
+	selectionAfterRemoval,
+	visibleWindow,
+} from './ready-picker.ts';
+
+const MAX_VISIBLE_SUGGESTIONS = 8;
+
+const CLOSE_KEY = 'x';
+
+// 'i' rather than 'o' to match the main list, where 'i' opens the issue and
+// 'o' opens the workspace.
+const OPEN_KEY = 'i';
+
+/**
+ * The ready-work list under the new-session prompt: what `bd ready` offers, the
+ * cursor the prompt shares with it, and the two row actions.
+ *
+ * Split out of PromptDialog because it is a self-contained surface with its own
+ * fetch, its own keymap and its own confirm step — none of which the prompt,
+ * the skill completer or the profile picker have any reason to be edited for.
+ */
+export interface ReadyWork {
+	issues: TrackerIssue[];
+	loading: boolean;
+	/** INPUT_INDEX when the caret is in the text field, else the row it is on. */
+	index: number;
+	identifiers: string[];
+	/** True when the cursor sits on a row, so Enter submits that issue. */
+	onRow: boolean;
+	openKeyActive: boolean;
+	closeKeyActive: boolean;
+	errorMessage: string | null;
+	/** Set while the close confirmation owns the screen. */
+	closeTarget: {issue: TrackerIssue; index: number} | null;
+	confirmClose: () => Promise<void>;
+	cancelClose: () => void;
+}
+
+/**
+ * `isActive` gates the keymap on the conditions the caller owns — whichever of
+ * its other boxes has the focus — so the skill completer can take the arrows
+ * back while it is open. The confirmation step is gated here instead, since the
+ * state it turns on belongs to this hook.
+ */
+export function useReadyWork(
+	tracker: IssueTrackerProvider | null,
+	isActive: boolean,
+): ReadyWork {
+	const [issues, setIssues] = useState<TrackerIssue[]>([]);
+	// Resolved up front so trackers without a ready query never flash a loading
+	// row on their way to rendering nothing.
+	const [loading, setLoading] = useState(
+		() => typeof tracker?.listReadyIssues === 'function',
+	);
+	// The prompt field and this list share one cursor: INPUT_INDEX means the
+	// caret is in the text field, 0..n-1 point at a suggestion.
+	const [index, setIndex] = useState(INPUT_INDEX);
+	const [closeTarget, setCloseTarget] = useState<{
+		issue: TrackerIssue;
+		index: number;
+	} | null>(null);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	// Trackers that can't answer "what's ready" cheaply leave listReadyIssues
+	// undefined, which collapses the picker to nothing and leaves the dialog
+	// exactly as it was before.
+	useEffect(() => {
+		let cancelled = false;
+
+		const load = async () => {
+			try {
+				const ready = (await tracker?.listReadyIssues?.()) ?? [];
+				if (!cancelled) setIssues(ready);
+			} catch {
+				// A tracker that cannot answer leaves the list empty; the prompt
+				// above it still works.
+				if (!cancelled) setIssues([]);
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		};
+
+		void load();
+		return () => {
+			cancelled = true;
+		};
+	}, [tracker]);
+
+	const identifiers = useMemo(
+		() => issues.map(issue => issue.identifier),
+		[issues],
+	);
+
+	// Trackers that can't close an issue locally leave closeIssue undefined; the
+	// keybinding and its hint disappear rather than failing on the keystroke.
+	const closeKeyActive = canCloseHighlightedRow(
+		typeof tracker?.closeIssue === 'function',
+		index,
+	);
+	// Every tracker can show an issue somehow — a popup for the local-only ones,
+	// a browser for the rest — so this needs no capability gate of its own.
+	const openKeyActive = hasHighlightedRow(index);
+
+	useInput(
+		(input, key) => {
+			if (key.downArrow || key.upArrow) {
+				setIndex(current =>
+					moveSelection(
+						current,
+						identifiers.length,
+						key.downArrow ? 'down' : 'up',
+					),
+				);
+				return;
+			}
+
+			if (key.ctrl || key.meta) return;
+
+			const issue = issues[index];
+			if (!issue) return;
+
+			if (closeKeyActive && input === CLOSE_KEY) {
+				setErrorMessage(null);
+				setCloseTarget({issue, index});
+				return;
+			}
+
+			if (openKeyActive && input === OPEN_KEY) {
+				// Read-only, so the cursor stays where it is: the popup is a detour
+				// on the way to picking this row up, not a replacement for it.
+				const result = openIssueForKey(issue.identifier);
+				setErrorMessage(result.ok ? null : result.message);
+			}
+		},
+		{isActive: isActive && closeTarget === null},
+	);
+
+	const confirmClose = async () => {
+		if (!closeTarget) return;
+		const {issue, index: removed} = closeTarget;
+
+		// closeIssue resolves false on every failure path rather than throwing,
+		// so a false here is "bd said no", not "something blew up".
+		const closed = (await tracker?.closeIssue?.(issue.identifier)) ?? false;
+		if (closed) {
+			const remaining = issues.filter(
+				candidate => candidate.identifier !== issue.identifier,
+			);
+			setIssues(remaining);
+			setIndex(selectionAfterRemoval(removed, remaining.length));
+		} else {
+			setErrorMessage(`Could not close ${issue.identifier}`);
+		}
+
+		setCloseTarget(null);
+	};
+
+	return {
+		issues,
+		loading,
+		index,
+		identifiers,
+		onRow: hasHighlightedRow(index) && identifiers[index] !== undefined,
+		openKeyActive,
+		closeKeyActive,
+		errorMessage,
+		closeTarget,
+		confirmClose,
+		cancelClose: () => setCloseTarget(null),
+	};
+}
+
+export function ReadyWorkList({
+	ready,
+	width,
+	isFocused,
+	hasHints,
+}: {
+	ready: ReadyWork;
+	width: number;
+	/** Whether the cursor is in this list, which owns the heavy outline. */
+	isFocused: boolean;
+	hasHints: boolean;
+}) {
+	const {issues, index} = ready;
+	const window = useMemo(
+		() => visibleWindow(index, issues.length, MAX_VISIBLE_SUGGESTIONS),
+		[index, issues.length],
+	);
+
+	if (ready.loading) {
+		return (
+			<Box paddingX={2}>
+				<Text dimColor>Loading ready work…</Text>
+			</Box>
+		);
+	}
+
+	if (issues.length === 0) return null;
+
+	const frame = focusFrame(isFocused);
+	const contentWidth = Math.max(0, width - 6);
+
+	return (
+		<>
+			<TitledBox
+				title={`Ready work (${issues.length})`}
+				borderColor="green"
+				titleColor="greenBright"
+				borderStyle={frame.borderStyle}
+				isDim={frame.isDim}
+				width={width}
+				paddingY={0}
+			>
+				{window.start > 0 && <Text dimColor>↑ {window.start} more</Text>}
+				{issues.slice(window.start, window.end).map((issue, offset) => {
+					const isSelected = window.start + offset === index;
+					const identifier = truncateToWidth(
+						issue.identifier,
+						contentWidth - 2,
+					);
+					const titleWidth = Math.max(
+						0,
+						contentWidth - 3 - widestLine(identifier),
+					);
+					const title = truncateToWidth(
+						issue.title.replace(/\s+/g, ' '),
+						titleWidth,
+					);
+					return (
+						<Box key={issue.identifier} height={1} overflow="hidden">
+							<Text wrap="truncate">
+								<Text color="green">{isSelected ? '❯ ' : '  '}</Text>
+								<Text color={isSelected ? 'green' : 'cyan'} bold={isSelected}>
+									{identifier}
+								</Text>
+								{title && <Text dimColor={!isSelected}> {title}</Text>}
+							</Text>
+						</Box>
+					);
+				})}
+				{window.end < issues.length && (
+					<Text dimColor>↓ {issues.length - window.end} more</Text>
+				)}
+			</TitledBox>
+
+			{hasHints && (
+				<Box paddingX={2}>
+					<Text dimColor>
+						<Text color="green">↑/↓</Text> pick up ready work
+						{ready.openKeyActive && (
+							<>
+								{' · '}
+								<Text color="green">{OPEN_KEY}</Text> issue
+							</>
+						)}
+						{ready.closeKeyActive && (
+							<>
+								{' · '}
+								<Text color="green">{CLOSE_KEY}</Text> close
+							</>
+						)}
+					</Text>
+				</Box>
+			)}
+		</>
+	);
+}

--- a/source/components/ReadyWork.tsx
+++ b/source/components/ReadyWork.tsx
@@ -19,18 +19,8 @@ const MAX_VISIBLE_SUGGESTIONS = 8;
 
 const CLOSE_KEY = 'x';
 
-// 'i' rather than 'o' to match the main list, where 'i' opens the issue and
-// 'o' opens the workspace.
 const OPEN_KEY = 'i';
 
-/**
- * The ready-work list under the new-session prompt: what `bd ready` offers, the
- * cursor the prompt shares with it, and the two row actions.
- *
- * Split out of PromptDialog because it is a self-contained surface with its own
- * fetch, its own keymap and its own confirm step — none of which the prompt,
- * the skill completer or the profile picker have any reason to be edited for.
- */
 export interface ReadyWork {
 	issues: TrackerIssue[];
 	loading: boolean;
@@ -48,12 +38,6 @@ export interface ReadyWork {
 	cancelClose: () => void;
 }
 
-/**
- * `isActive` gates the keymap on the conditions the caller owns — whichever of
- * its other boxes has the focus — so the skill completer can take the arrows
- * back while it is open. The confirmation step is gated here instead, since the
- * state it turns on belongs to this hook.
- */
 export function useReadyWork(
 	tracker: IssueTrackerProvider | null,
 	isActive: boolean,
@@ -74,8 +58,7 @@ export function useReadyWork(
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
 	// Trackers that can't answer "what's ready" cheaply leave listReadyIssues
-	// undefined, which collapses the picker to nothing and leaves the dialog
-	// exactly as it was before.
+	// undefined, which collapses the picker to nothing.
 	useEffect(() => {
 		let cancelled = false;
 
@@ -109,8 +92,6 @@ export function useReadyWork(
 		typeof tracker?.closeIssue === 'function',
 		index,
 	);
-	// Every tracker can show an issue somehow — a popup for the local-only ones,
-	// a browser for the rest — so this needs no capability gate of its own.
 	const openKeyActive = hasHighlightedRow(index);
 
 	useInput(

--- a/source/components/SpaceListItem.tsx
+++ b/source/components/SpaceListItem.tsx
@@ -60,10 +60,6 @@ export default function SpaceListItem({
 	layout,
 }: Props) {
 	const isTwoLine = layout === 'two_line';
-	// A pending row keeps its progress text ("Opening…") beside the key even
-	// under the two-line layout, but still occupies two terminal lines: the
-	// click hit-test divides by a uniform rows-per-item, so a short row would
-	// misaddress every space below it.
 	const inlineTitle = titleSharesKeyLine({
 		isTwoLine,
 		isPending: space.isPending,
@@ -342,18 +338,7 @@ export default function SpaceListItem({
 
 	const keyLine = (
 		<Box width={keyLineWidth} overflowX="hidden">
-			{/* Identity cluster: emoji, status icon and issue key. `flexShrink={0}`
-			    is load-bearing — `width` is the pane width pappardelle *believes*
-			    it has, and when that overshoots the pane Ink actually renders into,
-			    Yoga's default shrink squeezes every cell here at once: the status
-			    icon disappears, the separators collapse and the issue key is chopped
-			    mid-string with the remainder spilling onto extra lines. Refusing to
-			    shrink keeps the row's identity intact and pushes all give onto the
-			    title, which is the one part that can truncate meaningfully. */}
 			<Box flexShrink={0}>
-				{/* Profile emoji (NOT highlighted) — first cell on the row when set.
-				    Followed by a single space separator so it doesn't crash into the
-				    Claude status icon. */}
 				{emoji ? (
 					<>
 						<Text inverse={useBlinkInverse} color={textColor}>
@@ -405,10 +390,6 @@ export default function SpaceListItem({
 					</Text>
 				)}
 
-				{/* Separator between key and title. Sits in the fixed cluster rather
-				    than the title box so an overflowing row can't squeeze it away and
-				    weld the title onto the issue key. Only when the title shares this
-				    row — the two-line layout indents its title line instead. */}
 				{hasIssueKey && inlineTitle && truncatedTitle.length > 0 && (
 					<Text dimColor={!useInverse} inverse={useInverse} color={titleColor}>
 						{' '}

--- a/source/components/SpaceListItem.tsx
+++ b/source/components/SpaceListItem.tsx
@@ -12,20 +12,34 @@ import {
 	railPrefixWidth,
 	rowPrefixWidth,
 	ROW_ICON_CELLS,
+	twoLineTitleIndent,
+	titleSharesKeyLine,
 } from '../list-view-sizing.ts';
 import {inkRenderPad, resolveEmojiSlot} from '../emoji-rail-width.ts';
 import {truncateToWidth} from '../truncate-to-width.ts';
+import type {ListLayout} from '../config.ts';
+import {resolveRowHighlight} from './row-highlight.ts';
 import ClaudeAnimation from './ClaudeAnimation.tsx';
 
 interface Props {
 	space: SpaceData;
 	isSelected: boolean;
 	width: number;
+	layout: ListLayout;
 }
 
 interface PipelineIconStyle {
 	color: string;
 	icon: string;
+}
+
+/**
+ * Width to hand a Box that will be widened by `pad` cells at render time.
+ * `undefined` — Ink's "take the full width" — when nothing expands, which keeps
+ * the common row byte-identical to what it rendered before the emoji rail.
+ */
+function shrinkBy(width: number, pad: number): number | undefined {
+	return pad > 0 ? Math.max(0, width - pad) : undefined;
 }
 
 /** Single-color pipeline icons. `progressing_dirty` is rendered specially
@@ -39,7 +53,21 @@ const PIPELINE_SINGLE: Record<
 	progressing_clean: {color: 'yellow', icon: '◔'}, // ◔
 };
 
-export default function SpaceListItem({space, isSelected, width}: Props) {
+export default function SpaceListItem({
+	space,
+	isSelected,
+	width,
+	layout,
+}: Props) {
+	const isTwoLine = layout === 'two_line';
+	// A pending row keeps its progress text ("Opening…") beside the key even
+	// under the two-line layout, but still occupies two terminal lines: the
+	// click hit-test divides by a uniform rows-per-item, so a short row would
+	// misaddress every space below it.
+	const inlineTitle = titleSharesKeyLine({
+		isTwoLine,
+		isPending: space.isPending,
+	});
 	const baseStatusInfo = space.claudeStatus
 		? CLAUDE_STATUS_DISPLAY[space.claudeStatus]
 		: CLAUDE_STATUS_DISPLAY.unknown;
@@ -49,7 +77,9 @@ export default function SpaceListItem({space, isSelected, width}: Props) {
 		space.claudeStatus === 'waiting_for_approval' &&
 		space.claudeTool === 'AskUserQuestion';
 
-	const statusInfo = isQuestion ? {color: 'blue', icon: '?'} : baseStatusInfo;
+	const statusInfo = isQuestion
+		? {color: 'blue', icon: '?', dim: false}
+		: baseStatusInfo;
 
 	// Pending rows always show the animation spinner
 	const isWorking =
@@ -111,14 +141,14 @@ export default function SpaceListItem({space, isSelected, width}: Props) {
 		emoji ? {emoji, width: emojiCells} : undefined,
 	);
 	// Whether to emit our own separator space after the emoji. For most emoji
-	// we do — but for single-BMP default-emoji symbols (✨ ⭐ ✅ …) Ink draws
+	// we do, but for single-BMP default-emoji symbols (✨ ⭐ ✅ …) Ink draws
 	// the glyph one cell narrower than `string-width` reserved and pads the box
 	// with a trailing space. That pad already separates the emoji from the
 	// status icon, so emitting a second space here would double it (STA-1565).
 	const emojiNeedsSeparator = emojiSlot?.needsSeparator ?? false;
 
 	// Calculate available width for title
-	// Format: "[emoji ] ✢ STA-123 title…   [pipeline] [(N)]" — emoji on the
+	// Format: "[emoji ] ✢ STA-123 title…   [pipeline] [(N)]", with emoji on the
 	// far left, rail icons right-aligned. They reserve space by shrinking
 	// the title budget.
 	// A hand-narrowed rail (STA-2040) can leave fewer columns than the key
@@ -140,7 +170,12 @@ export default function SpaceListItem({space, isSelected, width}: Props) {
 		emojiPrefixCells +
 		(hasIssueKey ? 1 + 1 + issueKey.length + 1 : 1 + 1) +
 		prefixCells;
-	const availableTitleWidth = Math.max(0, width - fixedWidth);
+	const twoLineIndent = twoLineTitleIndent(
+		emoji ? {emoji, width: emojiCells} : undefined,
+	);
+	const availableTitleWidth = inlineTitle
+		? Math.max(0, width - fixedWidth)
+		: Math.max(0, width - twoLineIndent);
 
 	// Truncate title (pending rows use their own title text)
 	// Show "Loading…" while the Linear issue title is being fetched
@@ -150,7 +185,7 @@ export default function SpaceListItem({space, isSelected, width}: Props) {
 		(shouldShowLoadingTitle(space) ? 'Loading…' : '');
 	// The crux of STA-1565. A bare-BMP default-emoji symbol (✨ ⭐ ✅) is laid
 	// out by Ink one cell narrower than the terminal actually renders it, so the
-	// terminal expands every such glyph by a cell *beyond* Ink's layout — both
+	// terminal expands every such glyph by a cell *beyond* Ink's layout, both
 	// in the prefix and anywhere in the title. Two consequences, both handled
 	// here:
 	//   1. Truncate the title by *display width* (`truncateToWidth`), not UTF-16
@@ -161,26 +196,31 @@ export default function SpaceListItem({space, isSelected, width}: Props) {
 	//      this the rail's flex spacer refills to the full width in Ink's model
 	//      and the terminal expansion pushes the rail icons onto the next line.
 	// The prefix emoji is normalized by `resolveEmojiSlot` (STA-1861), so it no
-	// longer expands past its layout — the slot reports what's left, which is 0
+	// longer expands past its layout, and the slot reports what's left, which is 0
 	// for every glyph a variation selector can rescue. Titles are arbitrary user
 	// text and get no such treatment, so they still expand and still need (2).
 	const prefixInkPad = emojiSlot?.overflowCells ?? 0;
+	// The emoji only shares a line with the title when the title is inline; on a
+	// dedicated title row its expansion can't eat into that row.
+	const titlePrefixInkPad = inlineTitle ? prefixInkPad : 0;
 	let truncatedTitle = truncateToWidth(
 		title,
-		availableTitleWidth - prefixInkPad,
+		availableTitleWidth - titlePrefixInkPad,
 	);
 	const firstTitleInkPad = inkRenderPad(truncatedTitle);
 	if (firstTitleInkPad > 0) {
 		truncatedTitle = truncateToWidth(
 			title,
-			availableTitleWidth - prefixInkPad - firstTitleInkPad,
+			availableTitleWidth - titlePrefixInkPad - firstTitleInkPad,
 		);
 	}
-	const rowInkPad = prefixInkPad + inkRenderPad(truncatedTitle);
-	// Width the row's outer Box is given. Equals `width` when nothing expands
-	// (byte-identical to master), otherwise `width − rowInkPad` so the terminal
-	// expansion fills the row exactly to the pane edge instead of past it.
-	const rowWidth = rowInkPad > 0 ? Math.max(0, width - rowInkPad) : undefined;
+	const titleInkPad = inkRenderPad(truncatedTitle);
+	const rowInkPad = titlePrefixInkPad + titleInkPad;
+	const rowWidth = shrinkBy(width, rowInkPad);
+	// On a shared row the key line carries the whole row's expansion; on its own
+	// row it only carries the prefix emoji's, and the title row carries the rest.
+	const keyLineWidth = inlineTitle ? rowWidth : shrinkBy(width, prefixInkPad);
+	const titleLineWidth = inlineTitle ? undefined : shrinkBy(width, titleInkPad);
 
 	// Issue state color (applied to issue key).
 	// Uses the exact color from the tracker's API so pappardelle always matches,
@@ -201,14 +241,14 @@ export default function SpaceListItem({space, isSelected, width}: Props) {
 	};
 	const stateColor = getStateColor();
 
-	// Determine highlight mode:
-	// - needsAttention + blinkOn: blink color (blue for question, red for approval)
-	// - isSelected (and not blinking): white background via inverse
-	// - needsAttention + isSelected + !blinkOn: white background (blink off-phase)
-	const useBlinkInverse = needsAttention && blinkOn;
-	const useSelectionInverse = isSelected && !useBlinkInverse;
-	const useInverse = useBlinkInverse || useSelectionInverse;
-	const textColor = useBlinkInverse ? (isQuestion ? 'blue' : 'red') : undefined;
+	const {useBlinkInverse, useInverse, textColor, keyColor, titleColor} =
+		resolveRowHighlight({
+			isSelected,
+			needsAttention,
+			blinkOn,
+			isQuestion,
+			stateColor,
+		});
 
 	const renderPipelineIcon = () => {
 		if (!pipeline) return null;
@@ -261,7 +301,8 @@ export default function SpaceListItem({space, isSelected, width}: Props) {
 					{' '}
 				</Text>
 				<Text
-					color={useBlinkInverse ? textColor : 'gray'}
+					color={useBlinkInverse ? textColor : undefined}
+					dimColor={!useBlinkInverse}
 					inverse={useBlinkInverse}
 				>
 					{`(${commentCount})`}
@@ -288,82 +329,99 @@ export default function SpaceListItem({space, isSelected, width}: Props) {
 		);
 	};
 
-	return (
-		<Box width={rowWidth}>
-			{/* Profile emoji (NOT highlighted) — first cell on the row when set.
-			    Followed by a single space separator so it doesn't crash into the
-			    Claude status icon. */}
-			{emoji ? (
-				<>
-					<Text inverse={useBlinkInverse} color={textColor}>
-						{emoji}
-					</Text>
-					{emojiNeedsSeparator ? (
+	const renderTitle = () => (
+		<Text
+			dimColor={!useInverse}
+			wrap="truncate"
+			inverse={useInverse}
+			color={titleColor}
+		>
+			{truncatedTitle}
+		</Text>
+	);
+
+	const keyLine = (
+		<Box width={keyLineWidth} overflowX="hidden">
+			{/* Identity cluster: emoji, status icon and issue key. `flexShrink={0}`
+			    is load-bearing — `width` is the pane width pappardelle *believes*
+			    it has, and when that overshoots the pane Ink actually renders into,
+			    Yoga's default shrink squeezes every cell here at once: the status
+			    icon disappears, the separators collapse and the issue key is chopped
+			    mid-string with the remainder spilling onto extra lines. Refusing to
+			    shrink keeps the row's identity intact and pushes all give onto the
+			    title, which is the one part that can truncate meaningfully. */}
+			<Box flexShrink={0}>
+				{/* Profile emoji (NOT highlighted) — first cell on the row when set.
+				    Followed by a single space separator so it doesn't crash into the
+				    Claude status icon. */}
+				{emoji ? (
+					<>
 						<Text inverse={useBlinkInverse} color={textColor}>
-							{' '}
+							{emoji}
 						</Text>
-					) : null}
-				</>
-			) : null}
-			{/* Status icon (NOT highlighted, always shows its own color) */}
-			{isWorking ? (
-				<ClaudeAnimation
-					color={
-						useBlinkInverse
-							? textColor
-							: space.isPending
-								? COLORS.CLAUDE_ORANGE
-								: statusInfo.color
-					}
-					inverse={useBlinkInverse}
-				/>
-			) : (
-				<Text
-					color={useBlinkInverse ? textColor : statusInfo.color}
-					inverse={useBlinkInverse}
-				>
-					{statusInfo.icon ?? '?'}
-				</Text>
-			)}
-
-			{/* Space after status icon (NOT highlighted) */}
-			<Text inverse={useBlinkInverse} color={textColor}>
-				{' '}
-			</Text>
-
-			{/* Issue key badge (colored by Linear state, highlighted when selected) */}
-			{hasIssueKey && (
-				<Text
-					color={useBlinkInverse ? textColor : stateColor}
-					bold
-					wrap="truncate"
-					inverse={useInverse}
-				>
-					{issueKey}
-				</Text>
-			)}
-
-			{/* Space + title (only if there's a title to show) */}
-			{truncatedTitle.length > 0 && (
-				<>
-					{hasIssueKey && (
-						<Text
-							dimColor={!useInverse}
-							inverse={useInverse}
-							color={useSelectionInverse ? stateColor : textColor}
-						>
-							{' '}
-						</Text>
-					)}
+						{emojiNeedsSeparator ? (
+							<Text inverse={useBlinkInverse} color={textColor}>
+								{' '}
+							</Text>
+						) : null}
+					</>
+				) : null}
+				{/* Status icon (NOT highlighted, always shows its own color) */}
+				{isWorking ? (
+					<ClaudeAnimation
+						color={
+							useBlinkInverse
+								? textColor
+								: space.isPending
+									? COLORS.CLAUDE_ORANGE
+									: statusInfo.color
+						}
+						inverse={useBlinkInverse}
+					/>
+				) : (
 					<Text
-						dimColor={!useInverse}
+						color={useBlinkInverse ? textColor : statusInfo.color}
+						dimColor={!useBlinkInverse && (statusInfo.dim ?? false)}
+						inverse={useBlinkInverse}
+					>
+						{statusInfo.icon ?? '?'}
+					</Text>
+				)}
+
+				{/* Space after status icon (NOT highlighted) */}
+				<Text inverse={useBlinkInverse} color={textColor}>
+					{' '}
+				</Text>
+
+				{/* Issue key badge (colored by Linear state, highlighted when selected) */}
+				{hasIssueKey && (
+					<Text
+						color={useBlinkInverse ? textColor : keyColor}
+						bold
 						wrap="truncate"
 						inverse={useInverse}
-						color={useSelectionInverse ? stateColor : textColor}
 					>
-						{truncatedTitle}
+						{issueKey}
 					</Text>
-				</>
+				)}
+
+				{/* Separator between key and title. Sits in the fixed cluster rather
+				    than the title box so an overflowing row can't squeeze it away and
+				    weld the title onto the issue key. Only when the title shares this
+				    row — the two-line layout indents its title line instead. */}
+				{hasIssueKey && inlineTitle && truncatedTitle.length > 0 && (
+					<Text dimColor={!useInverse} inverse={useInverse} color={titleColor}>
+						{' '}
+					</Text>
+				)}
+			</Box>
+
+			{/* Title (only if there's a title to show, and only when the title
+			    shares this row — two-line layout renders it below) */}
+			{inlineTitle && truncatedTitle.length > 0 && (
+				<Box flexShrink={1} minWidth={0}>
+					{renderTitle()}
+				</Box>
 			)}
 
 			{/* Rail icons — right-aligned: unresolved comment count, then the
@@ -371,12 +429,35 @@ export default function SpaceListItem({space, isSelected, width}: Props) {
 			    right. Pushed right by a flex spacer that consumes whatever
 			    leftover width remains. */}
 			{pipeline !== null || commentCount > 0 || hasConflict ? (
-				<Box flexGrow={1} justifyContent="flex-end">
+				<Box flexGrow={1} flexShrink={0} justifyContent="flex-end">
 					{renderCommentCount()}
 					{renderConflictIcon()}
 					{renderPipelineIcon()}
 				</Box>
 			) : null}
+		</Box>
+	);
+
+	if (!isTwoLine) return keyLine;
+
+	// The second line is the title's, indented under the key. A pending row put
+	// its title on the key line already, so its second line is blank padding —
+	// still emitted, because every row has to be the same height.
+	return (
+		<Box flexDirection="column">
+			{keyLine}
+			<Box width={titleLineWidth} overflowX="hidden">
+				<Box flexShrink={0}>
+					<Text inverse={useBlinkInverse} color={textColor}>
+						{' '.repeat(twoLineIndent)}
+					</Text>
+				</Box>
+				{!inlineTitle && (
+					<Box flexShrink={1} minWidth={0}>
+						{renderTitle()}
+					</Box>
+				)}
+			</Box>
 		</Box>
 	);
 }

--- a/source/components/TextInput.tsx
+++ b/source/components/TextInput.tsx
@@ -137,13 +137,14 @@ export default function TextInput({
 				return;
 			}
 
-			// Cursor-only operations skip when cursor is hidden, matching the
-			// previous behavior where arrow keys were no-ops without a cursor.
-			const cursorMoved = result.cursorOffset !== cursorOffset;
-			const valueChanged = result.value !== originalValue;
-			if (cursorMoved && !valueChanged && !isShowingCursor) {
+			// The cursor is the field's claim on the keyboard. Hidden, the caret has
+			// moved to a sibling list and every edit belongs to that list instead —
+			// only Enter, handled above, still reaches the field.
+			if (!isShowingCursor) {
 				return;
 			}
+
+			const valueChanged = result.value !== originalValue;
 
 			setCursorOffset(result.cursorOffset);
 			if (valueChanged) {

--- a/source/components/ready-picker.test.ts
+++ b/source/components/ready-picker.test.ts
@@ -1,0 +1,105 @@
+import test from 'ava';
+import {
+	INPUT_INDEX,
+	moveSelection,
+	resolveSubmission,
+	selectionAfterRemoval,
+	visibleWindow,
+} from './ready-picker.ts';
+
+// moveSelection
+
+test('down from the input enters the list at the first row', t => {
+	t.is(moveSelection(INPUT_INDEX, 3, 'down'), 0);
+});
+
+test('down walks the list', t => {
+	t.is(moveSelection(0, 3, 'down'), 1);
+	t.is(moveSelection(1, 3, 'down'), 2);
+});
+
+test('down stops at the last row rather than wrapping', t => {
+	t.is(moveSelection(2, 3, 'down'), 2);
+});
+
+test('up from the first row returns to the input', t => {
+	t.is(moveSelection(0, 3, 'up'), INPUT_INDEX);
+});
+
+test('up stops at the input rather than wrapping to the last row', t => {
+	t.is(moveSelection(INPUT_INDEX, 3, 'up'), INPUT_INDEX);
+});
+
+test('an empty list pins the cursor to the input', t => {
+	t.is(moveSelection(INPUT_INDEX, 0, 'down'), INPUT_INDEX);
+	t.is(moveSelection(INPUT_INDEX, 0, 'up'), INPUT_INDEX);
+});
+
+// resolveSubmission
+
+test('a highlighted suggestion wins over typed text', t => {
+	t.is(
+		resolveSubmission('dark mode', ['pappardelle-a1', 'pappardelle-b2'], 1),
+		'pappardelle-b2',
+	);
+});
+
+test('typed text is submitted when the cursor is in the input', t => {
+	t.is(
+		resolveSubmission('add dark mode', ['pappardelle-a1'], INPUT_INDEX),
+		'add dark mode',
+	);
+});
+
+test('typed text is trimmed', t => {
+	t.is(resolveSubmission('  STA-123  ', [], INPUT_INDEX), 'STA-123');
+});
+
+test('an empty input submits nothing', t => {
+	t.is(resolveSubmission('', [], INPUT_INDEX), null);
+	t.is(resolveSubmission('   ', [], INPUT_INDEX), null);
+});
+
+test('a selection past the end of the list submits nothing', t => {
+	t.is(resolveSubmission('typed', ['pappardelle-a1'], 5), null);
+});
+
+// selectionAfterRemoval
+
+test('the cursor holds its row so the next issue slides under it', t => {
+	t.is(selectionAfterRemoval(1, 4), 1);
+});
+
+test('removing the last row steps the cursor back', t => {
+	t.is(selectionAfterRemoval(4, 4), 3);
+});
+
+test('emptying the list returns the cursor to the input', t => {
+	t.is(selectionAfterRemoval(0, 0), INPUT_INDEX);
+});
+
+test('a cursor already in the input stays there', t => {
+	t.is(selectionAfterRemoval(INPUT_INDEX, 3), INPUT_INDEX);
+});
+
+// visibleWindow
+
+test('a list shorter than the window renders whole', t => {
+	t.deepEqual(visibleWindow(INPUT_INDEX, 3, 8), {start: 0, end: 3});
+});
+
+test('a cursor in the input shows the head of a long list', t => {
+	t.deepEqual(visibleWindow(INPUT_INDEX, 20, 8), {start: 0, end: 8});
+});
+
+test('the window scrolls to keep the selection centered', t => {
+	t.deepEqual(visibleWindow(10, 20, 8), {start: 6, end: 14});
+});
+
+test('the window clamps at the end of the list', t => {
+	t.deepEqual(visibleWindow(19, 20, 8), {start: 12, end: 20});
+});
+
+test('the window never starts before the first row', t => {
+	t.deepEqual(visibleWindow(1, 20, 8), {start: 0, end: 8});
+});

--- a/source/components/ready-picker.ts
+++ b/source/components/ready-picker.ts
@@ -1,0 +1,114 @@
+/**
+ * Selection logic for the ready-work picker shown under the new-session
+ * prompt. Kept free of React so the keymap can be unit-tested directly.
+ *
+ * The text input and the list share one selection cursor: INPUT_INDEX means
+ * the caret is in the text field, and 0..count-1 point at a suggestion. That
+ * union is what lets the input stay focused the whole time — arrow keys are
+ * a no-op inside the field (handleTextInputKey ignores them), so the dialog
+ * can claim them for list movement without stealing typing.
+ */
+
+export const INPUT_INDEX = -1;
+
+/**
+ * Move the shared cursor by one row. Deliberately does not wrap: the list is
+ * anchored below a text field, so wrapping from the last suggestion back to
+ * the input reads as a glitch rather than a shortcut.
+ */
+export function moveSelection(
+	current: number,
+	count: number,
+	direction: 'up' | 'down',
+): number {
+	if (count <= 0) return INPUT_INDEX;
+
+	const next = direction === 'down' ? current + 1 : current - 1;
+	if (next < INPUT_INDEX) return INPUT_INDEX;
+	if (next > count - 1) return count - 1;
+	return next;
+}
+
+/**
+ * What Enter should submit. A highlighted suggestion wins over whatever is in
+ * the text field, so a user who typed a few characters and then arrowed into
+ * the list gets the issue they are looking at.
+ *
+ * Returns null when there is nothing to submit — an empty field with no
+ * selection — and the caller should ignore the keypress.
+ */
+export function resolveSubmission(
+	typed: string,
+	identifiers: readonly string[],
+	selectedIndex: number,
+): string | null {
+	if (selectedIndex >= 0) {
+		return identifiers[selectedIndex] ?? null;
+	}
+
+	const trimmed = typed.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Whether the cursor is on a suggestion rather than in the text field.
+ *
+ * Highlighting a suggestion moves the caret out of the field, and the field goes
+ * inert while it is gone, so letters over the list are unambiguously commands:
+ * typing a task that starts with one of them ("xcode crash on launch", "index
+ * rebuild times out") means first returning to the field with ↑.
+ */
+export function hasHighlightedRow(selectedIndex: number): boolean {
+	return selectedIndex >= 0;
+}
+
+/**
+ * Whether the close keybinding is live. Additionally gated on the tracker being
+ * able to close at all, which is not universal — unlike the open key, which
+ * every tracker can serve one way or another.
+ */
+export function canCloseHighlightedRow(
+	canClose: boolean,
+	selectedIndex: number,
+): boolean {
+	return canClose && hasHighlightedRow(selectedIndex);
+}
+
+/**
+ * Where the cursor lands after the highlighted row is removed from the list.
+ * Staying on the same index keeps the user over the next piece of work, which
+ * is what triage wants: closing three stale beads in a row costs three
+ * close-and-confirm rounds, with no re-navigation between them.
+ *
+ * `removedIndex` is the row that went away and `remaining` the new count.
+ */
+export function selectionAfterRemoval(
+	removedIndex: number,
+	remaining: number,
+): number {
+	if (remaining <= 0) return INPUT_INDEX;
+	if (removedIndex < 0) return INPUT_INDEX;
+	return Math.min(removedIndex, remaining - 1);
+}
+
+/**
+ * Which slice of the suggestions to render so the highlighted row stays on
+ * screen. The dialog floats over the space list, so an unbounded list would
+ * push the prompt off the top of short terminals.
+ */
+export function visibleWindow(
+	selectedIndex: number,
+	count: number,
+	maxVisible: number,
+): {start: number; end: number} {
+	if (count <= maxVisible) return {start: 0, end: count};
+
+	// A cursor in the text field shows the head of the list, not a window
+	// scrolled to wherever the user last was.
+	const anchor = Math.max(0, selectedIndex);
+	const start = Math.min(
+		Math.max(0, anchor - Math.floor(maxVisible / 2)),
+		count - maxVisible,
+	);
+	return {start, end: start + maxVisible};
+}

--- a/source/components/ready-picker.ts
+++ b/source/components/ready-picker.ts
@@ -1,21 +1,5 @@
-/**
- * Selection logic for the ready-work picker shown under the new-session
- * prompt. Kept free of React so the keymap can be unit-tested directly.
- *
- * The text input and the list share one selection cursor: INPUT_INDEX means
- * the caret is in the text field, and 0..count-1 point at a suggestion. That
- * union is what lets the input stay focused the whole time — arrow keys are
- * a no-op inside the field (handleTextInputKey ignores them), so the dialog
- * can claim them for list movement without stealing typing.
- */
-
 export const INPUT_INDEX = -1;
 
-/**
- * Move the shared cursor by one row. Deliberately does not wrap: the list is
- * anchored below a text field, so wrapping from the last suggestion back to
- * the input reads as a glitch rather than a shortcut.
- */
 export function moveSelection(
 	current: number,
 	count: number,
@@ -29,14 +13,6 @@ export function moveSelection(
 	return next;
 }
 
-/**
- * What Enter should submit. A highlighted suggestion wins over whatever is in
- * the text field, so a user who typed a few characters and then arrowed into
- * the list gets the issue they are looking at.
- *
- * Returns null when there is nothing to submit — an empty field with no
- * selection — and the caller should ignore the keypress.
- */
 export function resolveSubmission(
 	typed: string,
 	identifiers: readonly string[],
@@ -50,23 +26,10 @@ export function resolveSubmission(
 	return trimmed.length > 0 ? trimmed : null;
 }
 
-/**
- * Whether the cursor is on a suggestion rather than in the text field.
- *
- * Highlighting a suggestion moves the caret out of the field, and the field goes
- * inert while it is gone, so letters over the list are unambiguously commands:
- * typing a task that starts with one of them ("xcode crash on launch", "index
- * rebuild times out") means first returning to the field with ↑.
- */
 export function hasHighlightedRow(selectedIndex: number): boolean {
 	return selectedIndex >= 0;
 }
 
-/**
- * Whether the close keybinding is live. Additionally gated on the tracker being
- * able to close at all, which is not universal — unlike the open key, which
- * every tracker can serve one way or another.
- */
 export function canCloseHighlightedRow(
 	canClose: boolean,
 	selectedIndex: number,
@@ -74,14 +37,6 @@ export function canCloseHighlightedRow(
 	return canClose && hasHighlightedRow(selectedIndex);
 }
 
-/**
- * Where the cursor lands after the highlighted row is removed from the list.
- * Staying on the same index keeps the user over the next piece of work, which
- * is what triage wants: closing three stale beads in a row costs three
- * close-and-confirm rounds, with no re-navigation between them.
- *
- * `removedIndex` is the row that went away and `remaining` the new count.
- */
 export function selectionAfterRemoval(
 	removedIndex: number,
 	remaining: number,
@@ -91,11 +46,6 @@ export function selectionAfterRemoval(
 	return Math.min(removedIndex, remaining - 1);
 }
 
-/**
- * Which slice of the suggestions to render so the highlighted row stays on
- * screen. The dialog floats over the space list, so an unbounded list would
- * push the prompt off the top of short terminals.
- */
 export function visibleWindow(
 	selectedIndex: number,
 	count: number,

--- a/source/components/ready-work-narrow.test.ts
+++ b/source/components/ready-work-narrow.test.ts
@@ -1,0 +1,78 @@
+import test from 'ava';
+import React from 'react';
+import {Box} from 'ink';
+import {render} from 'ink-testing-library';
+import stringWidth from 'string-width';
+import {ReadyWorkList, type ReadyWork} from './ReadyWork.tsx';
+
+function renderReady(width: number, prefix: string, title: string): string {
+	const issues = Array.from({length: 8}, (_, index) => ({
+		identifier: `${prefix}-abc.${index + 1}`,
+		title,
+		state: {name: 'Open', type: 'unstarted', color: '#00ff00'},
+	}));
+	const ready: ReadyWork = {
+		issues,
+		loading: false,
+		index: 0,
+		identifiers: issues.map(issue => issue.identifier),
+		onRow: true,
+		openKeyActive: true,
+		closeKeyActive: true,
+		errorMessage: null,
+		closeTarget: null,
+		async confirmClose() {},
+		cancelClose() {},
+	};
+	const view = render(
+		React.createElement(
+			Box,
+			{width},
+			React.createElement(ReadyWorkList, {
+				ready,
+				width,
+				isFocused: true,
+				hasHints: false,
+			}),
+		),
+	);
+	const frame = view.lastFrame() ?? '';
+	view.unmount();
+	return frame;
+}
+
+test('eight ready suggestions fit eight rows inside narrow frames', t => {
+	for (const width of [20, 30, 40, 60, 90]) {
+		for (const prefix of ['bd', 'seatgeek-ticket-management-cli']) {
+			for (const title of [
+				'Repair the workspace configuration',
+				'Fix 界面 🍝\nNext line',
+			]) {
+				const frame = renderReady(width, prefix, title);
+				const lines = frame.split('\n');
+				t.is(lines.length, 10, `Rendered frame: ${frame}`);
+				for (const line of lines) {
+					t.is(stringWidth(line), width, `Rendered frame: ${frame}`);
+				}
+				t.true(lines[1]!.includes('❯ '), `Rendered frame: ${frame}`);
+			}
+		}
+	}
+});
+
+test('title budget follows identifier length and preserves full keys when they fit', t => {
+	const short = renderReady(40, 'bd', 'Repair the workspace configuration');
+	t.true(
+		short.includes('bd-abc.1 Repair the workspace'),
+		`Rendered frame: ${short}`,
+	);
+	const long = renderReady(
+		60,
+		'seatgeek-ticket-management-cli',
+		'Repair the workspace configuration',
+	);
+	t.true(
+		long.includes('seatgeek-ticket-management-cli-abc.1 Repair'),
+		`Rendered frame: ${long}`,
+	);
+});

--- a/source/components/row-highlight.test.ts
+++ b/source/components/row-highlight.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression for the two color symptoms in the narrow-sidebar bug: the selected
+ * row was barely distinguishable, and its title vanished on highlight instead
+ * of inverting with the rest of the row.
+ *
+ * Both came from the same line — the selected row painted its key and title
+ * with the tracker's workflow-state color *under* `inverse`, which makes that
+ * color the highlight's background and leaves the text in the terminal's
+ * background color. Contrast then rode entirely on a color pappardelle doesn't
+ * control.
+ */
+import test from 'ava';
+import {resolveRowHighlight} from './row-highlight.ts';
+
+const TEAL = '#26b5ce';
+const NEAR_BACKGROUND = '#0b3b45';
+
+const base = {
+	isSelected: false,
+	needsAttention: false,
+	blinkOn: false,
+	isQuestion: false,
+	stateColor: TEAL,
+};
+
+test('an unselected row keeps the tracker state color on its issue key', t => {
+	const row = resolveRowHighlight(base);
+	t.false(row.useInverse);
+	t.is(row.keyColor, TEAL);
+	t.is(row.titleColor, undefined);
+});
+
+test('a selected row drops the state color so it inverts against the default foreground', t => {
+	for (const stateColor of [TEAL, NEAR_BACKGROUND, 'gray', 'white']) {
+		const row = resolveRowHighlight({...base, isSelected: true, stateColor});
+		t.true(row.useSelectionInverse, `state color ${stateColor}`);
+		t.is(row.keyColor, undefined, `state color ${stateColor}`);
+		t.is(row.titleColor, undefined, `state color ${stateColor}`);
+	}
+});
+
+test('key and title share one color on a selected row (the title cannot vanish alone)', t => {
+	const row = resolveRowHighlight({...base, isSelected: true});
+	t.is(row.keyColor, row.titleColor);
+});
+
+test('a state color near the terminal background can no longer set the highlight', t => {
+	// The failure mode: pre-fix this returned NEAR_BACKGROUND, which inverse
+	// turned into a background indistinguishable from the terminal's own.
+	const row = resolveRowHighlight({
+		...base,
+		isSelected: true,
+		stateColor: NEAR_BACKGROUND,
+	});
+	t.not(row.keyColor, NEAR_BACKGROUND);
+});
+
+test('a bright-black state color never reaches the key, on any row', t => {
+	// Solarized and its descendants map ANSI 8 to the background itself, so an
+	// unselected key painted 'gray' rendered background-on-background and only
+	// appeared once selection inverted it. Falling back to no color puts it in
+	// the terminal's default foreground, which contrasts by construction.
+	for (const stateColor of ['gray', 'grey', 'blackBright']) {
+		t.is(
+			resolveRowHighlight({...base, stateColor}).keyColor,
+			undefined,
+			`unselected, state color ${stateColor}`,
+		);
+		t.is(
+			resolveRowHighlight({...base, needsAttention: true, stateColor}).keyColor,
+			undefined,
+			`attention off-phase, state color ${stateColor}`,
+		);
+	}
+});
+
+test('attention blink still owns the row and outranks selection', t => {
+	const approval = resolveRowHighlight({
+		...base,
+		isSelected: true,
+		needsAttention: true,
+		blinkOn: true,
+	});
+	t.true(approval.useBlinkInverse);
+	t.false(approval.useSelectionInverse);
+	t.is(approval.textColor, 'red');
+	t.is(approval.keyColor, TEAL);
+
+	const question = resolveRowHighlight({
+		...base,
+		needsAttention: true,
+		blinkOn: true,
+		isQuestion: true,
+	});
+	t.is(question.textColor, 'blue');
+});
+
+test('the blink off-phase falls back to the selection highlight', t => {
+	const row = resolveRowHighlight({
+		...base,
+		isSelected: true,
+		needsAttention: true,
+		blinkOn: false,
+	});
+	t.false(row.useBlinkInverse);
+	t.true(row.useSelectionInverse);
+	t.true(row.useInverse);
+	t.is(row.keyColor, undefined);
+});
+
+test('an unselected attention row in its off-phase is not inverted at all', t => {
+	const row = resolveRowHighlight({...base, needsAttention: true});
+	t.false(row.useInverse);
+	t.is(row.textColor, undefined);
+});

--- a/source/components/row-highlight.ts
+++ b/source/components/row-highlight.ts
@@ -36,19 +36,6 @@ export interface RowHighlight {
 	titleColor: string | undefined;
 }
 
-/**
- * State colors that mean "this issue has no color worth showing" rather than
- * naming a real one. They all resolve to ANSI 8, which Solarized — and every
- * palette derived from it — defines as the *background*, so a key painted with
- * one is invisible until selection inverts it.
- *
- * The key falls back to the terminal's default foreground rather than to a dim
- * of it: SGR 2 is a blend toward the background, which on a low-contrast theme
- * lands the row's primary identity around 2:1 against the pane, and Ink drops
- * the key's `bold` when both are set (they share reset code 22). Muted here
- * means "carries no state color", not "drawn faintly" — dimming is left to the
- * title and the rail, which are chrome and can afford to recede.
- */
 const BACKGROUND_RISK_COLORS = new Set(['gray', 'grey', 'blackBright']);
 
 export function resolveRowHighlight(input: RowHighlightInput): RowHighlight {
@@ -62,15 +49,6 @@ export function resolveRowHighlight(input: RowHighlightInput): RowHighlight {
 			: 'red'
 		: undefined;
 
-	// A tracker-supplied state color is the worst possible choice for a selected
-	// row. Inverted, it becomes the highlight's background — and nothing
-	// constrains what the tracker hands us, so a state color near the user's
-	// terminal background paints an invisible highlight, while the gray fallback
-	// the main worktree and untitled spaces fall back to paints a barely-there
-	// one. Leaving the color unset inverts against the terminal's own default
-	// foreground instead, the one pairing guaranteed to contrast on both light
-	// and dark themes. The state color still owns the key on unselected rows,
-	// where it is a foreground and carries its normal meaning.
 	const keyColor =
 		useSelectionInverse || BACKGROUND_RISK_COLORS.has(input.stateColor)
 			? undefined

--- a/source/components/row-highlight.ts
+++ b/source/components/row-highlight.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure color/attribute resolution for a space-list row's highlight state.
+ *
+ * A row can be highlighted two ways, and they mean different things:
+ *   - it needs attention (Claude is blocked on a permission or a question) —
+ *     drawn as a blinking colored block, red for approvals, blue for questions
+ *   - it is the selected row — drawn as a plain inverse block
+ *
+ * Both use the terminal's `inverse` attribute, which swaps foreground and
+ * background. That swap is the whole reason this lives in its own module: under
+ * `inverse` the color you set is the color the row is *painted* with, and the
+ * text is drawn in the terminal's background color.
+ */
+
+export interface RowHighlightInput {
+	isSelected: boolean;
+	/** Claude is waiting on the user (permission request or question). */
+	needsAttention: boolean;
+	/** Current phase of the attention blink. */
+	blinkOn: boolean;
+	/** The attention is an AskUserQuestion rather than a permission request. */
+	isQuestion: boolean;
+	/** Tracker-supplied workflow-state color for the issue key. */
+	stateColor: string;
+}
+
+export interface RowHighlight {
+	useBlinkInverse: boolean;
+	useSelectionInverse: boolean;
+	useInverse: boolean;
+	/** Color for the row's non-highlighted chrome (emoji, status icon, spaces). */
+	textColor: string | undefined;
+	/** Color for the issue key badge. */
+	keyColor: string | undefined;
+	/** Color for the issue title. */
+	titleColor: string | undefined;
+}
+
+/**
+ * State colors that mean "this issue has no color worth showing" rather than
+ * naming a real one. They all resolve to ANSI 8, which Solarized — and every
+ * palette derived from it — defines as the *background*, so a key painted with
+ * one is invisible until selection inverts it.
+ *
+ * The key falls back to the terminal's default foreground rather than to a dim
+ * of it: SGR 2 is a blend toward the background, which on a low-contrast theme
+ * lands the row's primary identity around 2:1 against the pane, and Ink drops
+ * the key's `bold` when both are set (they share reset code 22). Muted here
+ * means "carries no state color", not "drawn faintly" — dimming is left to the
+ * title and the rail, which are chrome and can afford to recede.
+ */
+const BACKGROUND_RISK_COLORS = new Set(['gray', 'grey', 'blackBright']);
+
+export function resolveRowHighlight(input: RowHighlightInput): RowHighlight {
+	const useBlinkInverse = input.needsAttention && input.blinkOn;
+	const useSelectionInverse = input.isSelected && !useBlinkInverse;
+	const useInverse = useBlinkInverse || useSelectionInverse;
+
+	const textColor = useBlinkInverse
+		? input.isQuestion
+			? 'blue'
+			: 'red'
+		: undefined;
+
+	// A tracker-supplied state color is the worst possible choice for a selected
+	// row. Inverted, it becomes the highlight's background — and nothing
+	// constrains what the tracker hands us, so a state color near the user's
+	// terminal background paints an invisible highlight, while the gray fallback
+	// the main worktree and untitled spaces fall back to paints a barely-there
+	// one. Leaving the color unset inverts against the terminal's own default
+	// foreground instead, the one pairing guaranteed to contrast on both light
+	// and dark themes. The state color still owns the key on unselected rows,
+	// where it is a foreground and carries its normal meaning.
+	const keyColor =
+		useSelectionInverse || BACKGROUND_RISK_COLORS.has(input.stateColor)
+			? undefined
+			: input.stateColor;
+	const titleColor = useSelectionInverse ? undefined : textColor;
+
+	return {
+		useBlinkInverse,
+		useSelectionInverse,
+		useInverse,
+		textColor,
+		keyColor,
+		titleColor,
+	};
+}

--- a/source/components/space-list-item-narrow.test.ts
+++ b/source/components/space-list-item-narrow.test.ts
@@ -1,0 +1,85 @@
+import test from 'ava';
+import React from 'react';
+import {Box} from 'ink';
+import {render} from 'ink-testing-library';
+import stringWidth from 'string-width';
+import SpaceListItem from './SpaceListItem.tsx';
+import type {SpaceData} from '../types.ts';
+import type {ListLayout} from '../config.ts';
+
+const ISSUE_KEY = 'pappardelle-akv';
+const TITLE = 'Workspace sidebar rows render no title';
+const space: SpaceData = {
+	name: ISSUE_KEY,
+	worktreePath: null,
+	profileEmoji: '🍝',
+	claudeStatus: 'waiting_for_input',
+	linearIssue: {
+		identifier: ISSUE_KEY,
+		title: TITLE,
+		state: {name: 'Open', type: 'unstarted', color: '#00ff00'},
+	},
+	railStatus: {
+		pipeline: 'passing',
+		unresolvedCommentCount: 3,
+		hasConflict: false,
+	},
+};
+
+function renderRow({
+	laidOutWidth,
+	renderWidth,
+	layout = 'single_line',
+	isSelected = false,
+}: {
+	laidOutWidth: number;
+	renderWidth: number;
+	layout?: ListLayout;
+	isSelected?: boolean;
+}): string {
+	const view = render(
+		React.createElement(
+			Box,
+			{width: renderWidth},
+			React.createElement(SpaceListItem, {
+				space,
+				isSelected,
+				width: laidOutWidth,
+				layout,
+			}),
+		),
+	);
+	const frame = view.lastFrame() ?? '';
+	view.unmount();
+	return frame;
+}
+
+test('the identity and title survive stale pane widths, including selection', t => {
+	for (const isSelected of [false, true]) {
+		for (let laidOutWidth = 40; laidOutWidth <= 120; laidOutWidth += 10) {
+			const row = renderRow({laidOutWidth, renderWidth: 40, isSelected});
+			t.true(row.includes(`🍝 ● ${ISSUE_KEY} `), `Rendered row: ${row}`);
+			t.true(row.includes('Workspace'), `Rendered row: ${row}`);
+			t.is(row.split('\n').length, 1, `Rendered row: ${row}`);
+		}
+	}
+});
+
+test('rows stay within the pane and retain their layout height', t => {
+	for (const layout of ['single_line', 'two_line'] as const) {
+		for (const renderWidth of [16, 20, 24, 30, 40]) {
+			for (const laidOutWidth of [renderWidth, 60, 90, 120]) {
+				const row = renderRow({laidOutWidth, renderWidth, layout});
+				const lines = row.split('\n');
+				t.is(
+					lines.length,
+					layout === 'two_line' ? 2 : 1,
+					`Rendered row: ${row}`,
+				);
+				for (const line of lines) {
+					t.true(stringWidth(line) <= renderWidth, `Rendered row: ${row}`);
+				}
+			}
+		}
+	}
+});

--- a/source/config-merge.test.ts
+++ b/source/config-merge.test.ts
@@ -1369,3 +1369,104 @@ state_colors:
 		cleanup();
 	}
 });
+
+// ============================================================================
+// loadConfigFromPaths — worktree fallback (pappardelle-xbe)
+// ============================================================================
+//
+// `.pappardelle.yml` is excluded rather than committed, so a linked worktree
+// has none and only the main checkout does. `.pappardelle.local.yml` is the
+// reverse: workspace setup copies it into each worktree. Both facts have to
+// hold at once, which is why the two layers resolve per file rather than per
+// directory.
+
+test('loadConfigFromPaths falls back to the main checkout for a missing project config', t => {
+	const {dir, cleanup} = setupTempDir({
+		'main/.pappardelle.yml': `version: 1
+team_prefix: MAIN
+profiles:
+  hive:
+    display_name: Hive
+`,
+		'worktree/.keep': '',
+	});
+	try {
+		const config = loadConfigFromPaths({
+			projectDir: path.join(dir, 'worktree'),
+			fallbackProjectDir: () => path.join(dir, 'main'),
+		});
+		t.is(getTeamPrefix(config), 'MAIN');
+		t.truthy(config.profiles['hive']);
+	} finally {
+		cleanup();
+	}
+});
+
+test("loadConfigFromPaths prefers the worktree's own local override", t => {
+	const {dir, cleanup} = setupTempDir({
+		'main/.pappardelle.yml': `version: 1
+team_prefix: MAIN
+profiles:
+  hive:
+    display_name: Hive
+`,
+		'main/.pappardelle.local.yml': `team_prefix: MAINLOCAL
+`,
+		'worktree/.pappardelle.local.yml': `team_prefix: WTLOCAL
+`,
+	});
+	try {
+		const config = loadConfigFromPaths({
+			projectDir: path.join(dir, 'worktree'),
+			fallbackProjectDir: () => path.join(dir, 'main'),
+		});
+		// Project layer came from the main checkout, local layer from the worktree.
+		t.is(getTeamPrefix(config), 'WTLOCAL');
+		t.truthy(config.profiles['hive']);
+	} finally {
+		cleanup();
+	}
+});
+
+test('loadConfigFromPaths without a fallback behaves exactly as before', t => {
+	const {dir, cleanup} = setupTempDir({
+		'main/.pappardelle.yml': `version: 1
+profiles:
+  hive:
+    display_name: Hive
+`,
+		'worktree/.keep': '',
+	});
+	try {
+		t.throws(
+			() => loadConfigFromPaths({projectDir: path.join(dir, 'worktree')}),
+			{instanceOf: ConfigNotFoundError},
+		);
+	} finally {
+		cleanup();
+	}
+});
+
+test('loadConfigFromPaths never resolves the fallback when the project dir has every layer', t => {
+	const {dir, cleanup} = setupTempDir({
+		'worktree/.pappardelle.yml': `version: 1
+team_prefix: WT
+profiles:
+  hive:
+    display_name: Hive
+`,
+		'worktree/.pappardelle.local.yml': `team_prefix: WTLOCAL
+`,
+	});
+	try {
+		const config = loadConfigFromPaths({
+			projectDir: path.join(dir, 'worktree'),
+			fallbackProjectDir() {
+				throw new Error('fallback resolved');
+			},
+		});
+		t.is(getTeamPrefix(config), 'WTLOCAL');
+	} finally {
+		cleanup();
+	}
+});

--- a/source/config.test.ts
+++ b/source/config.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'ava';
 import type {PappardelleConfig, Profile, KeybindingConfig} from './config.ts';
 import {
@@ -16,6 +19,7 @@ import {
 	getIssueWatchlist,
 	getResolvedWatchlists,
 	getAutoRemoveWhenDone,
+	getListLayout,
 	getCompanionCommand,
 	getStateColors,
 	DEFAULT_COMPANION_COMMAND,
@@ -30,6 +34,11 @@ import {
 	RESERVED_VAR_NAMES,
 	mergeKeybindings,
 	determineProfileForInput,
+	getBeadsPrefixes,
+	readBeadsIssuePrefix,
+	clearBeadsIssuePrefixCache,
+	matchProfilesByKeyPrefix,
+	matchProfilesByInputKeyPrefix,
 	DEFERRED_PROFILE_DISPLAY_NAME,
 } from './config.ts';
 
@@ -188,6 +197,30 @@ test('getProfileEmoji uses default_emoji when profile is undefined', t => {
 		profiles: {test: {keywords: ['test'], display_name: 'Test'}},
 	};
 	t.is(getProfileEmoji(undefined, config), '🍕');
+});
+
+test('validateConfig accepts issue_tracker.provider beads without base_url', t => {
+	// Beads is local — there is no host to configure.
+	const raw = {
+		version: 1,
+		default_profile: 'test',
+		issue_tracker: {provider: 'beads'},
+		profiles: {test: {keywords: ['test'], display_name: 'Test'}},
+	};
+	t.notThrows(() => validateConfig(raw));
+});
+
+test('validateConfig names every supported tracker when one is unknown', t => {
+	const raw = {
+		version: 1,
+		default_profile: 'test',
+		issue_tracker: {provider: 'bugzilla'},
+		profiles: {test: {keywords: ['test'], display_name: 'Test'}},
+	};
+	const error = t.throws(() => validateConfig(raw), {
+		instanceOf: ConfigValidationError,
+	});
+	t.truthy(error?.message.includes('"linear", "jira", or "beads"'));
 });
 
 test('validateConfig rejects non-string default_emoji', t => {
@@ -4206,6 +4239,162 @@ test("getProfileDefaultProject preserves exact casing — UUID resolution is the
 });
 
 // ============================================================================
+// matchProfilesByKeyPrefix
+//
+// Which profiles could plausibly own an issue whose key carries a given
+// prefix. Explicit claims (own team_prefix, or a tracker_projects entry
+// spelling a Jira project key) outrank the profiles that merely inherit the
+// global team_prefix.
+// ============================================================================
+
+test('matchProfilesByKeyPrefix matches a profile own team_prefix', t => {
+	const config = createConfig(
+		{
+			personal: {
+				...createProfile(['personal'], 'Personal'),
+				team_prefix: 'PER',
+			},
+			trotbooks: {
+				...createProfile(['trotbooks'], 'TrotBooks'),
+				team_prefix: 'TRT',
+			},
+		},
+		'personal',
+		'STA',
+	);
+	t.deepEqual(
+		matchProfilesByKeyPrefix(config, 'TRT').map(m => m.name),
+		['trotbooks'],
+	);
+});
+
+test('matchProfilesByKeyPrefix matches case-insensitively', t => {
+	const config = createConfig(
+		{
+			personal: {
+				...createProfile(['personal'], 'Personal'),
+				team_prefix: 'per',
+			},
+		},
+		'personal',
+		'STA',
+	);
+	t.deepEqual(
+		matchProfilesByKeyPrefix(config, 'per').map(m => m.name),
+		['personal'],
+	);
+});
+
+test('matchProfilesByKeyPrefix matches a tracker_projects entry as a project key', t => {
+	const config = createConfig(
+		{
+			personal: {
+				...createProfile(['personal'], 'Personal'),
+				tracker_projects: ['KAN'],
+			},
+			trotbooks: {
+				...createProfile(['trotbooks'], 'TrotBooks'),
+				team_prefix: 'TRT',
+			},
+		},
+		'personal',
+		'STA',
+	);
+	const matches = matchProfilesByKeyPrefix(config, 'KAN');
+	t.deepEqual(
+		matches.map(m => m.name),
+		['personal'],
+	);
+	t.true(matches[0]!.explicit);
+});
+
+test('matchProfilesByKeyPrefix matches an issue_watchlist key_prefixes entry', t => {
+	// The watchlist already spawns these issues under this profile
+	// (idow --profile), so a hand-typed key of the same prefix has to be able to
+	// reach it too.
+	const config = createConfig(
+		{
+			personal: {
+				...createProfile(['personal'], 'Personal'),
+				issue_watchlist: {
+					assignee: 'me',
+					statuses: ['To Do'],
+					key_prefixes: ['SDJ'],
+				},
+			},
+			trotbooks: createProfile(['trotbooks'], 'TrotBooks'),
+		},
+		'trotbooks',
+		'STA',
+	);
+	const matches = matchProfilesByKeyPrefix(config, 'SDJ');
+	t.deepEqual(
+		matches.map(m => m.name),
+		['personal'],
+	);
+	t.true(matches[0]!.explicit);
+});
+
+test('matchProfilesByKeyPrefix treats prefix-less profiles as inheriting the global prefix', t => {
+	const config = createConfig(
+		{
+			personal: createProfile(['personal'], 'Personal'),
+			trotbooks: {
+				...createProfile(['trotbooks'], 'TrotBooks'),
+				team_prefix: 'TRT',
+			},
+		},
+		'personal',
+		'STA',
+	);
+	const matches = matchProfilesByKeyPrefix(config, 'STA');
+	t.deepEqual(
+		matches.map(m => m.name),
+		['personal'],
+	);
+	t.false(matches[0]!.explicit);
+});
+
+test('matchProfilesByKeyPrefix ranks explicit claims ahead of inherited ones', t => {
+	const config = createConfig(
+		{
+			personal: createProfile(['personal'], 'Personal'),
+			trotbooks: {
+				...createProfile(['trotbooks'], 'TrotBooks'),
+				team_prefix: 'STA',
+			},
+		},
+		'personal',
+		'STA',
+	);
+	t.deepEqual(
+		matchProfilesByKeyPrefix(config, 'STA').map(m => m.name),
+		['trotbooks', 'personal'],
+	);
+});
+
+test('matchProfilesByKeyPrefix returns nothing for an unclaimed prefix', t => {
+	const config = createConfig(
+		{personal: createProfile(['personal'], 'Personal')},
+		'personal',
+		'STA',
+	);
+	t.deepEqual(matchProfilesByKeyPrefix(config, 'ZZZ'), []);
+	t.deepEqual(matchProfilesByKeyPrefix(config, '  '), []);
+});
+
+test('matchProfilesByKeyPrefix falls back to the STA default when no team_prefix is set', t => {
+	const config = createConfig(
+		{personal: createProfile(['personal'], 'Personal')},
+		'personal',
+	);
+	t.deepEqual(
+		matchProfilesByKeyPrefix(config, 'STA').map(m => m.name),
+		['personal'],
+	);
+});
+
+// ============================================================================
 // determineProfileForInput (STA-856, STA-865)
 //
 // Single source of truth for "which profile will this input resolve to?",
@@ -4242,6 +4431,278 @@ test('determineProfileForInput defers profile selection for issue keys', t => {
 	if (info!.kind === 'deferred') {
 		t.is(info.displayName, DEFERRED_PROFILE_DISPLAY_NAME);
 	}
+});
+
+test('determineProfileForInput defers profile selection for beads IDs', t => {
+	// Beads IDs match none of the classic patterns, so without this they would
+	// keyword-match and get pinned via --profile before the issue is fetched —
+	// defeating the prefix-based tracker_projects routing idow performs.
+	const config = {
+		...createConfig(
+			{
+				personal: createProfile(['personal'], 'Personal'),
+				dark: createProfile(['dark'], 'Dark Mode Work'),
+			},
+			'personal',
+		),
+		team_prefix: 'pap',
+		issue_tracker: {provider: 'beads' as const},
+	};
+	const info = determineProfileForInput(config, 'pap-a1b2');
+	t.is(info?.kind, 'deferred');
+});
+
+test('determineProfileForInput keyword-matches a beads-shaped phrase', t => {
+	// 'dark-mode' is prose, not an ID — no profile lists 'dark' as a prefix.
+	const config = {
+		...createConfig(
+			{
+				personal: createProfile(['personal'], 'Personal'),
+				dark: createProfile(['dark'], 'Dark Mode Work'),
+			},
+			'personal',
+		),
+		team_prefix: 'pap',
+		issue_tracker: {provider: 'beads' as const},
+	};
+	const info = determineProfileForInput(config, 'dark-mode');
+	t.is(info?.kind, 'resolved');
+});
+
+test('determineProfileForInput marks a beads ID pickable even when nothing claims its prefix', t => {
+	// A beads database is not a project: one prefix backs work belonging to
+	// several profiles, so the tracker-project lookup can only ever guess and
+	// the caller has to offer the choice. Every profile here names a prefix of
+	// its own, so nobody claims 'pap' by inheritance either.
+	const config = {
+		...createConfig(
+			{
+				personal: {
+					...createProfile(['personal'], 'Personal'),
+					team_prefix: 'STA',
+				},
+				dark: {
+					...createProfile(['dark'], 'Dark Mode Work'),
+					team_prefix: 'SDJ',
+				},
+			},
+			'personal',
+		),
+		team_prefix: 'pap',
+		issue_tracker: {provider: 'beads' as const},
+	};
+	t.deepEqual(matchProfilesByInputKeyPrefix(config, 'pap-a1b2'), []);
+	const info = determineProfileForInput(config, 'pap-a1b2');
+	t.is(info!.kind, 'deferred');
+	if (info!.kind === 'deferred') t.true(info.canPick);
+});
+
+test('matchProfilesByInputKeyPrefix reads the prefix of a beads ID', t => {
+	// The prefix of 'vendor-sdk-a1b2' is everything ahead of the last hyphen,
+	// which is the name a profile spells in tracker_projects.
+	const config = {
+		...createConfig(
+			{
+				personal: createProfile(['personal'], 'Personal'),
+				vendor: {
+					...createProfile(['vendor'], 'Vendor SDK'),
+					tracker_projects: ['vendor-sdk'],
+				},
+			},
+			'personal',
+		),
+		team_prefix: 'STA',
+		issue_tracker: {provider: 'beads' as const},
+	};
+	t.deepEqual(
+		matchProfilesByInputKeyPrefix(config, 'vendor-sdk-a1b2').map(m => m.name),
+		['vendor'],
+	);
+});
+
+test('determineProfileForInput does not defer beads IDs under other trackers', t => {
+	// Regression pin: the beads branch must be gated on the configured provider.
+	const config = {
+		...createConfig(
+			{personal: createProfile(['personal'], 'Personal')},
+			'personal',
+		),
+		team_prefix: 'pap',
+	};
+	t.is(determineProfileForInput(config, 'pap-a1b2')?.kind, 'resolved');
+});
+
+// ============================================================================
+// getBeadsPrefixes
+// ============================================================================
+
+test('getBeadsPrefixes collects the team prefix and tracker_projects', t => {
+	const config: PappardelleConfig = {
+		version: 1,
+		team_prefix: 'pap',
+		profiles: {
+			platform: {
+				display_name: 'Platform',
+				tracker_projects: ['myproj', 'vendor-sdk'],
+			},
+			other: {display_name: 'Other', team_prefix: 'alt'},
+		},
+	};
+	t.deepEqual(getBeadsPrefixes(config).sort(), [
+		'alt',
+		'myproj',
+		'pap',
+		'vendor-sdk',
+	]);
+});
+
+test('getBeadsPrefixes lowercases and dedupes', t => {
+	const config: PappardelleConfig = {
+		version: 1,
+		team_prefix: 'PAP',
+		profiles: {a: {display_name: 'A', tracker_projects: ['pap', ' Pap ']}},
+	};
+	t.deepEqual(getBeadsPrefixes(config), ['pap']);
+});
+
+test('getBeadsPrefixes is empty when nothing is configured', t => {
+	t.deepEqual(getBeadsPrefixes({version: 1, profiles: {}}), []);
+});
+
+test('getBeadsPrefixes includes the database issue-prefix', t => {
+	// bd mints IDs under .beads/config.yaml's issue-prefix, which need not match
+	// team_prefix — a repo migrating off Linear keeps the old team prefix while
+	// beads names issues after the repo directory. Missing it made those IDs read
+	// as prose and file a duplicate issue.
+	t.deepEqual(
+		getBeadsPrefixes({version: 1, profiles: {}, team_prefix: 'STA'}, 'myrepo'),
+		['myrepo', 'sta'],
+	);
+});
+
+test('getBeadsPrefixes lowercases and dedupes the database issue-prefix', t => {
+	t.deepEqual(
+		getBeadsPrefixes({version: 1, profiles: {}, team_prefix: 'pap'}, 'PAP'),
+		['pap'],
+	);
+});
+
+test('readBeadsIssuePrefix reads issue-prefix from .beads/config.yaml', t => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'beads-prefix-'));
+	fs.mkdirSync(path.join(dir, '.beads'));
+	fs.writeFileSync(
+		path.join(dir, '.beads', 'config.yaml'),
+		'issue-prefix: vendor-sdk\n',
+	);
+	t.is(readBeadsIssuePrefix(dir), 'vendor-sdk');
+});
+
+test('readBeadsIssuePrefix is undefined when the file or key is absent', t => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'beads-prefix-'));
+	t.is(readBeadsIssuePrefix(dir), undefined);
+
+	fs.mkdirSync(path.join(dir, '.beads'));
+	fs.writeFileSync(path.join(dir, '.beads', 'config.yaml'), 'other: value\n');
+	clearBeadsIssuePrefixCache();
+	t.is(readBeadsIssuePrefix(dir), undefined);
+});
+
+// determineProfileForInput runs on every keystroke in the new-session prompt,
+// so this has to stay a cache hit — an uncached read puts a blocking
+// readFileSync and a YAML parse on the TUI's render path per character.
+test('readBeadsIssuePrefix parses .beads/config.yaml at most once per root', t => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'beads-prefix-'));
+	fs.mkdirSync(path.join(dir, '.beads'));
+	const configPath = path.join(dir, '.beads', 'config.yaml');
+	fs.writeFileSync(configPath, 'issue-prefix: first\n');
+
+	clearBeadsIssuePrefixCache();
+	t.is(readBeadsIssuePrefix(dir), 'first');
+
+	// Rewriting on disk must not be observable: a second call that re-reads
+	// would return 'second' and fail here.
+	fs.writeFileSync(configPath, 'issue-prefix: second\n');
+	t.is(readBeadsIssuePrefix(dir), 'first');
+
+	// The cache is keyed per root, so a different repo still resolves on its own.
+	const other = fs.mkdtempSync(path.join(os.tmpdir(), 'beads-prefix-'));
+	fs.mkdirSync(path.join(other, '.beads'));
+	fs.writeFileSync(
+		path.join(other, '.beads', 'config.yaml'),
+		'issue-prefix: elsewhere\n',
+	);
+	t.is(readBeadsIssuePrefix(other), 'elsewhere');
+	t.is(readBeadsIssuePrefix(dir), 'first');
+});
+
+// A repo with no beads config is the case that would otherwise re-stat a
+// missing file on every keystroke, so the negative result has to cache too.
+test('readBeadsIssuePrefix caches a missing .beads/config.yaml', t => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'beads-prefix-'));
+
+	clearBeadsIssuePrefixCache();
+	t.is(readBeadsIssuePrefix(dir), undefined);
+
+	fs.mkdirSync(path.join(dir, '.beads'));
+	fs.writeFileSync(
+		path.join(dir, '.beads', 'config.yaml'),
+		'issue-prefix: x\n',
+	);
+	t.is(readBeadsIssuePrefix(dir), undefined);
+});
+
+test('determineProfileForInput defers a lowercase issue key like an uppercase one', t => {
+	// A lowercase key reaches the tracker as the same issue, so it has to reach
+	// the same profile decision — otherwise the preview and the option list the
+	// picker renders disagree about what Enter is going to do.
+	const config = createConfig(
+		{personal: createProfile(['personal'], 'Personal')},
+		'personal',
+	);
+	t.is(determineProfileForInput(config, 'sta-123')!.kind, 'deferred');
+	t.is(
+		determineProfileForInput(
+			config,
+			'https://linear.app/acme/issue/sta-123/slug',
+		)!.kind,
+		'deferred',
+	);
+});
+
+test('determineProfileForInput marks a claimed key prefix as pickable', t => {
+	// Neither profile names a prefix, so both inherit the global one and both
+	// could own STA-123 — the caller should offer the choice rather than an
+	// inert label.
+	const config = createConfig(
+		{
+			personal: createProfile(['personal'], 'Personal'),
+			trotbooks: createProfile(['trotbooks'], 'TrotBooks'),
+		},
+		'personal',
+	);
+	const info = determineProfileForInput(config, 'STA-123');
+	t.is(info!.kind, 'deferred');
+	if (info!.kind === 'deferred') t.true(info.canPick);
+});
+
+test('determineProfileForInput leaves an unclaimed key prefix unpickable', t => {
+	const config = createConfig(
+		{personal: createProfile(['personal'], 'Personal')},
+		'personal',
+	);
+	const info = determineProfileForInput(config, 'ZZZ-123');
+	t.is(info!.kind, 'deferred');
+	if (info!.kind === 'deferred') t.false(info.canPick);
+});
+
+test('determineProfileForInput leaves a bare number unpickable', t => {
+	const config = createConfig(
+		{personal: createProfile(['personal'], 'Personal')},
+		'personal',
+	);
+	const info = determineProfileForInput(config, '42');
+	t.is(info!.kind, 'deferred');
+	if (info!.kind === 'deferred') t.false(info.canPick);
 });
 
 test('determineProfileForInput defers profile selection for bare issue numbers', t => {
@@ -4571,4 +5032,79 @@ test('getStateColors returns the configured map', t => {
 	);
 	config.state_colors = {'In Review': 'cyan'};
 	t.deepEqual(getStateColors(config), {'In Review': 'cyan'});
+});
+
+// getListLayout — the layout defaults per tracker (beads keys are wide enough
+// to crowd a shared row) but an explicit list_view.layout always wins.
+
+const listLayoutConfig = (
+	provider?: 'linear' | 'jira' | 'beads',
+	layout?: 'single_line' | 'two_line',
+) => {
+	const config = createConfig({test: createProfile(['test'], 'Test')});
+	if (provider) config.issue_tracker = {provider};
+	if (layout) config.list_view = {layout};
+	return config;
+};
+
+test('only beads defaults to two_line', t => {
+	t.is(getListLayout(listLayoutConfig('beads')), 'two_line');
+	t.is(getListLayout(listLayoutConfig('linear')), 'single_line');
+	t.is(getListLayout(listLayoutConfig('jira')), 'single_line');
+	t.is(getListLayout(listLayoutConfig()), 'single_line');
+	t.is(getListLayout(null), 'single_line');
+});
+
+test('an explicit list_view.layout overrides the tracker default either way', t => {
+	t.is(getListLayout(listLayoutConfig('beads', 'single_line')), 'single_line');
+	t.is(getListLayout(listLayoutConfig('linear', 'two_line')), 'two_line');
+});
+
+test('an empty list_view block leaves the tracker default standing', t => {
+	const config = createConfig({test: createProfile(['test'], 'Test')});
+	config.issue_tracker = {provider: 'beads'};
+	config.list_view = {};
+	t.is(getListLayout(config), 'two_line');
+});
+
+test('validateConfig accepts both list_view layouts', t => {
+	for (const layout of ['single_line', 'two_line']) {
+		t.notThrows(() =>
+			validateConfig({
+				version: 1,
+				profiles: {test: {display_name: 'Test'}},
+				list_view: {layout},
+			}),
+		);
+	}
+});
+
+test('validateConfig rejects an unknown list_view layout', t => {
+	const error = t.throws(
+		() =>
+			validateConfig({
+				version: 1,
+				profiles: {test: {display_name: 'Test'}},
+				list_view: {layout: 'three_line'},
+			}),
+		{instanceOf: ConfigValidationError},
+	);
+	t.truthy(
+		error?.message.includes(
+			'list_view.layout: must be "single_line" or "two_line"',
+		),
+	);
+});
+
+test('validateConfig rejects a non-object list_view', t => {
+	const error = t.throws(
+		() =>
+			validateConfig({
+				version: 1,
+				profiles: {test: {display_name: 'Test'}},
+				list_view: 'two_line',
+			}),
+		{instanceOf: ConfigValidationError},
+	);
+	t.truthy(error?.message.includes('list_view: must be an object'));
 });

--- a/source/config.ts
+++ b/source/config.ts
@@ -10,6 +10,12 @@ import {
 	isValidStateColor,
 	normalizeStateName,
 } from './state-color-override.ts';
+import {
+	isBeadsIssueKey,
+	issueKeyPrefix,
+	issueKeyTeamPrefix,
+} from './issue-utils.ts';
+import type {TrackerProviderName, VcsProviderName} from './providers/types.ts';
 
 // ============================================================================
 // Types
@@ -49,8 +55,8 @@ export interface ClaudeConfig {
 	/**
 	 * Model to launch Claude with, forwarded verbatim to `claude --model`.
 	 * Accepts an alias ("opus", "sonnet", "fable") or a full model id
-	 * ("claude-opus-5[1m]") — deliberately unvalidated beyond "is a string",
-	 * since the set of valid names changes faster than this config schema.
+	 * ("claude-opus-5[1m]"). Unvalidated beyond "is a string", since the set of
+	 * valid names changes faster than this config schema.
 	 *
 	 * Absent ⇒ no `--model` flag is passed at all and Claude picks its own
 	 * default. Settable top-level and per-profile; see `getClaudeModel`.
@@ -59,7 +65,7 @@ export interface ClaudeConfig {
 	/**
 	 * Reasoning effort to launch Claude with, forwarded verbatim to
 	 * `claude --effort` (low, medium, high, xhigh, max at time of writing).
-	 * Unvalidated for the same reason as `model` — new levels ship on Claude
+	 * Unvalidated for the same reason as `model`: new levels ship on Claude
 	 * Code's schedule, not ours.
 	 *
 	 * Absent ⇒ no `--effort` flag is passed at all.
@@ -84,12 +90,12 @@ export interface VcsConfig {
 }
 
 export interface IssueTrackerConfig {
-	provider: 'linear' | 'jira';
+	provider: TrackerProviderName;
 	base_url?: string; // Required for jira
 }
 
 export interface VcsHostConfig {
-	provider: 'github' | 'gitlab';
+	provider: VcsProviderName;
 	host?: string; // For self-hosted GitLab
 }
 
@@ -110,6 +116,13 @@ export interface IssueWatchlistConfig {
 
 export interface TerminalConfig {
 	app?: string; // Default: "iTerm"
+}
+
+/** How each space is drawn in the TUI list. */
+export type ListLayout = 'single_line' | 'two_line';
+
+export interface ListViewConfig {
+	layout?: ListLayout;
 }
 
 export interface Profile {
@@ -225,6 +238,8 @@ export interface PappardelleConfig {
 	/** Commands to run before workspace deletion. If any fails, deletion is aborted. */
 	pre_workspace_deinit?: CommandConfig[];
 	terminal?: TerminalConfig;
+	/** How each space is drawn in the TUI list. Defaults per tracker. */
+	list_view?: ListViewConfig;
 	hooks?: HooksConfig;
 	keybindings?: KeybindingConfig[];
 	profiles: Record<string, Profile>;
@@ -323,17 +338,73 @@ export class ConfigValidationError extends Error {
 // ============================================================================
 
 /**
- * Get the git repository root directory
+ * Get the root of the working tree we are standing in. Inside a linked
+ * worktree that is the worktree itself, not the main checkout — use
+ * `getMainRepoRoot` when you specifically need the latter.
  */
+let repoRootCache: string | undefined;
+
 export function getRepoRoot(): string {
+	if (repoRootCache !== undefined) return repoRootCache;
+
 	try {
-		return execSync('git rev-parse --show-toplevel', {
+		repoRootCache = execSync('git rev-parse --show-toplevel', {
 			encoding: 'utf-8',
 			stdio: ['pipe', 'pipe', 'pipe'],
 		}).trim();
+		return repoRootCache;
 	} catch {
 		throw new Error('Not in a git repository');
 	}
+}
+
+let mainRepoRootCache: string | undefined;
+
+export function getMainRepoRoot(): string {
+	if (mainRepoRootCache !== undefined) return mainRepoRootCache;
+	mainRepoRootCache = resolveMainRepoRoot();
+	return mainRepoRootCache;
+}
+
+function resolveMainRepoRoot(): string {
+	try {
+		const commonDir = execSync(
+			'git rev-parse --path-format=absolute --git-common-dir',
+			{encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe']},
+		).trim();
+		if (commonDir) return path.dirname(commonDir.replace(/\/+$/, ''));
+	} catch {
+		// Fall through to the worktree root
+	}
+
+	return getRepoRoot();
+}
+
+/**
+ * Locate a repo-level config file, resolving through linked worktrees.
+ *
+ * `.pappardelle.yml` is routinely listed in `.git/info/exclude` rather than
+ * committed, so a linked worktree never receives a copy and only the main
+ * checkout has one. `.pappardelle.local.yml` is the opposite: workspace setup
+ * copies it *into* each worktree, so the worktree's own copy is the one that
+ * should win. Resolving per file rather than per directory is what lets both
+ * be true at once.
+ *
+ * The working tree is checked first so the main checkout — where the two
+ * directories coincide — never pays for the extra lookup. That only holds if
+ * the second root is resolved lazily; an array literal of both would fork git
+ * for the main root before the first candidate is ever tested.
+ *
+ * Mirrors `find_repo_config` in hooks/tracker_config.py.
+ */
+export function findRepoConfig(filename: string): string | undefined {
+	const inWorkingTree = path.join(getRepoRoot(), filename);
+	if (fs.existsSync(inWorkingTree)) return inWorkingTree;
+
+	const inMainCheckout = path.join(getMainRepoRoot(), filename);
+	if (fs.existsSync(inMainCheckout)) return inMainCheckout;
+
+	return undefined;
 }
 
 /**
@@ -501,8 +572,31 @@ export function getDefaultHomeConfigDir(): string {
 export function loadConfigFromPaths(opts: {
 	homeConfigDir?: string;
 	projectDir?: string;
+	/**
+	 * Second directory to consult per file when `projectDir` lacks it — the
+	 * main checkout, when `projectDir` is a linked worktree. Each layer is
+	 * resolved independently; see `findRepoConfig` for why. Passed as a thunk
+	 * so the main checkout, where both directories coincide and every file is
+	 * found on the first candidate, never forks git to resolve the second.
+	 */
+	fallbackProjectDir?: () => string | undefined;
 }): PappardelleConfig {
-	const {homeConfigDir, projectDir} = opts;
+	const {homeConfigDir, projectDir, fallbackProjectDir} = opts;
+
+	const resolveProjectFile = (filename: string): string | undefined => {
+		if (projectDir) {
+			const candidate = path.join(projectDir, filename);
+			if (fs.existsSync(candidate)) return candidate;
+		}
+
+		const fallbackDir = fallbackProjectDir?.();
+		if (fallbackDir) {
+			const candidate = path.join(fallbackDir, filename);
+			if (fs.existsSync(candidate)) return candidate;
+		}
+
+		return undefined;
+	};
 
 	// Load each layer if its file exists
 	let home: Record<string, unknown> | null = null;
@@ -527,33 +621,31 @@ export function loadConfigFromPaths(opts: {
 		}
 	}
 
-	if (projectDir) {
-		const projectPath = path.join(projectDir, '.pappardelle.yml');
-		if (fs.existsSync(projectPath)) {
-			try {
-				const content = fs.readFileSync(projectPath, 'utf-8');
-				const parsed = YAML.load(content);
-				if (parsed && typeof parsed === 'object') {
-					project = parsed as Record<string, unknown>;
-				}
-			} catch (error) {
-				const msg = error instanceof Error ? error.message : String(error);
-				throw new ConfigValidationError([`.pappardelle.yml: ${msg}`]);
+	const projectPath = resolveProjectFile('.pappardelle.yml');
+	if (projectPath) {
+		try {
+			const content = fs.readFileSync(projectPath, 'utf-8');
+			const parsed = YAML.load(content);
+			if (parsed && typeof parsed === 'object') {
+				project = parsed as Record<string, unknown>;
 			}
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			throw new ConfigValidationError([`.pappardelle.yml: ${msg}`]);
 		}
+	}
 
-		const localPath = path.join(projectDir, '.pappardelle.local.yml');
-		if (fs.existsSync(localPath)) {
-			try {
-				const content = fs.readFileSync(localPath, 'utf-8');
-				const parsed = YAML.load(content);
-				if (parsed && typeof parsed === 'object') {
-					local = parsed as Record<string, unknown>;
-				}
-			} catch (error) {
-				const msg = error instanceof Error ? error.message : String(error);
-				throw new ConfigValidationError([`.pappardelle.local.yml: ${msg}`]);
+	const localPath = resolveProjectFile('.pappardelle.local.yml');
+	if (localPath) {
+		try {
+			const content = fs.readFileSync(localPath, 'utf-8');
+			const parsed = YAML.load(content);
+			if (parsed && typeof parsed === 'object') {
+				local = parsed as Record<string, unknown>;
 			}
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			throw new ConfigValidationError([`.pappardelle.local.yml: ${msg}`]);
 		}
 	}
 
@@ -572,10 +664,10 @@ export function loadConfigFromPaths(opts: {
  * project (.pappardelle.yml) → local (.pappardelle.local.yml).
  */
 export function loadConfig(): PappardelleConfig {
-	const repoRoot = getRepoRoot();
 	return loadConfigFromPaths({
 		homeConfigDir: getDefaultHomeConfigDir(),
-		projectDir: repoRoot,
+		projectDir: getRepoRoot(),
+		fallbackProjectDir: getMainRepoRoot,
 	});
 }
 
@@ -588,10 +680,9 @@ export function loadProviderConfigs(): {
 	issue_tracker?: IssueTrackerConfig;
 	vcs_host?: VcsHostConfig;
 } {
-	const repoRoot = getRepoRoot();
-	const configPath = path.join(repoRoot, '.pappardelle.yml');
+	const configPath = findRepoConfig('.pappardelle.yml');
 
-	if (!fs.existsSync(configPath)) {
+	if (!configPath) {
 		return {};
 	}
 
@@ -608,9 +699,7 @@ export function loadProviderConfigs(): {
  */
 export function configExists(): boolean {
 	try {
-		const repoRoot = getRepoRoot();
-		const configPath = path.join(repoRoot, '.pappardelle.yml');
-		return fs.existsSync(configPath);
+		return findRepoConfig('.pappardelle.yml') !== undefined;
 	} catch {
 		return false;
 	}
@@ -666,8 +755,14 @@ export function validateConfig(
 		} else {
 			const it = cfg['issue_tracker'] as Record<string, unknown>;
 			const {provider} = it;
-			if (provider !== 'linear' && provider !== 'jira') {
-				errors.push('issue_tracker.provider: must be "linear" or "jira"');
+			if (
+				provider !== 'linear' &&
+				provider !== 'jira' &&
+				provider !== 'beads'
+			) {
+				errors.push(
+					'issue_tracker.provider: must be "linear", "jira", or "beads"',
+				);
 			} else if (provider === 'jira' && typeof it['base_url'] !== 'string') {
 				errors.push('issue_tracker.base_url: required when provider is "jira"');
 			}
@@ -728,6 +823,22 @@ export function validateConfig(
 		typeof cfg['auto_remove_when_done'] !== 'boolean'
 	) {
 		errors.push('auto_remove_when_done: must be a boolean');
+	}
+
+	// Check list_view (optional; an absent layout defers to the tracker default)
+	if (cfg['list_view'] !== undefined) {
+		if (typeof cfg['list_view'] !== 'object' || cfg['list_view'] === null) {
+			errors.push('list_view: must be an object');
+		} else {
+			const listView = cfg['list_view'] as Record<string, unknown>;
+			if (
+				listView['layout'] !== undefined &&
+				listView['layout'] !== 'single_line' &&
+				listView['layout'] !== 'two_line'
+			) {
+				errors.push('list_view.layout: must be "single_line" or "two_line"');
+			}
+		}
 	}
 
 	// Check companion_command (optional, free-form shell command). Any string is
@@ -1220,7 +1331,15 @@ export interface TemplateVars {
 	TITLE?: string;
 	DESCRIPTION?: string;
 	WORKTREE_PATH: string;
+	/** The working tree pappardelle is running in. */
 	REPO_ROOT: string;
+	/**
+	 * The main checkout, which differs from `REPO_ROOT` only when pappardelle
+	 * itself was launched from a linked worktree. Hooks that seed a new workspace
+	 * from an uncommitted file (`cp -n ${MAIN_REPO_ROOT}/.env ${WORKTREE_PATH}/`)
+	 * want this one: a worktree carries no copy of what was never committed.
+	 */
+	MAIN_REPO_ROOT: string;
 	REPO_NAME: string;
 	PR_URL?: string;
 	/** Provider-agnostic alias for PR_URL */
@@ -1465,11 +1584,189 @@ export function getProfileDefaultProject(profile: Profile): string | undefined {
 	return first === undefined || first === '' ? undefined : first;
 }
 
+/**
+ * Memoized per repo root. `determineProfileForInput` runs on every keystroke
+ * in the new-session prompt, so an uncached read would put a blocking
+ * `readFileSync` plus a YAML parse on the TUI's render path.
+ *
+ * A miss is stored even when it resolves to `undefined`, so repos with no
+ * beads config — the case that would otherwise re-stat the file forever — get
+ * the same single-read treatment as repos that have one.
+ */
+const beadsIssuePrefixCache = new Map<string, string | undefined>();
+
+export function readBeadsIssuePrefix(repoRoot?: string): string | undefined {
+	// getMainRepoRoot throws outside a git repo; this function's contract is to
+	// return undefined rather than propagate, so it has to resolve inside the try.
+	let root: string;
+	try {
+		root = repoRoot ?? getMainRepoRoot();
+	} catch {
+		return undefined;
+	}
+
+	if (beadsIssuePrefixCache.has(root)) {
+		return beadsIssuePrefixCache.get(root);
+	}
+	const result = resolveBeadsIssuePrefix(root);
+	beadsIssuePrefixCache.set(root, result);
+	return result;
+}
+
+export function clearBeadsIssuePrefixCache(): void {
+	beadsIssuePrefixCache.clear();
+}
+
+function resolveBeadsIssuePrefix(root: string): string | undefined {
+	try {
+		const raw = fs.readFileSync(
+			path.join(root, '.beads', 'config.yaml'),
+			'utf-8',
+		);
+		const parsed = YAML.load(raw) as Record<string, unknown> | undefined;
+		const prefix = parsed?.['issue-prefix'];
+		return typeof prefix === 'string' && prefix.trim()
+			? prefix.trim()
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function getBeadsPrefixes(
+	config: PappardelleConfig,
+	beadsConfigPrefix?: string,
+): string[] {
+	const prefixes = new Set<string>();
+	const add = (value: string | undefined) => {
+		const trimmed = value?.trim().toLowerCase();
+		if (trimmed) prefixes.add(trimmed);
+	};
+
+	add(beadsConfigPrefix);
+	add(config.team_prefix);
+	for (const profile of Object.values(config.profiles ?? {})) {
+		add(profile.team_prefix);
+		for (const project of profile.tracker_projects ?? []) add(project);
+	}
+
+	return [...prefixes];
+}
+
+export type ProfilePrefixMatch = {
+	name: string;
+	profile: Profile;
+	/**
+	 * The profile named this prefix itself (own `team_prefix`, or a
+	 * `tracker_projects` entry spelling the project key) rather than inheriting
+	 * it from the global `team_prefix`. Explicit claims outrank inherited ones
+	 * and are the only ones worth surfacing in the picker.
+	 */
+	explicit: boolean;
+};
+
+/**
+ * Profiles that can plausibly own an issue whose key carries `prefix`.
+ *
+ * Ways to claim one, in descending strength:
+ *   - the profile's own `team_prefix` is that prefix
+ *   - a `tracker_projects` entry spells it — Jira issue keys are their project
+ *     key, so `tracker_projects: [KAN]` and `KAN-12` are the same statement
+ *   - its `issue_watchlist.key_prefixes` lists it, which is the strongest
+ *     statement of all: the watchlist already spawns those issues under this
+ *     profile, so a hand-typed key of the same prefix must be able to reach it
+ *   - the profile declares none of those, so it inherits the global
+ *     `team_prefix`;
+ *     in a single-team config that is every profile, which is the point — the
+ *     user gets to choose among all of them rather than none of them
+ *
+ * Returns [] when the prefix is unclaimed, which keeps issue keys from an
+ * unknown team on the deferred path.
+ */
+export function matchProfilesByKeyPrefix(
+	config: PappardelleConfig,
+	prefix: string,
+): ProfilePrefixMatch[] {
+	const wanted = prefix.trim().toUpperCase();
+	if (!wanted) return [];
+
+	const globalPrefix = getTeamPrefix(config);
+	const explicit: ProfilePrefixMatch[] = [];
+	const inherited: ProfilePrefixMatch[] = [];
+
+	for (const [name, profile] of Object.entries(config.profiles)) {
+		const ownPrefix = profile.team_prefix?.toUpperCase();
+		const projectKeyMatch = profile.tracker_projects?.some(
+			tp => tp.trim().toUpperCase() === wanted,
+		);
+		const watchedPrefixMatch = profile.issue_watchlist?.key_prefixes?.some(
+			kp => kp.trim().toUpperCase() === wanted,
+		);
+
+		if (ownPrefix === wanted || projectKeyMatch || watchedPrefixMatch) {
+			explicit.push({name, profile, explicit: true});
+			continue;
+		}
+
+		if (ownPrefix === undefined && globalPrefix === wanted) {
+			inherited.push({name, profile, explicit: false});
+		}
+	}
+
+	return [...explicit, ...inherited];
+}
+
+/**
+ * The beads issue-source prefix `input` names, or null when it is not a beads
+ * ID under a prefix this repo can mint. Always null for the other trackers,
+ * whose keys carry a team prefix instead.
+ */
+function beadsInputKeyPrefix(
+	config: PappardelleConfig,
+	input: string,
+): string | null {
+	if (config.issue_tracker?.provider !== 'beads') return null;
+
+	const trimmed = input.trim();
+	const prefixes = getBeadsPrefixes(config, readBeadsIssuePrefix());
+	if (!isBeadsIssueKey(trimmed, prefixes)) return null;
+	return issueKeyPrefix(trimmed);
+}
+
+/**
+ * The prefix an issue identifier claims, under whichever key grammar its
+ * tracker uses: the team prefix of `STA-123` or a Linear URL, or the
+ * issue-source prefix of a beads ID. Null for prose and for bare numbers,
+ * which have no prefix of their own.
+ */
+export function inputKeyPrefix(
+	config: PappardelleConfig,
+	input: string,
+): string | null {
+	return issueKeyTeamPrefix(input) ?? beadsInputKeyPrefix(config, input);
+}
+
+/**
+ * Profiles claiming the prefix of whatever issue identifier `input` names.
+ * Empty for prose and for bare numbers, which have no prefix of their own.
+ */
+export function matchProfilesByInputKeyPrefix(
+	config: PappardelleConfig,
+	input: string,
+): ProfilePrefixMatch[] {
+	const prefix = inputKeyPrefix(config, input);
+	if (!prefix) return [];
+	return matchProfilesByKeyPrefix(config, prefix);
+}
+
 // Issue-key patterns used to short-circuit keyword matching and return the default profile.
-const DETERMINE_PROFILE_ISSUE_KEY = /^[A-Z][A-Z0-9]*-\d+$/;
+// Case-insensitive like isLinearIssueKey and normalizeIssueIdentifier: a
+// lowercase key reaches the tracker as the same issue, so it has to reach the
+// same profile decision too.
+const DETERMINE_PROFILE_ISSUE_KEY = /^[A-Z][A-Z0-9]*-\d+$/i;
 const DETERMINE_PROFILE_ISSUE_NUMBER = /^\d+$/;
 const DETERMINE_PROFILE_LINEAR_URL =
-	/^https:\/\/linear\.app\/.+\/issue\/[A-Z][A-Z0-9]*-\d+/;
+	/^https:\/\/linear\.app\/.+\/issue\/[A-Z][A-Z0-9]*-\d+/i;
 
 /**
  * Label shown in the TUI when profile selection is deferred to idow's
@@ -1481,6 +1778,17 @@ export type ProfileSelection =
 	| {
 			kind: 'deferred';
 			displayName: string;
+			/**
+			 * There is something to choose between, so the deferred lookup is the
+			 * *preselected* answer rather than the only one — the TUI should offer
+			 * the picker instead of an inert label. True when a profile claims
+			 * this key's prefix, and true for every beads key: a beads database is
+			 * not a project, so several profiles' worth of work shares one prefix
+			 * and the lookup can only ever guess. False for bare numbers and for
+			 * Linear/Jira prefixes no profile claims, where deferring to the
+			 * issue's own project is genuinely all we can do.
+			 */
+			canPick: boolean;
 	  }
 	| {
 			kind: 'resolved';
@@ -1509,8 +1817,10 @@ export type ProfileSelection =
  * Returns:
  *  - null for empty/whitespace input
  *  - `{kind: 'deferred'}` for issue keys, bare numbers, or Linear URLs —
- *    the caller should NOT pass --profile to idow; idow will pick the
- *    profile based on the fetched issue's tracker project
+ *    idow picks the profile from the fetched issue's tracker project, so
+ *    that is what the caller gets by default. `canPick` says whether any
+ *    profile claims the key's prefix, in which case the caller should still
+ *    offer the picker and honor an explicit override
  *  - `{kind: 'resolved'}` otherwise (keyword match or default fallback)
  */
 export function determineProfileForInput(
@@ -1520,12 +1830,20 @@ export function determineProfileForInput(
 	const trimmed = input.trim();
 	if (!trimmed) return null;
 
+	const isBeadsKey = beadsInputKeyPrefix(config, trimmed) !== null;
+
 	if (
 		DETERMINE_PROFILE_ISSUE_KEY.test(trimmed) ||
 		DETERMINE_PROFILE_ISSUE_NUMBER.test(trimmed) ||
-		DETERMINE_PROFILE_LINEAR_URL.test(trimmed)
+		DETERMINE_PROFILE_LINEAR_URL.test(trimmed) ||
+		isBeadsKey
 	) {
-		return {kind: 'deferred', displayName: DEFERRED_PROFILE_DISPLAY_NAME};
+		return {
+			kind: 'deferred',
+			displayName: DEFERRED_PROFILE_DISPLAY_NAME,
+			canPick:
+				isBeadsKey || matchProfilesByInputKeyPrefix(config, trimmed).length > 0,
+		};
 	}
 
 	const matches = matchProfiles(config, trimmed);
@@ -1690,14 +2008,14 @@ export function getDangerouslySkipPermissions(
 /**
  * Resolve one of the pass-through Claude launch flags for a workspace.
  *
- * Resolution order — per-profile value → top-level value → `''`. The profile is
+ * Resolution order: per-profile value, then top-level value, then `''`. The profile is
  * matched from `issueTitle` the same way `getCompanionCommand` does it, so a
  * space with no title (the main worktree, or a call site that doesn't have one
  * handy) simply gets the top-level value.
  *
  * The profile layer wins whenever the *key is present*, not merely when it's
  * truthy. That's what makes `model: ""` on a profile mean "ignore the global
- * model, launch with Claude's default" rather than "no opinion" — the same
+ * model, launch with Claude's default" rather than "no opinion", the same
  * empty-string-is-meaningful convention `companion_command` uses.
  *
  * `''` is the universal "don't pass this flag" signal: callers omit the flag
@@ -1720,7 +2038,7 @@ function resolveClaudeLaunchField(
 
 /**
  * Get the Claude model to launch a workspace with (`claude --model <value>`).
- * Returns '' when no model is configured — pass no flag at all in that case.
+ * Returns '' when no model is configured; pass no flag at all in that case.
  */
 export function getClaudeModel(
 	config: PappardelleConfig,
@@ -1877,6 +2195,14 @@ export function getAutoRemoveWhenDone(config: PappardelleConfig): boolean {
 	return config.auto_remove_when_done ?? false;
 }
 
+export function getListLayout(config: PappardelleConfig | null): ListLayout {
+	const explicit = config?.list_view?.layout;
+	if (explicit) return explicit;
+	return config?.issue_tracker?.provider === 'beads'
+		? 'two_line'
+		: 'single_line';
+}
+
 /**
  * The command the companion pane runs when nothing is configured. gitui
  * replaced lazygit as the default in STA-1464. GIT_OPTIONAL_LOCKS=0 keeps the
@@ -1928,14 +2254,12 @@ export function buildWorkspaceTemplateVars(
 	issueTitle?: string,
 	configOverride?: PappardelleConfig,
 ): TemplateVars {
-	const repoRoot = getRepoRoot();
-	const repoName = getRepoName();
-
 	const vars: TemplateVars = {
 		ISSUE_KEY: issueKey,
 		WORKTREE_PATH: worktreePath,
-		REPO_ROOT: repoRoot,
-		REPO_NAME: repoName,
+		REPO_ROOT: getRepoRoot(),
+		MAIN_REPO_ROOT: getMainRepoRoot(),
+		REPO_NAME: getRepoName(),
 		SCRIPT_DIR: path.resolve(__dirname, '..', 'scripts'),
 	};
 

--- a/source/config.ts
+++ b/source/config.ts
@@ -386,10 +386,11 @@ function resolveMainRepoRoot(): string {
 }
 
 /**
- * `.pappardelle.yml` is usually excluded rather than committed, so only the main
- * checkout has one; `.pappardelle.local.yml` is copied into each worktree, so the
- * worktree's copy wins. Resolving per file rather than per directory lets both be
- * true at once. Mirrors `find_repo_config` in hooks/tracker_config.py.
+ * Working tree first, main checkout second, resolved per file. A committed
+ * `.pappardelle.yml` is checked out into the worktree and found there; one kept
+ * out of git exists only in the main checkout. `.pappardelle.local.yml` is
+ * gitignored but copied into each worktree by workspace setup, so the worktree's
+ * copy wins. Mirrors `find_repo_config` in hooks/tracker_config.py.
  */
 export function findRepoConfig(filename: string): string | undefined {
 	const inWorkingTree = path.join(getRepoRoot(), filename);

--- a/source/config.ts
+++ b/source/config.ts
@@ -367,6 +367,11 @@ export function getMainRepoRoot(): string {
 }
 
 function resolveMainRepoRoot(): string {
+	// Set by whoever created this workspace, so a worktree session is told its
+	// main checkout instead of forking git to work it out again.
+	const injected = process.env['PAPPARDELLE_MAIN_REPO_ROOT'];
+	if (injected) return injected;
+
 	try {
 		const commonDir = execSync(
 			'git rev-parse --path-format=absolute --git-common-dir',
@@ -381,21 +386,10 @@ function resolveMainRepoRoot(): string {
 }
 
 /**
- * Locate a repo-level config file, resolving through linked worktrees.
- *
- * `.pappardelle.yml` is routinely listed in `.git/info/exclude` rather than
- * committed, so a linked worktree never receives a copy and only the main
- * checkout has one. `.pappardelle.local.yml` is the opposite: workspace setup
- * copies it *into* each worktree, so the worktree's own copy is the one that
- * should win. Resolving per file rather than per directory is what lets both
- * be true at once.
- *
- * The working tree is checked first so the main checkout — where the two
- * directories coincide — never pays for the extra lookup. That only holds if
- * the second root is resolved lazily; an array literal of both would fork git
- * for the main root before the first candidate is ever tested.
- *
- * Mirrors `find_repo_config` in hooks/tracker_config.py.
+ * `.pappardelle.yml` is usually excluded rather than committed, so only the main
+ * checkout has one; `.pappardelle.local.yml` is copied into each worktree, so the
+ * worktree's copy wins. Resolving per file rather than per directory lets both be
+ * true at once. Mirrors `find_repo_config` in hooks/tracker_config.py.
  */
 export function findRepoConfig(filename: string): string | undefined {
 	const inWorkingTree = path.join(getRepoRoot(), filename);
@@ -572,13 +566,6 @@ export function getDefaultHomeConfigDir(): string {
 export function loadConfigFromPaths(opts: {
 	homeConfigDir?: string;
 	projectDir?: string;
-	/**
-	 * Second directory to consult per file when `projectDir` lacks it — the
-	 * main checkout, when `projectDir` is a linked worktree. Each layer is
-	 * resolved independently; see `findRepoConfig` for why. Passed as a thunk
-	 * so the main checkout, where both directories coincide and every file is
-	 * found on the first candidate, never forks git to resolve the second.
-	 */
 	fallbackProjectDir?: () => string | undefined;
 }): PappardelleConfig {
 	const {homeConfigDir, projectDir, fallbackProjectDir} = opts;
@@ -1333,12 +1320,6 @@ export interface TemplateVars {
 	WORKTREE_PATH: string;
 	/** The working tree pappardelle is running in. */
 	REPO_ROOT: string;
-	/**
-	 * The main checkout, which differs from `REPO_ROOT` only when pappardelle
-	 * itself was launched from a linked worktree. Hooks that seed a new workspace
-	 * from an uncommitted file (`cp -n ${MAIN_REPO_ROOT}/.env ${WORKTREE_PATH}/`)
-	 * want this one: a worktree carries no copy of what was never committed.
-	 */
 	MAIN_REPO_ROOT: string;
 	REPO_NAME: string;
 	PR_URL?: string;
@@ -1584,15 +1565,6 @@ export function getProfileDefaultProject(profile: Profile): string | undefined {
 	return first === undefined || first === '' ? undefined : first;
 }
 
-/**
- * Memoized per repo root. `determineProfileForInput` runs on every keystroke
- * in the new-session prompt, so an uncached read would put a blocking
- * `readFileSync` plus a YAML parse on the TUI's render path.
- *
- * A miss is stored even when it resolves to `undefined`, so repos with no
- * beads config — the case that would otherwise re-stat the file forever — get
- * the same single-read treatment as repos that have one.
- */
 const beadsIssuePrefixCache = new Map<string, string | undefined>();
 
 export function readBeadsIssuePrefix(repoRoot?: string): string | undefined {
@@ -1656,33 +1628,9 @@ export function getBeadsPrefixes(
 export type ProfilePrefixMatch = {
 	name: string;
 	profile: Profile;
-	/**
-	 * The profile named this prefix itself (own `team_prefix`, or a
-	 * `tracker_projects` entry spelling the project key) rather than inheriting
-	 * it from the global `team_prefix`. Explicit claims outrank inherited ones
-	 * and are the only ones worth surfacing in the picker.
-	 */
 	explicit: boolean;
 };
 
-/**
- * Profiles that can plausibly own an issue whose key carries `prefix`.
- *
- * Ways to claim one, in descending strength:
- *   - the profile's own `team_prefix` is that prefix
- *   - a `tracker_projects` entry spells it — Jira issue keys are their project
- *     key, so `tracker_projects: [KAN]` and `KAN-12` are the same statement
- *   - its `issue_watchlist.key_prefixes` lists it, which is the strongest
- *     statement of all: the watchlist already spawns those issues under this
- *     profile, so a hand-typed key of the same prefix must be able to reach it
- *   - the profile declares none of those, so it inherits the global
- *     `team_prefix`;
- *     in a single-team config that is every profile, which is the point — the
- *     user gets to choose among all of them rather than none of them
- *
- * Returns [] when the prefix is unclaimed, which keeps issue keys from an
- * unknown team on the deferred path.
- */
 export function matchProfilesByKeyPrefix(
 	config: PappardelleConfig,
 	prefix: string,
@@ -1716,11 +1664,6 @@ export function matchProfilesByKeyPrefix(
 	return [...explicit, ...inherited];
 }
 
-/**
- * The beads issue-source prefix `input` names, or null when it is not a beads
- * ID under a prefix this repo can mint. Always null for the other trackers,
- * whose keys carry a team prefix instead.
- */
 function beadsInputKeyPrefix(
 	config: PappardelleConfig,
 	input: string,
@@ -1733,12 +1676,6 @@ function beadsInputKeyPrefix(
 	return issueKeyPrefix(trimmed);
 }
 
-/**
- * The prefix an issue identifier claims, under whichever key grammar its
- * tracker uses: the team prefix of `STA-123` or a Linear URL, or the
- * issue-source prefix of a beads ID. Null for prose and for bare numbers,
- * which have no prefix of their own.
- */
 export function inputKeyPrefix(
 	config: PappardelleConfig,
 	input: string,
@@ -1778,16 +1715,6 @@ export type ProfileSelection =
 	| {
 			kind: 'deferred';
 			displayName: string;
-			/**
-			 * There is something to choose between, so the deferred lookup is the
-			 * *preselected* answer rather than the only one — the TUI should offer
-			 * the picker instead of an inert label. True when a profile claims
-			 * this key's prefix, and true for every beads key: a beads database is
-			 * not a project, so several profiles' worth of work shares one prefix
-			 * and the lookup can only ever guess. False for bare numbers and for
-			 * Linear/Jira prefixes no profile claims, where deferring to the
-			 * issue's own project is genuinely all we can do.
-			 */
 			canPick: boolean;
 	  }
 	| {

--- a/source/idow-worktree-config.test.ts
+++ b/source/idow-worktree-config.test.ts
@@ -1,0 +1,200 @@
+/* eslint-disable no-template-curly-in-string -- These are idow shell templates. */
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test, {type ExecutionContext} from 'ava';
+import YAML from 'js-yaml';
+
+const scriptsDir = path.resolve(import.meta.dirname, '../scripts');
+
+function writeScript(filename: string, body: string) {
+	const script = `#!/bin/bash\nset -e\n${body}\n`;
+	execFileSync('shellcheck', ['-s', 'bash', '-'], {input: script});
+	fs.writeFileSync(filename, script, {mode: 0o755});
+}
+
+function setup(t: ExecutionContext) {
+	const root = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'idow-config-')),
+	);
+	t.teardown(() => fs.rmSync(root, {recursive: true, force: true}));
+	const main = path.join(root, 'main checkout');
+	const linked = path.join(root, 'linked checkout');
+	const scripts = path.join(root, 'scripts');
+	const bin = path.join(root, 'bin');
+	const home = path.join(root, 'home');
+	const workspace = path.join(root, 'new workspace');
+	const launchArgs = path.join(root, 'launch-args');
+	for (const dir of [main, scripts, bin, home]) fs.mkdirSync(dir);
+	const git = (...args: string[]) =>
+		execFileSync('git', ['-C', main, ...args], {stdio: 'pipe'});
+	git('init');
+	git(
+		'-c',
+		'user.name=Test',
+		'-c',
+		'user.email=test@example.com',
+		'commit',
+		'--allow-empty',
+		'-m',
+		'initial',
+	);
+	git('worktree', 'add', '-b', 'linked', linked);
+	for (const file of [
+		'idow',
+		'provider-helpers.sh',
+		'resolve-claude-config.sh',
+	]) {
+		fs.copyFileSync(path.join(scriptsDir, file), path.join(scripts, file));
+	}
+	writeScript(
+		path.join(bin, 'bd'),
+		`printf '%s\\n' '{"id":"test-abc","title":"Test issue","description":""}'`,
+	);
+	writeScript(path.join(bin, 'gh'), 'exit 1');
+	writeScript(path.join(bin, 'tmux'), 'exit 1');
+	writeScript(
+		path.join(scripts, 'start-claude-session.sh'),
+		`printf '%s\\n' "$@" > "$IDOW_TEST_LAUNCH_ARGS"`,
+	);
+	writeScript(
+		path.join(scripts, 'create-worktree.sh'),
+		`mkdir -p "$IDOW_TEST_WORKSPACE"
+jq -n --arg worktree_path "$IDOW_TEST_WORKSPACE" '{worktree_path: $worktree_path}'`,
+	);
+	fs.writeFileSync(path.join(main, '.env'), 'FROM_MAIN=1\n');
+
+	const config = (displayName: string) =>
+		YAML.dump({
+			version: 1,
+			team_prefix: 'test',
+			issue_tracker: {provider: 'beads'},
+			default_profile: 'dev',
+			terminal: {app: 'none'},
+			profiles: {
+				dev: {
+					display_name: displayName,
+					post_workspace_init: [
+						{
+							name: 'Profile init',
+							run: 'cp "${MAIN_REPO_ROOT}/.env" "${WORKTREE_PATH}/profile.env"',
+						},
+					],
+				},
+			},
+			post_workspace_init: [
+				{
+					name: 'Global init',
+					run: 'cp "${MAIN_REPO_ROOT}/.env" "${WORKTREE_PATH}/.env"',
+				},
+			],
+			hooks: {
+				post_workspace_create: [
+					{
+						name: 'Create hook',
+						run: 'printf "%s\\n" "${MAIN_REPO_ROOT}" "${REPO_ROOT}" > "${WORKTREE_PATH}/roots"',
+					},
+				],
+			},
+		});
+	fs.writeFileSync(path.join(main, '.pappardelle.yml'), config('Main config'));
+	fs.writeFileSync(
+		path.join(main, '.pappardelle.local.yml'),
+		'claude:\n  model: main-model\n',
+	);
+
+	return {
+		main,
+		linked,
+		workspace,
+		launchArgs,
+		config,
+		run({open = false, projectRoot = true} = {}) {
+			const env = {...process.env};
+			delete env.PAPPARDELLE_PROJECT_ROOT;
+			delete env.MAIN_REPO_ROOT;
+			return execFileSync(
+				'bash',
+				[
+					path.join(scripts, 'idow'),
+					...(open ? ['--resume', '--open'] : []),
+					'--existing-issue',
+					'test-abc',
+				],
+				{
+					cwd: projectRoot ? root : linked,
+					encoding: 'utf8',
+					timeout: 30_000,
+					env: {
+						...env,
+						HOME: home,
+						PATH: `${bin}:${process.env.PATH!}`,
+						...(projectRoot ? {PAPPARDELLE_PROJECT_ROOT: linked} : {}),
+						IDOW_TEST_WORKSPACE: workspace,
+						IDOW_TEST_LAUNCH_ARGS: launchArgs,
+					},
+				},
+			);
+		},
+	};
+}
+
+test('idow creates a session using main config and worktree-local overrides', t => {
+	const fixture = setup(t);
+	fs.writeFileSync(
+		path.join(fixture.linked, '.pappardelle.local.yml'),
+		'claude:\n  model: linked-model\n',
+	);
+	const output = fixture.run();
+	t.true(output.includes('Workspace test-abc is ready!'), output);
+	t.true(output.includes('Profile:   Main config'), output);
+	t.true(
+		fs
+			.readFileSync(fixture.launchArgs, 'utf8')
+			.includes('--model\nlinked-model\n'),
+	);
+	t.is(
+		fs.readFileSync(
+			path.join(fixture.workspace, '.pappardelle.local.yml'),
+			'utf8',
+		),
+		'claude:\n  model: linked-model\n',
+	);
+	for (const file of ['.env', 'profile.env']) {
+		t.is(
+			fs.readFileSync(path.join(fixture.workspace, file), 'utf8'),
+			'FROM_MAIN=1\n',
+		);
+	}
+});
+
+test('idow opens from a linked checkout and expands both repository roots', t => {
+	const fixture = setup(t);
+	const output = fixture.run({open: true, projectRoot: false});
+	t.true(output.includes('Workspace test-abc is ready!'), output);
+	t.true(
+		fs
+			.readFileSync(fixture.launchArgs, 'utf8')
+			.includes('--model\nmain-model\n'),
+	);
+	t.is(
+		fs.readFileSync(path.join(fixture.workspace, 'roots'), 'utf8'),
+		`${fixture.main}\n${fixture.linked}\n`,
+	);
+});
+
+test('idow prefers a worktree project config while falling back for local config', t => {
+	const fixture = setup(t);
+	fs.writeFileSync(
+		path.join(fixture.linked, '.pappardelle.yml'),
+		fixture.config('Linked config'),
+	);
+	const output = fixture.run();
+	t.true(output.includes('Profile:   Linked config'), output);
+	t.true(
+		fs
+			.readFileSync(fixture.launchArgs, 'utf8')
+			.includes('--model\nmain-model\n'),
+	);
+});

--- a/source/idow-worktree-config.test.ts
+++ b/source/idow-worktree-config.test.ts
@@ -119,7 +119,7 @@ jq -n --arg worktree_path "$IDOW_TEST_WORKSPACE" '{worktree_path: $worktree_path
 				[
 					path.join(scripts, 'idow'),
 					...(open ? ['--resume', '--open'] : []),
-					'--existing-issue',
+					'--issue-key',
 					'test-abc',
 				],
 				{

--- a/source/inner-socket.test.ts
+++ b/source/inner-socket.test.ts
@@ -370,6 +370,30 @@ test('cleanupOrphanedInnerSessions kills orphans (not in registry, not main)', t
 	t.deepEqual(killed, ['claude-repo-STA-999', 'companion-repo-STA-999']);
 });
 
+test('cleanupOrphanedInnerSessions decodes encoded keys before matching the registry', t => {
+	// Session names carry the '.'/'_' encoding; the registry holds keys as the
+	// tracker spells them. Comparing raw reaped every beads child issue and every
+	// underscored prefix out from under its live worktree on startup.
+	const {runner, calls} = makeFakeRunner({
+		listSessionsStdout: [
+			'claude-repo-bd-a3f8e9_1', // registered as bd-a3f8e9.1 → keep
+			'companion-repo-my__service-a1b2', // registered as my_service-a1b2 → keep
+			'claude-repo-bd-dead_9', // orphan → kill
+		].join('\n'),
+	});
+	t.is(
+		cleanupOrphanedInnerSessions(
+			new Set(['bd-a3f8e9.1', 'my_service-a1b2']),
+			'repo',
+			runner,
+		),
+		1,
+	);
+
+	const killed = calls.filter(c => c[0] === 'kill-session').map(c => c[2]);
+	t.deepEqual(killed, ['claude-repo-bd-dead_9']);
+});
+
 test('cleanupOrphanedInnerSessions sweeps legacy lazygit-{repo}-* orphans (STA-1464 upgrade)', t => {
 	// A hard-quit straddling the STA-1464 upgrade can leave the old
 	// `lazygit-{repo}-*` companion sessions behind on the inner socket. They

--- a/source/issue-checker.test.ts
+++ b/source/issue-checker.test.ts
@@ -1,8 +1,11 @@
 import test from 'ava';
 import {
+	isBeadsIssueKey,
+	issueKeyPrefix,
 	isLinearIssueKey,
 	isIssueKey,
 	isIssueNumber,
+	issueKeyTeamPrefix,
 	normalizeIssueIdentifier,
 } from './issue-utils.ts';
 
@@ -91,48 +94,94 @@ test('isIssueNumber returns false for decimal', t => {
 });
 
 // ============================================================================
+// issueKeyTeamPrefix Tests
+// ============================================================================
+
+test('issueKeyTeamPrefix returns the prefix of a standard key', t => {
+	t.is(issueKeyTeamPrefix('STA-123'), 'STA');
+});
+
+test('issueKeyTeamPrefix uppercases a lowercase key', t => {
+	t.is(issueKeyTeamPrefix('sta-123'), 'STA');
+});
+
+test('issueKeyTeamPrefix tolerates whitespace padding', t => {
+	t.is(issueKeyTeamPrefix('  STA-789  '), 'STA');
+});
+
+test('issueKeyTeamPrefix handles an alphanumeric prefix', t => {
+	t.is(issueKeyTeamPrefix('B2B-100'), 'B2B');
+});
+
+test('issueKeyTeamPrefix reads the prefix out of a Linear issue URL', t => {
+	t.is(
+		issueKeyTeamPrefix('https://linear.app/acme/issue/ENG-456/some-slug'),
+		'ENG',
+	);
+});
+
+test('issueKeyTeamPrefix reads a Linear URL carrying an extra path segment', t => {
+	// Linear emits both /<workspace>/issue/KEY and /<workspace>/team/issue/KEY;
+	// idow and determineProfileForInput both accept the longer form.
+	t.is(
+		issueKeyTeamPrefix('https://linear.app/acme/team/issue/ENG-456/slug'),
+		'ENG',
+	);
+});
+
+test('issueKeyTeamPrefix returns null for a bare number', t => {
+	// A bare number borrows its prefix from config, so it states none itself.
+	t.is(issueKeyTeamPrefix('400'), null);
+});
+
+test('issueKeyTeamPrefix returns null for prose and for empty input', t => {
+	t.is(issueKeyTeamPrefix('fix the login page'), null);
+	t.is(issueKeyTeamPrefix(''), null);
+});
+
+// ============================================================================
 // normalizeIssueIdentifier Tests
 // ============================================================================
 
 test('normalizeIssueIdentifier returns uppercase STA-400 for bare number 400', t => {
-	t.is(normalizeIssueIdentifier('400', 'STA'), 'STA-400');
+	t.is(normalizeIssueIdentifier('400', 'STA', 'linear', []), 'STA-400');
 });
 
 test('normalizeIssueIdentifier returns uppercase STA-123 for lowercase sta-123', t => {
-	t.is(normalizeIssueIdentifier('sta-123', 'STA'), 'STA-123');
+	t.is(normalizeIssueIdentifier('sta-123', 'STA', 'linear', []), 'STA-123');
 });
 
 test('normalizeIssueIdentifier returns uppercase for mixed case Sta-456', t => {
-	t.is(normalizeIssueIdentifier('Sta-456', 'STA'), 'STA-456');
+	t.is(normalizeIssueIdentifier('Sta-456', 'STA', 'linear', []), 'STA-456');
 });
 
 test('normalizeIssueIdentifier trims whitespace', t => {
-	t.is(normalizeIssueIdentifier('  400  ', 'STA'), 'STA-400');
-	t.is(normalizeIssueIdentifier('  STA-400  ', 'STA'), 'STA-400');
+	t.is(normalizeIssueIdentifier('  400  ', 'STA', 'linear', []), 'STA-400');
+	t.is(normalizeIssueIdentifier('  STA-400  ', 'STA', 'linear', []), 'STA-400');
 });
 
 test('normalizeIssueIdentifier returns null for descriptions', t => {
-	t.is(normalizeIssueIdentifier('fix the bug', 'STA'), null);
+	t.is(normalizeIssueIdentifier('fix the bug', 'STA', 'linear', []), null);
 });
 
 test('normalizeIssueIdentifier returns null for empty string', t => {
-	t.is(normalizeIssueIdentifier('', 'STA'), null);
+	t.is(normalizeIssueIdentifier('', 'STA', 'linear', []), null);
 });
 
 test('normalizeIssueIdentifier works with different team prefixes', t => {
-	t.is(normalizeIssueIdentifier('100', 'ENG'), 'ENG-100');
-	t.is(normalizeIssueIdentifier('eng-100', 'ENG'), 'ENG-100');
+	t.is(normalizeIssueIdentifier('100', 'ENG', 'linear', []), 'ENG-100');
+	t.is(normalizeIssueIdentifier('eng-100', 'ENG', 'linear', []), 'ENG-100');
 });
 
 test('normalizeIssueIdentifier preserves original team prefix when different from default', t => {
 	// If user types ENG-100 but default is STA, keep ENG-100
-	t.is(normalizeIssueIdentifier('ENG-100', 'STA'), 'ENG-100');
+	t.is(normalizeIssueIdentifier('ENG-100', 'STA', 'linear', []), 'ENG-100');
 });
 
 test('normalizeIssueIdentifier works with alphanumeric prefixes', t => {
-	t.is(normalizeIssueIdentifier('b2b-100', 'B2B'), 'B2B-100');
-	t.is(normalizeIssueIdentifier('B2B-200', 'STA'), 'B2B-200');
-	t.is(normalizeIssueIdentifier('100', 'B2B'), 'B2B-100');
+	t.is(normalizeIssueIdentifier('b2b-100', 'B2B', 'linear', []), 'B2B-100');
+	t.is(normalizeIssueIdentifier('B2B-200', 'STA', 'linear', []), 'B2B-200');
+	t.is(normalizeIssueIdentifier('100', 'B2B', 'linear', []), 'B2B-100');
 });
 
 // ============================================================================
@@ -148,4 +197,151 @@ test('isIssueKey works for standard format', t => {
 	t.true(isIssueKey('PROJ-456'));
 	t.false(isIssueKey('fix bug'));
 	t.false(isIssueKey('400'));
+});
+
+// ============================================================================
+// issueKeyPrefix Tests
+// ============================================================================
+
+test('issueKeyPrefix splits on the last hyphen', t => {
+	t.is(issueKeyPrefix('STA-123'), 'STA');
+	t.is(issueKeyPrefix('bd-a1b2'), 'bd');
+});
+
+test('issueKeyPrefix keeps hyphens inside a beads prefix', t => {
+	// Splitting on the first hyphen instead silently broke watchlist filtering
+	// for these repos.
+	t.is(
+		issueKeyPrefix('seatgeek-ticket-management-cli-bqm'),
+		'seatgeek-ticket-management-cli',
+	);
+});
+
+test('issueKeyPrefix drops a hierarchical child suffix', t => {
+	t.is(issueKeyPrefix('bd-a3f8e9.1'), 'bd');
+	t.is(issueKeyPrefix('bd-a3f8e9.1.2'), 'bd');
+});
+
+test('issueKeyPrefix yields the whole string when there is no hyphen', t => {
+	// Allowlist callers then exclude it rather than matching everything.
+	t.is(issueKeyPrefix('nohyphen'), 'nohyphen');
+});
+
+// ============================================================================
+// isBeadsIssueKey Tests
+// ============================================================================
+
+test('isBeadsIssueKey accepts hash-suffixed IDs of a known prefix', t => {
+	t.true(isBeadsIssueKey('bd-a1b2', ['bd']));
+	t.true(isBeadsIssueKey('sddamico-hic', ['sddamico']));
+});
+
+test('isBeadsIssueKey accepts a prefix containing hyphens', t => {
+	// The prefix defaults to the repo directory name.
+	t.true(
+		isBeadsIssueKey('seatgeek-ticket-management-cli-bqm', [
+			'seatgeek-ticket-management-cli',
+		]),
+	);
+});
+
+test('isBeadsIssueKey accepts a prefix containing underscores', t => {
+	// The repo directory name a prefix defaults to may be snake_case, and the
+	// tmux session encoding already treats these as valid keys.
+	t.true(isBeadsIssueKey('my_service-a1b2', ['my_service']));
+	t.true(isBeadsIssueKey('my_service-sub_x1', ['my_service']));
+});
+
+test('isBeadsIssueKey accepts hierarchical child IDs', t => {
+	t.true(isBeadsIssueKey('bd-a3f8e9.1', ['bd']));
+	t.true(isBeadsIssueKey('bd-a3f8e9.1.2.3', ['bd']));
+});
+
+test('isBeadsIssueKey rejects nesting deeper than beads allows', t => {
+	t.false(isBeadsIssueKey('bd-a3f8e9.1.2.3.4', ['bd']));
+});
+
+test('isBeadsIssueKey rejects a hyphenated phrase that is not a known prefix', t => {
+	// A beads hash can be pure letters, so shape alone cannot tell 'dark-mode'
+	// from an ID — without the prefix anchor these would be sent to idow as
+	// existing keys and die on a lookup instead of creating an issue.
+	t.false(isBeadsIssueKey('dark-mode', ['bd']));
+	t.false(isBeadsIssueKey('fix-crash', ['bd']));
+});
+
+test('isBeadsIssueKey matches the prefix case-insensitively', t => {
+	t.true(isBeadsIssueKey('BD-A1B2', ['bd']));
+	t.true(isBeadsIssueKey('bd-a1b2', ['BD']));
+});
+
+test('isBeadsIssueKey rejects everything when no prefixes are known', t => {
+	t.false(isBeadsIssueKey('bd-a1b2', []));
+});
+
+test('isBeadsIssueKey rejects prose and bare numbers', t => {
+	t.false(isBeadsIssueKey('fix the bug', ['bd']));
+	t.false(isBeadsIssueKey('400', ['bd']));
+	t.false(isBeadsIssueKey('nohyphen', ['bd']));
+});
+
+// ============================================================================
+// normalizeIssueIdentifier — beads
+// ============================================================================
+
+test('normalizeIssueIdentifier lowercases beads IDs', t => {
+	// Uppercasing would yield an ID bd cannot resolve and a worktree named
+	// unlike its issue.
+	t.is(normalizeIssueIdentifier('bd-a1b2', 'bd', 'beads', ['bd']), 'bd-a1b2');
+	t.is(normalizeIssueIdentifier('BD-A1B2', 'bd', 'beads', ['bd']), 'bd-a1b2');
+	t.is(
+		normalizeIssueIdentifier('sddamico-hic', 'sddamico', 'beads', ['sddamico']),
+		'sddamico-hic',
+	);
+});
+
+test('normalizeIssueIdentifier keeps beads child IDs intact', t => {
+	t.is(
+		normalizeIssueIdentifier('bd-a3f8e9.1', 'bd', 'beads', ['bd']),
+		'bd-a3f8e9.1',
+	);
+	t.is(
+		normalizeIssueIdentifier('BD-A3F8E9.1', 'bd', 'beads', ['bd']),
+		'bd-a3f8e9.1',
+	);
+});
+
+test('normalizeIssueIdentifier accepts a beads ID from any known prefix', t => {
+	t.is(
+		normalizeIssueIdentifier('vendor-sdk-hic', 'bd', 'beads', [
+			'bd',
+			'vendor-sdk',
+		]),
+		'vendor-sdk-hic',
+	);
+});
+
+test('normalizeIssueIdentifier treats an unknown-prefix phrase as a description', t => {
+	t.is(normalizeIssueIdentifier('dark-mode', 'bd', 'beads', ['bd']), null);
+});
+
+test('normalizeIssueIdentifier lowercases the prefix for a bare beads number', t => {
+	// Only resolves in databases old enough to have sequential IDs, but the
+	// prefix is lowercase either way.
+	t.is(normalizeIssueIdentifier('42', 'BD', 'beads', ['bd']), 'bd-42');
+});
+
+test('normalizeIssueIdentifier returns null for beads descriptions', t => {
+	t.is(normalizeIssueIdentifier('fix the bug', 'bd', 'beads', ['bd']), null);
+});
+
+test('normalizeIssueIdentifier still uppercases for linear and jira', t => {
+	// Regression pin: adding the beads grammar must not touch the others.
+	t.is(normalizeIssueIdentifier('sta-123', 'STA', 'linear', []), 'STA-123');
+	t.is(normalizeIssueIdentifier('sta-123', 'STA', 'jira', []), 'STA-123');
+});
+
+test('normalizeIssueIdentifier needs a beads prefix to read a beads key', t => {
+	// An empty allowlist is what a caller with no config passes, and nothing
+	// about `dark-mode`'s shape distinguishes it from an ID — so nothing matches.
+	t.is(normalizeIssueIdentifier('bd-a1b2', 'bd', 'beads', []), null);
 });

--- a/source/issue-checker.ts
+++ b/source/issue-checker.ts
@@ -8,6 +8,7 @@ export type {PRInfo} from './providers/types.ts';
 // Re-export pure utility functions for backwards compatibility
 export {
 	isLinearIssueKey,
+	isBeadsIssueKey,
 	isIssueNumber,
 	normalizeIssueIdentifier,
 } from './issue-utils.ts';

--- a/source/issue-utils.ts
+++ b/source/issue-utils.ts
@@ -19,10 +19,6 @@ export const isIssueKey = isLinearIssueKey;
  * The issue-source prefix of an issue key: everything ahead of the last hyphen,
  * with any `.N` child suffix dropped first. `STA-123` -> `STA`,
  * `seatgeek-ticket-management-cli-bqm` -> `seatgeek-ticket-management-cli`.
- *
- * Splitting on the last hyphen rather than the first is what admits beads
- * prefixes, which may contain hyphens of their own. An identifier with no
- * hyphen yields itself.
  */
 export function issueKeyPrefix(identifier: string): string {
 	// split always yields at least one element, so index 0 is never undefined.
@@ -34,10 +30,6 @@ export function issueKeyPrefix(identifier: string): string {
 /**
  * Check if a string is a beads issue ID belonging to one of `prefixes`
  * (e.g. bd-a1b2, bd-a3f8e9.1, seatgeek-ticket-management-cli-bqm).
- *
- * A beads suffix is a content hash and can be pure letters, so shape alone
- * cannot tell `dark-mode` from an ID. The prefix allowlist is what does; with
- * no known prefixes, nothing matches.
  */
 export function isBeadsIssueKey(input: string, prefixes: string[]): boolean {
 	const trimmed = input.trim();
@@ -53,23 +45,12 @@ export function isIssueNumber(input: string): boolean {
 	return /^\d+$/.test(input.trim());
 }
 
-// The workspace segment is `.+` rather than `[^/]+` to stay in lockstep with
-// config.ts's DETERMINE_PROFILE_LINEAR_URL and idow's own URL parse, both of
-// which accept the extra `/team/` segment Linear sometimes emits.
 const LINEAR_URL_ISSUE_KEY =
 	/^https:\/\/linear\.app\/.+\/issue\/([A-Z][A-Z0-9]*)-\d+/i;
 
 /**
  * Extract the team prefix an issue identifier belongs to (e.g. 'STA' for
  * 'STA-123'), uppercased. Accepts a bare key or a Linear issue URL.
- *
- * Distinct from `issueKeyPrefix`, which answers a different question for a
- * different grammar: the issue *source* ahead of the last hyphen, verbatim,
- * for beads IDs that carry hyphens of their own.
- *
- * Returns null when the input carries no prefix of its own — bare numbers
- * borrow one from config, and prose has none — which is the signal callers
- * use to fall back to prefix-independent behavior.
  */
 export function issueKeyTeamPrefix(input: string): string | null {
 	const trimmed = input.trim();
@@ -93,8 +74,6 @@ export function issueKeyTeamPrefix(input: string): string | null {
  * uppercase, since that is the only casing `bd` can resolve. `beadsPrefixes` is
  * the allowlist from `getBeadsPrefixes`; anything outside it is prose, not a
  * key, and an empty allowlist therefore makes every beads input a description.
- * Both are required: which grammar applies is not something this function can
- * guess, and a defaulted allowlist would silently promote prose to a key.
  */
 export function normalizeIssueIdentifier(
 	input: string,
@@ -105,9 +84,6 @@ export function normalizeIssueIdentifier(
 	const trimmed = input.trim();
 
 	if (provider === 'beads') {
-		// A bare number only names an issue in databases old enough to have
-		// sequential IDs. Hash-based ones never match, and the input falls
-		// through to being treated as a description.
 		if (isIssueNumber(trimmed)) {
 			return `${teamPrefix.toLowerCase()}-${trimmed}`;
 		}

--- a/source/issue-utils.ts
+++ b/source/issue-utils.ts
@@ -1,5 +1,6 @@
 // Pure utility functions for issue identification
 // These have no side effects and can be easily tested
+import type {TrackerProviderName} from './providers/types.ts';
 
 /**
  * Check if a string looks like a Linear issue key (e.g., STA-123, ENG-456)
@@ -15,25 +16,106 @@ export function isLinearIssueKey(input: string): boolean {
 export const isIssueKey = isLinearIssueKey;
 
 /**
+ * The issue-source prefix of an issue key: everything ahead of the last hyphen,
+ * with any `.N` child suffix dropped first. `STA-123` -> `STA`,
+ * `seatgeek-ticket-management-cli-bqm` -> `seatgeek-ticket-management-cli`.
+ *
+ * Splitting on the last hyphen rather than the first is what admits beads
+ * prefixes, which may contain hyphens of their own. An identifier with no
+ * hyphen yields itself.
+ */
+export function issueKeyPrefix(identifier: string): string {
+	// split always yields at least one element, so index 0 is never undefined.
+	const root = identifier.split('.')[0]!;
+	const lastDash = root.lastIndexOf('-');
+	return lastDash === -1 ? root : root.slice(0, lastDash);
+}
+
+/**
+ * Check if a string is a beads issue ID belonging to one of `prefixes`
+ * (e.g. bd-a1b2, bd-a3f8e9.1, seatgeek-ticket-management-cli-bqm).
+ *
+ * A beads suffix is a content hash and can be pure letters, so shape alone
+ * cannot tell `dark-mode` from an ID. The prefix allowlist is what does; with
+ * no known prefixes, nothing matches.
+ */
+export function isBeadsIssueKey(input: string, prefixes: string[]): boolean {
+	const trimmed = input.trim();
+	if (!/^[a-z\d_]+(-[a-z\d_]+)+(\.\d+){0,3}$/i.test(trimmed)) return false;
+	const prefix = issueKeyPrefix(trimmed).toLowerCase();
+	return prefixes.some(p => p.trim().toLowerCase() === prefix);
+}
+
+/**
  * Check if a string is a bare issue number (e.g., 400, 123)
  */
 export function isIssueNumber(input: string): boolean {
 	return /^\d+$/.test(input.trim());
 }
 
+// The workspace segment is `.+` rather than `[^/]+` to stay in lockstep with
+// config.ts's DETERMINE_PROFILE_LINEAR_URL and idow's own URL parse, both of
+// which accept the extra `/team/` segment Linear sometimes emits.
+const LINEAR_URL_ISSUE_KEY =
+	/^https:\/\/linear\.app\/.+\/issue\/([A-Z][A-Z0-9]*)-\d+/i;
+
 /**
- * Normalize an issue identifier to uppercase format (e.g., STA-400)
+ * Extract the team prefix an issue identifier belongs to (e.g. 'STA' for
+ * 'STA-123'), uppercased. Accepts a bare key or a Linear issue URL.
+ *
+ * Distinct from `issueKeyPrefix`, which answers a different question for a
+ * different grammar: the issue *source* ahead of the last hyphen, verbatim,
+ * for beads IDs that carry hyphens of their own.
+ *
+ * Returns null when the input carries no prefix of its own — bare numbers
+ * borrow one from config, and prose has none — which is the signal callers
+ * use to fall back to prefix-independent behavior.
+ */
+export function issueKeyTeamPrefix(input: string): string | null {
+	const trimmed = input.trim();
+
+	const url = trimmed.match(LINEAR_URL_ISSUE_KEY);
+	if (url) return url[1]!.toUpperCase();
+
+	if (!isLinearIssueKey(trimmed)) return null;
+	return trimmed.split('-')[0]!.toUpperCase();
+}
+
+/**
+ * Normalize an issue identifier to the form its tracker uses.
  * Accepts:
  *   - Bare numbers: '400' -> 'STA-400' (uses teamPrefix)
  *   - Lowercase keys: 'sta-123' -> 'STA-123'
  *   - Mixed case: 'Sta-456' -> 'STA-456'
  * Returns null if input is not a valid issue identifier
+ *
+ * `provider` selects the key grammar. Beads IDs fold to lowercase rather than
+ * uppercase, since that is the only casing `bd` can resolve. `beadsPrefixes` is
+ * the allowlist from `getBeadsPrefixes`; anything outside it is prose, not a
+ * key, and an empty allowlist therefore makes every beads input a description.
+ * Both are required: which grammar applies is not something this function can
+ * guess, and a defaulted allowlist would silently promote prose to a key.
  */
 export function normalizeIssueIdentifier(
 	input: string,
 	teamPrefix: string,
+	provider: TrackerProviderName,
+	beadsPrefixes: string[],
 ): string | null {
 	const trimmed = input.trim();
+
+	if (provider === 'beads') {
+		// A bare number only names an issue in databases old enough to have
+		// sequential IDs. Hash-based ones never match, and the input falls
+		// through to being treated as a description.
+		if (isIssueNumber(trimmed)) {
+			return `${teamPrefix.toLowerCase()}-${trimmed}`;
+		}
+
+		return isBeadsIssueKey(trimmed, beadsPrefixes)
+			? trimmed.toLowerCase()
+			: null;
+	}
 
 	// Bare number: expand with team prefix
 	if (isIssueNumber(trimmed)) {

--- a/source/list-view-sizing.test.ts
+++ b/source/list-view-sizing.test.ts
@@ -1,6 +1,8 @@
 import test from 'ava';
 import {
 	calculateMaxVisibleItems,
+	twoLineTitleIndent,
+	titleSharesKeyLine,
 	calculateScrollOffset,
 	calculateVisibleWindow,
 	calculateAvailableTitleWidth,
@@ -1354,4 +1356,120 @@ test('clipIssueKey with rail icons at the 8-column floor still fits', t => {
 	const trailing = railPrefixWidth(icons);
 	const clipped = clipIssueKey('STA-2040', 8 - ROW_ICON_CELLS - trailing);
 	t.true(ROW_ICON_CELLS + clipped.length + trailing <= 8);
+});
+
+// ============================================================================
+// Two-line layout — each item occupies 2 terminal rows, which halves how many
+// spaces fit and makes both of an item's lines click through to that item.
+// ============================================================================
+
+test('calculateMaxVisibleItems: two-line items halve the capacity', t => {
+	t.is(calculateMaxVisibleItems(8), 6, 'single-line baseline');
+	t.is(calculateMaxVisibleItems(8, 2), 3, '6 rows of content fit 3 items');
+});
+
+test('calculateMaxVisibleItems: an odd leftover row is not a partial item', t => {
+	// 9 - 2 chrome = 7 content rows; the 7th can only hold half an item.
+	t.is(calculateMaxVisibleItems(9, 2), 3);
+});
+
+test('calculateMaxVisibleItems: always yields at least one item', t => {
+	t.is(calculateMaxVisibleItems(3, 2), 1);
+	t.is(calculateMaxVisibleItems(0, 2), 1);
+});
+
+test('calculateMaxVisibleItems: linesPerItem of 1 matches the default', t => {
+	t.is(calculateMaxVisibleItems(20, 1), calculateMaxVisibleItems(20));
+});
+
+test('calculateVisibleWindow: two-line layout shows half as many items', t => {
+	const single = calculateVisibleWindow(0, 20, 12);
+	const double = calculateVisibleWindow(0, 20, 12, 2);
+	t.is(single.visibleCount, 10);
+	t.is(double.visibleCount, 5);
+});
+
+test('calculateVisibleWindow: two-line layout still centers the selection', t => {
+	const {scrollOffset, adjustedSelectedIndex} = calculateVisibleWindow(
+		10,
+		20,
+		12,
+		2,
+	);
+	// maxVisible is 5, so centering puts the selection 2 rows down.
+	t.is(scrollOffset, 8);
+	t.is(adjustedSelectedIndex, 2);
+});
+
+test('calculateListClickRow: both lines of a two-line item select that item', t => {
+	const opts = {bannerHeight: 0, visibleRows: 5, linesPerItem: 2};
+	t.is(calculateListClickRow({...opts, y: 2}), 0, 'key line of item 0');
+	t.is(calculateListClickRow({...opts, y: 3}), 0, 'title line of item 0');
+	t.is(calculateListClickRow({...opts, y: 4}), 1, 'key line of item 1');
+	t.is(calculateListClickRow({...opts, y: 5}), 1, 'title line of item 1');
+});
+
+test('calculateListClickRow: two-line clicks past the last item are rejected', t => {
+	const opts = {bannerHeight: 0, visibleRows: 3, linesPerItem: 2};
+	t.is(calculateListClickRow({...opts, y: 7}), 2, 'title line of last item');
+	t.is(calculateListClickRow({...opts, y: 8}), null, 'one line past the list');
+});
+
+test('calculateListClickRow: two-line layout still rejects header clicks', t => {
+	const opts = {bannerHeight: 0, visibleRows: 5, linesPerItem: 2};
+	t.is(calculateListClickRow({...opts, y: 0}), null);
+	t.is(calculateListClickRow({...opts, y: 1}), null);
+});
+
+test('calculateListClickRow: two-line layout accounts for the banner', t => {
+	const opts = {bannerHeight: 4, visibleRows: 5, linesPerItem: 2};
+	t.is(calculateListClickRow({...opts, y: 6}), 0);
+	t.is(calculateListClickRow({...opts, y: 7}), 0);
+	t.is(calculateListClickRow({...opts, y: 8}), 1);
+});
+
+// ============================================================================
+// twoLineTitleIndent — the title row must start in the same column as the
+// issue key above it, or the two lines read as unrelated rows.
+// ============================================================================
+
+test('twoLineTitleIndent clears the status icon and its space', t => {
+	t.is(twoLineTitleIndent(), 2);
+});
+
+test('twoLineTitleIndent clears a 2-cell emoji prefix too', t => {
+	t.is(twoLineTitleIndent({emoji: '\u{1F35D}', width: 2}), 5);
+});
+
+test('twoLineTitleIndent aligns with where the issue key starts', t => {
+	// renderListRow lays out "<emoji> <icon> <key>"; the indent must equal the
+	// offset of the key within that row.
+	const prefix = {emoji: '\u{1F35D}', width: 2};
+	const row = renderListRow('sta-1', '\u25CF', 'title', 40, undefined, prefix);
+	t.is(row.indexOf('sta-1'), twoLineTitleIndent(prefix));
+});
+
+test('twoLineTitleIndent aligns with the key when there is no emoji', t => {
+	const row = renderListRow('sta-1', '\u25CF', 'title', 40);
+	t.is(row.indexOf('sta-1'), twoLineTitleIndent());
+});
+
+// ============================================================================
+// titleSharesKeyLine — a pending row's progress text ("Starting new session…")
+// has to sit beside the spinner on the first line, not on the indented title
+// line below it.
+// ============================================================================
+
+test('titleSharesKeyLine: single-line layout always shares the row', t => {
+	t.true(titleSharesKeyLine({isTwoLine: false}));
+	t.true(titleSharesKeyLine({isTwoLine: false, isPending: true}));
+});
+
+test('titleSharesKeyLine: two-line layout gives real spaces their own title row', t => {
+	t.false(titleSharesKeyLine({isTwoLine: true}));
+	t.false(titleSharesKeyLine({isTwoLine: true, isPending: false}));
+});
+
+test('titleSharesKeyLine: two-line pending rows keep the text on the key line', t => {
+	t.true(titleSharesKeyLine({isTwoLine: true, isPending: true}));
 });

--- a/source/list-view-sizing.ts
+++ b/source/list-view-sizing.ts
@@ -19,11 +19,6 @@ export const LIST_CHROME_ROWS = HEADER_ROWS;
 /** Fixed-width characters per row (excluding issue key): icon(1) + space(1) + space(1) = 3 */
 export const ROW_FIXED_OVERHEAD = 3;
 
-/**
- * Terminal rows one list item occupies. Two, and only two, because that is how
- * many layouts `list_view.layout` offers; typing it as a union rather than a
- * number is what lets the scroll math divide by it without a floor guard.
- */
 export type LinesPerItem = 1 | 2;
 
 // ============================================================================
@@ -168,10 +163,6 @@ export function rowPrefixWidth(prefix?: RowPrefix): number {
 /**
  * Columns the two-line layout indents its title row by, so the title starts
  * under the issue key rather than under the status icon.
- *
- * Built from the cells actually ahead of the key — the emoji prefix and the
- * status icon with its trailing space — rather than from `ROW_FIXED_OVERHEAD`,
- * which also counts the space *after* the key and so overshoots by one here.
  */
 export function twoLineTitleIndent(prefix?: RowPrefix): number {
 	return rowPrefixWidth(prefix) + ROW_ICON_CELLS;

--- a/source/list-view-sizing.ts
+++ b/source/list-view-sizing.ts
@@ -19,6 +19,13 @@ export const LIST_CHROME_ROWS = HEADER_ROWS;
 /** Fixed-width characters per row (excluding issue key): icon(1) + space(1) + space(1) = 3 */
 export const ROW_FIXED_OVERHEAD = 3;
 
+/**
+ * Terminal rows one list item occupies. Two, and only two, because that is how
+ * many layouts `list_view.layout` offers; typing it as a union rather than a
+ * number is what lets the scroll math divide by it without a floor guard.
+ */
+export type LinesPerItem = 1 | 2;
+
 // ============================================================================
 // Scrolling / visibility
 // ============================================================================
@@ -27,10 +34,17 @@ export const ROW_FIXED_OVERHEAD = 3;
  * Calculate how many list items can be displayed given the terminal height.
  *
  * @param termHeight - Height of the list pane in rows
+ * @param linesPerItem - Terminal rows each item occupies (2 in two-line layout)
  * @returns Maximum number of items that fit
  */
-export function calculateMaxVisibleItems(termHeight: number): number {
-	return Math.max(1, termHeight - LIST_CHROME_ROWS);
+export function calculateMaxVisibleItems(
+	termHeight: number,
+	linesPerItem: LinesPerItem = 1,
+): number {
+	return Math.max(
+		1,
+		Math.floor((termHeight - LIST_CHROME_ROWS) / linesPerItem),
+	);
 }
 
 /**
@@ -64,12 +78,13 @@ export function calculateVisibleWindow(
 	selectedIndex: number,
 	totalItems: number,
 	termHeight: number,
+	linesPerItem: LinesPerItem = 1,
 ): {
 	scrollOffset: number;
 	visibleCount: number;
 	adjustedSelectedIndex: number;
 } {
-	const maxVisible = calculateMaxVisibleItems(termHeight);
+	const maxVisible = calculateMaxVisibleItems(termHeight, linesPerItem);
 	const scrollOffset = calculateScrollOffset(
 		selectedIndex,
 		totalItems,
@@ -88,15 +103,22 @@ export function calculateVisibleWindow(
  * constant — the caller passes the current measured height (0 when the
  * banner is hidden). Returns null when the click is on chrome (banner /
  * header) or below the visible rows.
+ *
+ * `visibleRows` counts items, not terminal lines: with a `linesPerItem` of 2,
+ * a click on either of an item's two lines selects that one item.
  */
 export function calculateListClickRow(options: {
 	y: number;
 	bannerHeight: number;
 	visibleRows: number;
+	linesPerItem?: LinesPerItem;
 }): number | null {
+	const perItem = options.linesPerItem ?? 1;
 	const headerOffset = options.bannerHeight + HEADER_ROWS;
-	const row = options.y - headerOffset;
-	if (row < 0 || row >= options.visibleRows) return null;
+	const line = options.y - headerOffset;
+	if (line < 0) return null;
+	const row = Math.floor(line / perItem);
+	if (row >= options.visibleRows) return null;
 	return row;
 }
 
@@ -141,6 +163,25 @@ export function rowPrefixWidth(prefix?: RowPrefix): number {
 	if (!prefix?.emoji) return 0;
 	const width = prefix.width ?? 2;
 	return width + 1; // emoji + trailing space
+}
+
+/**
+ * Columns the two-line layout indents its title row by, so the title starts
+ * under the issue key rather than under the status icon.
+ *
+ * Built from the cells actually ahead of the key — the emoji prefix and the
+ * status icon with its trailing space — rather than from `ROW_FIXED_OVERHEAD`,
+ * which also counts the space *after* the key and so overshoots by one here.
+ */
+export function twoLineTitleIndent(prefix?: RowPrefix): number {
+	return rowPrefixWidth(prefix) + ROW_ICON_CELLS;
+}
+
+export function titleSharesKeyLine(options: {
+	isTwoLine: boolean;
+	isPending?: boolean;
+}): boolean {
+	return !options.isTwoLine || options.isPending === true;
 }
 
 /**

--- a/source/open-issue.test.ts
+++ b/source/open-issue.test.ts
@@ -1,0 +1,73 @@
+import test from 'ava';
+import {openIssueForKey} from './open-issue.ts';
+
+const urlTracker = {
+	buildIssueUrl: (issueKey: string) => `https://example.test/${issueKey}`,
+};
+
+test('a tracker that shows issues in place is used instead of the browser', t => {
+	const opened: string[] = [];
+	const shown: string[] = [];
+
+	const result = openIssueForKey('bd-a1b2', {
+		createTracker: () => ({
+			...urlTracker,
+			openIssue(issueKey: string) {
+				shown.push(issueKey);
+				return true;
+			},
+		}),
+		openUrl: (url: string) => opened.push(url),
+	});
+
+	t.deepEqual(shown, ['bd-a1b2']);
+	t.deepEqual(opened, []);
+	t.deepEqual(result, {ok: true, message: 'Showing bd-a1b2'});
+});
+
+test('an in-place tracker that cannot display reports it without falling back to the browser', t => {
+	const opened: string[] = [];
+
+	const result = openIssueForKey('bd-a1b2', {
+		createTracker: () => ({...urlTracker, openIssue: () => false}),
+		openUrl: (url: string) => opened.push(url),
+	});
+
+	t.deepEqual(opened, []);
+	t.deepEqual(result, {ok: false, message: 'Cannot show issue outside tmux'});
+});
+
+test('a tracker with a web UI opens the issue URL', t => {
+	const opened: string[] = [];
+
+	const result = openIssueForKey('STA-123', {
+		createTracker: () => urlTracker,
+		openUrl: (url: string) => opened.push(url),
+	});
+
+	t.deepEqual(opened, ['https://example.test/STA-123']);
+	t.deepEqual(result, {ok: true, message: 'Opened STA-123'});
+});
+
+test('a tracker that cannot be constructed fails without throwing', t => {
+	const result = openIssueForKey('STA-123', {
+		createTracker() {
+			throw new Error('no tracker configured');
+		},
+	});
+
+	t.deepEqual(result, {ok: false, message: 'Failed to look up issue'});
+});
+
+test('a URL that cannot be built fails without throwing', t => {
+	const result = openIssueForKey('STA-123', {
+		createTracker: () => ({
+			buildIssueUrl() {
+				throw new Error('no base_url');
+			},
+		}),
+		openUrl: () => undefined,
+	});
+
+	t.deepEqual(result, {ok: false, message: 'Failed to look up issue'});
+});

--- a/source/open-issue.ts
+++ b/source/open-issue.ts
@@ -20,22 +20,12 @@ export interface OpenIssueResult {
 function launchBrowser(url: string): void {
 	const child = spawn('open', [url], {detached: true, stdio: 'ignore'});
 
-	// A missing opener binary — anywhere `open` isn't the name, so anywhere but
-	// macOS — surfaces asynchronously, long after this has returned success. With
-	// no listener Node rethrows it and takes the whole TUI down over a failed
-	// browser launch, so swallow it: the worst case is a browser that never
-	// appears, which the user can see for themselves.
 	child.on('error', () => {});
 	child.unref();
 }
 
 /**
  * Show an issue to the user, wherever that tracker's issues live.
- *
- * Local-only trackers (beads) have no web page, so they render into a tmux
- * popup via `openIssue` and report false when there's no tmux to draw into.
- * That is a dead end rather than a reason to fall back — there is no URL to
- * open — so the failure is surfaced instead of retried in a browser.
  */
 export function openIssueForKey(
 	issueKey: string,

--- a/source/open-issue.ts
+++ b/source/open-issue.ts
@@ -1,0 +1,60 @@
+import {spawn} from 'node:child_process';
+import {createIssueTracker} from './providers/index.ts';
+import type {IssueTrackerProvider} from './providers/types.ts';
+
+/** The slice of the provider this needs, so callers can stub it in tests. */
+type OpenableTracker = Pick<IssueTrackerProvider, 'buildIssueUrl'> &
+	Partial<Pick<IssueTrackerProvider, 'openIssue'>>;
+
+export interface OpenIssueDeps {
+	createTracker?: () => OpenableTracker;
+	openUrl?: (url: string) => void;
+}
+
+export interface OpenIssueResult {
+	ok: boolean;
+	/** Ready to hand straight to a header or an inline error line. */
+	message: string;
+}
+
+function launchBrowser(url: string): void {
+	const child = spawn('open', [url], {detached: true, stdio: 'ignore'});
+
+	// A missing opener binary — anywhere `open` isn't the name, so anywhere but
+	// macOS — surfaces asynchronously, long after this has returned success. With
+	// no listener Node rethrows it and takes the whole TUI down over a failed
+	// browser launch, so swallow it: the worst case is a browser that never
+	// appears, which the user can see for themselves.
+	child.on('error', () => {});
+	child.unref();
+}
+
+/**
+ * Show an issue to the user, wherever that tracker's issues live.
+ *
+ * Local-only trackers (beads) have no web page, so they render into a tmux
+ * popup via `openIssue` and report false when there's no tmux to draw into.
+ * That is a dead end rather than a reason to fall back — there is no URL to
+ * open — so the failure is surfaced instead of retried in a browser.
+ */
+export function openIssueForKey(
+	issueKey: string,
+	deps: OpenIssueDeps = {},
+): OpenIssueResult {
+	const createTracker = deps.createTracker ?? createIssueTracker;
+	const openUrl = deps.openUrl ?? launchBrowser;
+
+	try {
+		const tracker = createTracker();
+		if (tracker.openIssue) {
+			return tracker.openIssue(issueKey)
+				? {ok: true, message: `Showing ${issueKey}`}
+				: {ok: false, message: 'Cannot show issue outside tmux'};
+		}
+
+		openUrl(tracker.buildIssueUrl(issueKey));
+		return {ok: true, message: `Opened ${issueKey}`};
+	} catch {
+		return {ok: false, message: 'Failed to look up issue'};
+	}
+}

--- a/source/profile-picker.test.ts
+++ b/source/profile-picker.test.ts
@@ -7,7 +7,10 @@ import {
 	focusFrame,
 	PICKER_MAX_VISIBLE,
 } from './profile-picker.ts';
-import type {PappardelleConfig} from './config.ts';
+import {
+	DEFERRED_PROFILE_DISPLAY_NAME,
+	type PappardelleConfig,
+} from './config.ts';
 
 // ============================================================================
 // Test helpers
@@ -16,15 +19,23 @@ import type {PappardelleConfig} from './config.ts';
 function makeConfig(
 	profiles: Record<
 		string,
-		{display_name: string; keywords?: string[]; emoji?: string}
+		{
+			display_name: string;
+			keywords?: string[];
+			emoji?: string;
+			team_prefix?: string;
+			tracker_projects?: string[];
+		}
 	>,
 	defaultProfile?: string,
 	defaultEmoji?: string,
+	teamPrefix?: string,
 ): PappardelleConfig {
 	return {
 		version: 1,
 		default_profile: defaultProfile,
 		default_emoji: defaultEmoji,
+		team_prefix: teamPrefix,
 		profiles,
 	} as unknown as PappardelleConfig;
 }
@@ -53,12 +64,11 @@ test('buildProfileOptions puts the keyword-matched profile first', t => {
 test('buildProfileOptions lists every profile exactly once', t => {
 	const options = buildProfileOptions(CONFIG, 'fix the stardust map crash');
 	t.is(options.length, 4);
-	t.deepEqual(options.map(o => o.name).sort(), [
-		'hive',
-		'platform',
-		'stardust',
-		'trotbooks',
-	]);
+	// Sorted with an explicit comparator because an option's name is nullable —
+	// the profile-less row exists, just never on the keyword path.
+	const names = options.map(o => o.name);
+	names.sort((a, b) => String(a).localeCompare(String(b)));
+	t.deepEqual(names, ['hive', 'platform', 'stardust', 'trotbooks']);
 });
 
 test('buildProfileOptions falls back to the default profile when nothing matches', t => {
@@ -199,6 +209,186 @@ test('buildProfileOptions on a single-profile config yields one option', t => {
 });
 
 // ============================================================================
+// buildProfileOptions — issue-key prefixes
+//
+// An issue key is a name, not a description, so there are no keywords to score
+// it against. Its prefix still says which profiles could own it, and the
+// picker ranks on that instead — behind a leading row that names no profile at
+// all, so Enter-Enter keeps idow's tracker-project lookup.
+// ============================================================================
+
+const PREFIX_CONFIG = makeConfig(
+	{
+		platform: {display_name: 'Platform', keywords: ['platform']},
+		stardust: {
+			display_name: 'Stardust Jams',
+			keywords: ['stardust'],
+			team_prefix: 'SDJ',
+		},
+		hive: {
+			display_name: 'The Hive',
+			keywords: ['hive'],
+			tracker_projects: ['KAN'],
+		},
+	},
+	'platform',
+	undefined,
+	'STA',
+);
+
+test('buildProfileOptions leads an issue key with the profile-less row', t => {
+	const options = buildProfileOptions(PREFIX_CONFIG, 'SDJ-42');
+	t.is(options[0]!.name, null);
+	t.is(options[0]!.displayName, DEFERRED_PROFILE_DISPLAY_NAME);
+});
+
+test('buildProfileOptions ranks the profile owning the key prefix first', t => {
+	const options = buildProfileOptions(PREFIX_CONFIG, 'SDJ-42');
+	t.is(options[1]!.name, 'stardust');
+	t.is(options[1]!.matchedPrefix, 'SDJ');
+});
+
+test('buildProfileOptions treats a tracker_projects entry as a project key claim', t => {
+	// Jira issue keys ARE their project key, so `tracker_projects: [KAN]` and
+	// `KAN-12` are the same statement about ownership.
+	const options = buildProfileOptions(PREFIX_CONFIG, 'KAN-12');
+	t.is(options[1]!.name, 'hive');
+	t.is(options[1]!.matchedPrefix, 'KAN');
+});
+
+test('buildProfileOptions treats profiles with no team_prefix as claiming the global one', t => {
+	const options = buildProfileOptions(PREFIX_CONFIG, 'STA-7');
+	// stardust declared SDJ, so it does not claim STA and drops to the tail.
+	t.deepEqual(
+		options.map(o => o.name),
+		[null, 'platform', 'hive', 'stardust'],
+	);
+	// Inheritance is not a statement about this key, so it earns no hint.
+	t.is(options[1]!.matchedPrefix, undefined);
+});
+
+test('buildProfileOptions ranks explicit prefix claims above inherited ones', t => {
+	const config = makeConfig(
+		{
+			platform: {display_name: 'Platform'},
+			stardust: {display_name: 'Stardust Jams', team_prefix: 'STA'},
+		},
+		'platform',
+		undefined,
+		'STA',
+	);
+	const options = buildProfileOptions(config, 'STA-9');
+	t.deepEqual(
+		options.map(o => o.name),
+		[null, 'stardust', 'platform'],
+	);
+});
+
+test('buildProfileOptions still lists every profile for a claimed prefix', t => {
+	const options = buildProfileOptions(PREFIX_CONFIG, 'SDJ-42');
+	t.deepEqual(
+		options.map(o => o.name),
+		[null, 'stardust', 'platform', 'hive'],
+	);
+});
+
+test('buildProfileOptions reads the prefix out of a Linear issue URL', t => {
+	const options = buildProfileOptions(
+		PREFIX_CONFIG,
+		'https://linear.app/acme/issue/SDJ-42/some-slug',
+	);
+	t.is(options[1]!.name, 'stardust');
+	t.is(options[1]!.matchedPrefix, 'SDJ');
+});
+
+test('buildProfileOptions leaves an unclaimed prefix on the keyword path', t => {
+	const options = buildProfileOptions(PREFIX_CONFIG, 'ZZZ-1');
+	t.is(options[0]!.name, 'platform');
+	t.true(options[0]!.isDefault);
+});
+
+test('buildProfileOptions ignores prefixes for bare numbers', t => {
+	// '42' means STA-42 only after config expands it, and the profile that
+	// expansion implies is exactly what idow is better placed to decide.
+	const options = buildProfileOptions(PREFIX_CONFIG, '42');
+	t.is(options[0]!.name, 'platform');
+});
+
+// beads IDs — beads profiles are not 1:1 with issue trackers: one database
+// backs work belonging to several profiles, so the tracker-project lookup that
+// serves Linear and Jira can only guess here. The choice has to be on screen.
+
+const BEADS_CONFIG: PappardelleConfig = {
+	...makeConfig(
+		{
+			// Both name a prefix of their own, so neither inherits 'pap'.
+			platform: {
+				display_name: 'Platform',
+				keywords: ['platform'],
+				team_prefix: 'STA',
+			},
+			stardust: {
+				display_name: 'Stardust Jams',
+				keywords: ['stardust'],
+				team_prefix: 'SDJ',
+			},
+			vendor: {
+				display_name: 'Vendor SDK',
+				team_prefix: 'VEN',
+				tracker_projects: ['vendor-sdk'],
+			},
+		},
+		'platform',
+		undefined,
+		'pap',
+	),
+	issue_tracker: {provider: 'beads'},
+};
+
+test('resolvePromptSubmit opens the picker for a beads ID nothing claims', t => {
+	const result = resolvePromptSubmit(BEADS_CONFIG, 'pap-a1b2');
+	t.is(result.kind, 'pick');
+	if (result.kind !== 'pick') return;
+	// The preselected row names a real profile — the same one idow falls back
+	// to — rather than a deferred lookup with nothing to resolve against.
+	t.is(result.options[0]!.name, 'platform');
+	t.true(result.options[0]!.isDefault);
+});
+
+test('buildProfileOptions omits the deferred row for a beads ID nothing claims', t => {
+	const options = buildProfileOptions(BEADS_CONFIG, 'pap-a1b2');
+	t.false(options.some(o => o.name === null));
+	t.deepEqual(
+		options.map(o => o.name),
+		['platform', 'stardust', 'vendor'],
+	);
+});
+
+test('buildProfileOptions leads a claimed beads prefix with the deferred row', t => {
+	// 'vendor-sdk' is spelled in tracker_projects, so idow's lookup does resolve
+	// it and stays the preselected answer — the picker only adds the override.
+	const options = buildProfileOptions(BEADS_CONFIG, 'vendor-sdk-a1b2');
+	t.is(options[0]!.name, null);
+	t.is(options[0]!.displayName, DEFERRED_PROFILE_DISPLAY_NAME);
+	t.is(options[1]!.name, 'vendor');
+	t.is(options[1]!.matchedPrefix, 'vendor-sdk');
+});
+
+test('resolvePromptSubmit opens the picker for a claimed beads prefix', t => {
+	const result = resolvePromptSubmit(BEADS_CONFIG, 'vendor-sdk-a1b2');
+	t.is(result.kind, 'pick');
+});
+
+test('resolvePromptSubmit leaves beads-shaped prose on the keyword path', t => {
+	// 'stardust-crash' names no beads prefix, so it is a description and the
+	// keyword match leads.
+	const result = resolvePromptSubmit(BEADS_CONFIG, 'stardust-crash');
+	t.is(result.kind, 'pick');
+	if (result.kind !== 'pick') return;
+	t.is(result.options[0]!.name, 'stardust');
+});
+
+// ============================================================================
 // resolvePromptSubmit — which inputs open the picker
 // ============================================================================
 
@@ -209,19 +399,35 @@ test('resolvePromptSubmit opens the picker for a free-text prompt', t => {
 	t.is(result.options[0]!.name, 'stardust');
 });
 
-test('resolvePromptSubmit spawns immediately for an issue key, deferring the profile', t => {
-	// Regression guard: issue-key inputs must behave exactly as they did before
-	// the picker existed — one Enter, no --profile flag, so idow resolves the
-	// profile from the fetched issue's tracker project.
+test('resolvePromptSubmit spawns immediately for inputs carrying no key prefix', t => {
+	// A bare number borrows its prefix from config rather than stating one, so
+	// there is no prefix to match profiles against — behaves exactly as it did
+	// before the picker existed: one Enter, no --profile flag, so idow resolves
+	// the profile from the fetched issue's tracker project.
+	const result = resolvePromptSubmit(CONFIG, '123');
+	t.is(result.kind, 'spawn');
+	if (result.kind !== 'spawn') return;
+	t.is(result.profileName, null);
+});
+
+test('resolvePromptSubmit spawns immediately for an issue key no profile claims', t => {
+	const result = resolvePromptSubmit(CONFIG, 'ZZZ-123');
+	t.is(result.kind, 'spawn');
+	if (result.kind !== 'spawn') return;
+	t.is(result.profileName, null);
+});
+
+test('resolvePromptSubmit opens the picker for an issue key whose prefix is claimed', t => {
 	for (const input of [
 		'STA-123',
-		'123',
 		'https://linear.app/acme/issue/STA-123/some-slug',
 	]) {
 		const result = resolvePromptSubmit(CONFIG, input);
-		t.is(result.kind, 'spawn');
-		if (result.kind !== 'spawn') continue;
-		t.is(result.profileName, null);
+		t.is(result.kind, 'pick');
+		if (result.kind !== 'pick') continue;
+		// The deferred lookup leads, so Enter-Enter still spawns with no
+		// --profile — the picker only adds the ability to override it.
+		t.is(result.options[0]!.name, null);
 	}
 });
 
@@ -237,7 +443,7 @@ test('resolvePromptSubmit spawns with no profile when config failed to load', t 
 });
 
 test('resolvePromptSubmit trims surrounding whitespace before deciding', t => {
-	const result = resolvePromptSubmit(CONFIG, '  STA-123  ');
+	const result = resolvePromptSubmit(CONFIG, '  ZZZ-123  ');
 	t.is(result.kind, 'spawn');
 });
 
@@ -417,6 +623,14 @@ test('buildProfileOptions reserves a blank slot for an emoji-less profile when s
 	// still line up. Only `undefined` means "no slot at all".
 	const options = buildProfileOptions(EMOJI_CONFIG, 'stardust');
 	t.is(options.find(o => o.name === 'hive')!.emoji, '');
+});
+
+test('buildProfileOptions reserves the emoji slot on the profile-less row too', t => {
+	// It leads the list for issue keys, so if it skipped the slot the row you
+	// land on first would be the one hanging two columns left of the rest.
+	const options = buildProfileOptions(EMOJI_CONFIG, 'STA-1');
+	t.is(options[0]!.name, null);
+	t.is(options[0]!.emoji, '');
 });
 
 test('buildProfileOptions leaves emoji undefined when no profile configures one', t => {

--- a/source/profile-picker.ts
+++ b/source/profile-picker.ts
@@ -25,23 +25,13 @@ import {
 export const PICKER_MAX_VISIBLE = 4;
 
 export type ProfileOption = {
-	/**
-	 * `profile` rows spawn under their own name. The single `deferred` row names
-	 * no profile and lets idow resolve one from the fetched issue's tracker
-	 * project (issue-key inputs only) — a distinct kind of row rather than a null
-	 * name, so the renderer never has to read "no name" as "not a profile".
-	 */
 	kind: 'profile' | 'deferred';
 	/** The `--profile` value this row spawns under; null for the deferred row. */
 	name: string | null;
 	displayName: string;
 	/** Keywords in the prompt that selected this profile; empty for non-matches. */
 	matchedKeywords: string[];
-	/**
-	 * The issue-key prefix this profile claims by name, when that is why it is
-	 * ranked where it is. Unset for keyword matches, for profiles that merely
-	 * inherit the global prefix, and for the tail of the list.
-	 */
+	/** The issue-key prefix this profile claims by name. */
 	matchedPrefix?: string;
 	/** True for the config's `default_profile`, wherever it lands in the list. */
 	isDefault: boolean;
@@ -56,11 +46,6 @@ export type ProfileOption = {
 	emoji: string | undefined;
 };
 
-/**
- * The row that names no profile, so idow resolves one from the fetched issue's
- * tracker project. It leads the list for issue-key inputs, which keeps
- * Enter-Enter on a key byte-identical to the single Enter it used to be.
- */
 export function deferredOption(config: PappardelleConfig): ProfileOption {
 	return {
 		kind: 'deferred',
@@ -69,9 +54,6 @@ export function deferredOption(config: PappardelleConfig): ProfileOption {
 		matchedKeywords: [],
 		isDefault: false,
 		enforced: false,
-		// Owns no profile, so it owns no emoji — but it still has to reserve the
-		// slot its emoji-bearing neighbors occupy, or the one row you land on
-		// first is the one hanging two columns left of the rest.
 		emoji: getProfileEmoji(undefined, config),
 	};
 }
@@ -212,10 +194,6 @@ export function resolvePromptSubmit(
 	const selection = determineProfileForInput(config, trimmed);
 	if (!selection) return {kind: 'spawn', profileName: null};
 
-	// A Linear/Jira key whose prefix nobody claims has nothing to choose between,
-	// so it keeps the one-Enter spawn it always had; anything else — a claimed
-	// prefix, or any beads key, where one database backs several profiles — goes
-	// to the picker with the current inference merely preselected.
 	if (selection.kind === 'deferred' && !selection.canPick) {
 		return {kind: 'spawn', profileName: null};
 	}

--- a/source/profile-picker.ts
+++ b/source/profile-picker.ts
@@ -1,14 +1,17 @@
 import {
 	determineProfileForInput,
 	matchProfiles,
+	matchProfilesByInputKeyPrefix,
 	getDefaultProfile,
 	getProfileEmoji,
+	DEFERRED_PROFILE_DISPLAY_NAME,
+	inputKeyPrefix,
 	type PappardelleConfig,
 } from './config.ts';
 
 /**
  * The new-session flow used to be one keystroke: type a prompt, hit Enter, and
- * whatever profile the keywords happened to match is what you got — the only
+ * whatever profile the keywords happened to match is what you got, and the only
  * way to override it was to bend the prompt text around a keyword. This module
  * backs a second stage where that inferred profile is merely the *pre-selected*
  * entry in a list of every profile, so overriding costs an arrow key instead of
@@ -18,26 +21,60 @@ import {
  * without rendering Ink.
  */
 
-/** Rows of the picker visible at once — a screen-size compromise, not a limit. */
+/** Rows of the picker visible at once. Longer lists scroll. */
 export const PICKER_MAX_VISIBLE = 4;
 
 export type ProfileOption = {
-	name: string;
+	/**
+	 * `profile` rows spawn under their own name. The single `deferred` row names
+	 * no profile and lets idow resolve one from the fetched issue's tracker
+	 * project (issue-key inputs only) — a distinct kind of row rather than a null
+	 * name, so the renderer never has to read "no name" as "not a profile".
+	 */
+	kind: 'profile' | 'deferred';
+	/** The `--profile` value this row spawns under; null for the deferred row. */
+	name: string | null;
 	displayName: string;
 	/** Keywords in the prompt that selected this profile; empty for non-matches. */
 	matchedKeywords: string[];
+	/**
+	 * The issue-key prefix this profile claims by name, when that is why it is
+	 * ranked where it is. Unset for keyword matches, for profiles that merely
+	 * inherit the global prefix, and for the tail of the list.
+	 */
+	matchedPrefix?: string;
 	/** True for the config's `default_profile`, wherever it lands in the list. */
 	isDefault: boolean;
 	/** True when a `keyword!` in the prompt forced this profile to the front. */
 	enforced: boolean;
 	/**
 	 * Ticket-rail emoji slot for this profile, with the rail's exact three-state
-	 * semantics — `undefined` for "nobody configured an emoji", `''` for "slot
+	 * semantics: `undefined` for "nobody configured an emoji", `''` for "slot
 	 * reserved but empty". Resolved here rather than in the component so the
 	 * picker and the rail always agree about which profile wears which glyph.
 	 */
 	emoji: string | undefined;
 };
+
+/**
+ * The row that names no profile, so idow resolves one from the fetched issue's
+ * tracker project. It leads the list for issue-key inputs, which keeps
+ * Enter-Enter on a key byte-identical to the single Enter it used to be.
+ */
+export function deferredOption(config: PappardelleConfig): ProfileOption {
+	return {
+		kind: 'deferred',
+		name: null,
+		displayName: DEFERRED_PROFILE_DISPLAY_NAME,
+		matchedKeywords: [],
+		isDefault: false,
+		enforced: false,
+		// Owns no profile, so it owns no emoji — but it still has to reserve the
+		// slot its emoji-bearing neighbors occupy, or the one row you land on
+		// first is the one hanging two columns left of the rest.
+		emoji: getProfileEmoji(undefined, config),
+	};
+}
 
 /**
  * Order every profile for the picker: the profile that would have been chosen
@@ -51,9 +88,17 @@ export type ProfileOption = {
  * sits first for a blank prompt and eleventh for a matched one, which puts the
  * most-used fallback out of reach exactly when the guess is most likely wrong.
  *
- * The tail is deliberately *not* sorted alphabetically — config order is the
- * order the user wrote their profiles in, which is the closest thing we have to
- * their own sense of priority.
+ * For an issue key the ranking comes from the key's prefix rather than
+ * keywords, behind the deferred row — a key is a name, not a description, so
+ * there are no keywords to score, but the prefix still says which profiles
+ * could own it. Beads IDs carry a prefix too — the issue source ahead of the
+ * last hyphen — but a database nobody named in `tracker_projects` is claimed by
+ * no profile, so its key falls through to the default-led list rather than
+ * leading with a deferred row that resolves to nothing.
+ *
+ * The tail keeps config declaration order rather than sorting alphabetically:
+ * that is the order the user wrote their profiles in, which is the closest thing
+ * we have to their own sense of priority.
  */
 export function buildProfileOptions(
 	config: PappardelleConfig,
@@ -72,13 +117,16 @@ export function buildProfileOptions(
 		name: string,
 		matchedKeywords: string[],
 		enforced: boolean,
+		matchedPrefix?: string,
 	): ProfileOption | null => {
 		const profile = config.profiles[name];
 		if (!profile) return null;
 		return {
+			kind: 'profile',
 			name,
 			displayName: profile.display_name,
 			matchedKeywords,
+			...(matchedPrefix ? {matchedPrefix} : {}),
 			isDefault: name === defaultName,
 			enforced,
 			emoji: getProfileEmoji(profile, config),
@@ -87,6 +135,24 @@ export function buildProfileOptions(
 
 	const ordered: ProfileOption[] = [];
 	const seen = new Set<string>();
+
+	const prefix = inputKeyPrefix(config, trimmed);
+	const prefixMatches = matchProfilesByInputKeyPrefix(config, trimmed);
+	if (prefixMatches.length > 0) {
+		ordered.push(deferredOption(config));
+		for (const match of prefixMatches) {
+			const option = toOption(
+				match.name,
+				[],
+				false,
+				match.explicit && prefix ? prefix : undefined,
+			);
+			if (option && !seen.has(match.name)) {
+				seen.add(match.name);
+				ordered.push(option);
+			}
+		}
+	}
 
 	for (const match of matches) {
 		const option = toOption(match.name, match.matchedKeywords, match.enforced);
@@ -117,12 +183,13 @@ export function buildProfileOptions(
 }
 
 export type PromptSubmit =
-	/** Blank input — stay where you are. */
+	/** Blank input: stay where you are. */
 	| {kind: 'none'}
 	/**
-	 * Spawn without showing the picker. Used for issue keys, bare numbers, and
-	 * Linear URLs, where the profile is resolved downstream by idow from the
-	 * fetched issue's tracker project — there is nothing meaningful to preselect.
+	 * Spawn without showing the picker. Used for bare numbers and for issue keys
+	 * whose prefix no profile claims, where the profile is resolved downstream by
+	 * idow from the fetched issue's tracker project — there is nothing meaningful
+	 * to preselect.
 	 */
 	| {kind: 'spawn'; profileName: string | null}
 	/** Advance to the picker with these options, index 0 preselected. */
@@ -130,8 +197,9 @@ export type PromptSubmit =
 
 /**
  * Decide what the first Enter does. Keeping this separate from the component
- * makes the backwards-compatibility guarantee (issue keys still spawn on a
- * single Enter with no `--profile`) something a test can pin down.
+ * makes the backwards-compatibility guarantee (an unclaimed issue key still
+ * spawns on a single Enter with no `--profile`, and a claimed one still spawns
+ * that way on Enter-Enter) something a test can pin down.
  */
 export function resolvePromptSubmit(
 	config: PappardelleConfig | null,
@@ -142,13 +210,22 @@ export function resolvePromptSubmit(
 	if (!config) return {kind: 'spawn', profileName: null};
 
 	const selection = determineProfileForInput(config, trimmed);
-	if (!selection || selection.kind === 'deferred') {
+	if (!selection) return {kind: 'spawn', profileName: null};
+
+	// A Linear/Jira key whose prefix nobody claims has nothing to choose between,
+	// so it keeps the one-Enter spawn it always had; anything else — a claimed
+	// prefix, or any beads key, where one database backs several profiles — goes
+	// to the picker with the current inference merely preselected.
+	if (selection.kind === 'deferred' && !selection.canPick) {
 		return {kind: 'spawn', profileName: null};
 	}
 
 	const options = buildProfileOptions(config, trimmed);
 	if (options.length === 0) {
-		return {kind: 'spawn', profileName: selection.name};
+		return {
+			kind: 'spawn',
+			profileName: selection.kind === 'resolved' ? selection.name : null,
+		};
 	}
 
 	return {kind: 'pick', options};
@@ -157,7 +234,7 @@ export function resolvePromptSubmit(
 export type PickerWindow = {
 	start: number;
 	end: number;
-	/** Items scrolled off the top — drives the "↑ N more" affordance. */
+	/** Items scrolled off the top; drives the "↑ N more" affordance. */
 	above: number;
 	/** Items scrolled off the bottom. */
 	below: number;
@@ -200,7 +277,7 @@ type PickerKey = {
 };
 
 /**
- * Movement clamps rather than wraps, matching the main space list — arrowing
+ * Movement clamps rather than wraps, matching the main space list: arrowing
  * past the end of a four-item list should not silently teleport you back to the
  * profile you were trying to move away from.
  */
@@ -234,7 +311,7 @@ export function handleProfilePickerKey(
  * Which of the two stacked frames owns the double outline.
  *
  * Both boxes are on screen at all times, so the outline is the only thing
- * telling you where your keystrokes are going — the focused box gets the heavy
+ * telling you where your keystrokes are going. The focused box gets the heavy
  * double rule at full brightness, the idle one a dim round rule.
  */
 export function focusFrame(isFocused: boolean): {

--- a/source/providers.test.ts
+++ b/source/providers.test.ts
@@ -4,6 +4,7 @@ import {
 	createVcsHost,
 	resetProviders,
 } from './providers/index.ts';
+import {claimIssue} from './tracker.ts';
 
 // Tests must be serial because they share singleton state
 test.beforeEach(() => {
@@ -35,6 +36,39 @@ test.serial(
 			base_url: 'https://mycompany.atlassian.net',
 		});
 		t.is(provider.name, 'jira');
+	},
+);
+
+test.serial('createIssueTracker returns BeadsProvider for beads config', t => {
+	const provider = createIssueTracker({provider: 'beads'});
+	t.is(provider.name, 'beads');
+});
+
+test.serial('createIssueTracker needs no base_url for beads', t => {
+	// Beads is local — there is no host to point at.
+	t.notThrows(() => createIssueTracker({provider: 'beads'}));
+});
+
+test.serial(
+	'createIssueTracker throws when re-initialized from beads to jira',
+	t => {
+		createIssueTracker({provider: 'beads'});
+		t.throws(
+			() =>
+				createIssueTracker({
+					provider: 'jira',
+					base_url: 'https://example.com',
+				}),
+			{message: /already initialized as "beads"/},
+		);
+	},
+);
+
+test.serial(
+	'createIssueTracker with no config returns existing Beads singleton',
+	t => {
+		const beads = createIssueTracker({provider: 'beads'});
+		t.is(createIssueTracker(), beads);
 	},
 );
 
@@ -181,5 +215,33 @@ test.serial(
 			base_url: 'https://example.com',
 		});
 		t.is(b.name, 'jira');
+	},
+);
+
+// ============================================================================
+// claimIssue capability
+// ============================================================================
+
+test.serial('only beads advertises claimIssue', t => {
+	// Regression: an unconditional `bd update --claim` at the call site fired
+	// for Linear and Jira keys too, handing a remote tracker's key to a local
+	// database. Capability lives on the provider so the call site cannot guess.
+	t.truthy(createIssueTracker({provider: 'beads'}).claimIssue);
+
+	resetProviders();
+	t.falsy(createIssueTracker({provider: 'linear'}).claimIssue);
+
+	resetProviders();
+	t.falsy(
+		createIssueTracker({provider: 'jira', base_url: 'https://example.com'})
+			.claimIssue,
+	);
+});
+
+test.serial(
+	'claimIssue facade resolves false for a tracker without it',
+	async t => {
+		createIssueTracker({provider: 'linear'});
+		t.false(await claimIssue('STA-1234'));
 	},
 );

--- a/source/providers/beads-provider.ts
+++ b/source/providers/beads-provider.ts
@@ -1,4 +1,3 @@
-// Beads issue tracker provider — wraps the `bd` CLI (git-native, local-first)
 import {execFile} from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -28,18 +27,6 @@ const RETRY_DELAY_MS = 500;
 // The rail and the watchlist both want the complete set.
 const NO_LIMIT = ['-n', '0'];
 
-/**
- * Types the watchlist must never auto-spawn a workspace for. A watchlist match
- * turns into a worktree plus a Claude session with no one in the loop, and none
- * of these is a thing to sit down and write code against: epic, convoy and
- * molecule are containers whose children are the real work, event rows are
- * audit records, and merge-request rows stand for a change that already exists.
- * Decisions/ADRs are absent on purpose — writing one produces a real diff.
- *
- * The new-session picker deliberately does not filter: a person is choosing
- * there, and opening a worktree against a container to poke at its children is
- * a legitimate thing to want.
- */
 const NON_WORK_TYPES = [
 	'--exclude-type',
 	'epic,convoy,molecule,event,merge-request',
@@ -90,31 +77,12 @@ function removeQuietly(dir: string | undefined): void {
 	}
 }
 
-/**
- * Fold a user-authored status onto the spelling beads stores it under.
- * Watchlists get carried over from Linear and Jira, so the same status arrives
- * as "In Progress", "in progress" or "in_progress" depending on where it was
- * copied from. The reachability warning and the filter that actually drops rows
- * both read these strings, and they used to normalize differently — one
- * spelling could be warned about as unreachable and matched anyway.
- */
 export function normalizeBeadsStatus(status: string): string {
 	return status.trim().toLowerCase().replace(/\s+/g, '_');
 }
 
-/**
- * What `bd ready` can actually return. Its help is explicit: "Excludes
- * in_progress, blocked, deferred, and hooked issues." Membership is always
- * tested through `normalizeBeadsStatus`, so the display spelling folds onto
- * this one entry rather than needing a listing of its own.
- */
 const READY_STATUSES = new Set(['open']);
 
-/**
- * Which of the configured watchlist statuses `bd ready` can never return.
- * A watchlist carried over from Linear or Jira ("In Progress") would otherwise
- * sit permanently empty with nothing to explain it.
- */
 export function unreachableReadyStatuses(statuses: string[]): string[] {
 	return statuses.filter(s => {
 		const normalized = normalizeBeadsStatus(s);
@@ -140,29 +108,11 @@ export function beadsStateName(status: string): string {
 		.join(' ');
 }
 
-/**
- * The issue-source prefix of a beads ID — everything ahead of the hash.
- *
- * Beads IDs are `<prefix>-<hash>` with an optional `.N` suffix per nesting
- * level (`sddamico-hic`, `seatgeek-ticket-management-cli-bqm`, `bd-a3f8e9.1`).
- * One database routinely holds several prefixes, which is what makes prefix
- * matching a usable stand-in for Linear/Jira's project field. Unlike the shared
- * `issueKeyPrefix`, a prefixless ID reports no prefix at all rather than
- * itself, so `mapBeadsIssue` can leave `project` null.
- */
 export function beadsIssuePrefix(issueId: string): string {
 	const prefix = issueKeyPrefix(issueId);
 	return prefix === issueId.split('.')[0] ? '' : prefix;
 }
 
-/**
- * Pull the payload out of `bd`'s JSON, tolerating every shape it ships.
- *
- * Current releases print the bare value; `BD_JSON_ENVELOPE=1` (and beads 2.0 by
- * default) wraps it as `{schema_version, data}`. Single-issue commands like
- * `bd show` return a one-element *array*, not an object, despite what the
- * schema doc says. Callers get a list either way.
- */
 export function unwrapBeadsJson(
 	stdout: string,
 ): Array<Record<string, unknown>> {
@@ -218,19 +168,11 @@ export function mapBeadsIssue(raw: Record<string, unknown>): TrackerIssue {
 			type: beadsStateType(status),
 			color: BEADS_STATUS_COLORS[status] ?? FALLBACK_STATUS_COLOR,
 		},
-		// Beads has no project field; the ID prefix is its issue-source
-		// partition, so it fills both slots that `tracker_projects` matches on.
 		project: prefix ? {name: prefix, key: prefix} : null,
 		labels,
 	};
 }
 
-/**
- * Argv for the issue-detail popup. `-C` for the same reason every other bd call
- * sets its cwd: the popup runs in the pane's directory, so from a worktree bd
- * would auto-discover that worktree's checked-out `.beads/` copy and show a
- * different database than the rail was reading.
- */
 export function buildIssuePopupArgv(
 	mainRoot: string,
 	issueKey: string,
@@ -298,14 +240,6 @@ export class BeadsProvider implements IssueTrackerProvider {
 		});
 	}
 
-	/**
-	 * Keyed under the requested spelling as well when the two differ. `getIssue`
-	 * deliberately accepts a row whose id is not what it asked for (bd resolves
-	 * aliases and folds case), and storing only bd's spelling left the requested
-	 * key permanently absent: every read re-forked bd, and `getIssueCached` —
-	 * which the space list calls on each render — answered null forever, so the
-	 * row never stopped saying "Loading…".
-	 */
 	private cache(issue: TrackerIssue, requestedKey?: string): void {
 		const entry = {issue, timestamp: Date.now()};
 		this.issueCache.set(issue.identifier, entry);
@@ -493,13 +427,6 @@ export class BeadsProvider implements IssueTrackerProvider {
 		return displayPopup(buildIssuePopupArgv(this.resolveCwd(), issueKey));
 	}
 
-	/**
-	 * Watchlist source. `bd ready` is beads' own notion of actionable work —
-	 * open issues whose blocking dependencies are all closed — which is a
-	 * stronger filter than a status query and the reason it's used here instead
-	 * of `bd list --status`. A configured `statuses` list narrows further;
-	 * omitting it takes every ready issue.
-	 */
 	async searchAssignedIssues(
 		assignee: string | undefined,
 		statuses: string[],
@@ -563,12 +490,6 @@ export class BeadsProvider implements IssueTrackerProvider {
 		}
 	}
 
-	/**
-	 * Suggestion source for the new-session prompt. Unlike the watchlist, this
-	 * takes no assignee filter: the picker exists to answer "what could I start
-	 * next", and beads issues are frequently unassigned until someone claims
-	 * them, so filtering by assignee would usually empty the list.
-	 */
 	async listReadyIssues(): Promise<TrackerIssue[]> {
 		if (this.bdMissing) return [];
 
@@ -598,11 +519,6 @@ export class BeadsProvider implements IssueTrackerProvider {
 		}
 	}
 
-	/**
-	 * Drops the cached copy rather than rewriting its state: `bd close` also
-	 * stamps closed_at and can cascade to dependents, so the next read should
-	 * come from bd rather than from a locally-patched guess.
-	 */
 	async closeIssue(issueKey: string): Promise<boolean> {
 		if (this.bdMissing) return false;
 
@@ -627,12 +543,6 @@ export class BeadsProvider implements IssueTrackerProvider {
 		}
 	}
 
-	/**
-	 * `--claim` both assigns the issue and moves it to in_progress, which is
-	 * what drops it from `bd ready` (see searchAssignedIssues — ready excludes
-	 * in_progress). Failure is logged and swallowed: the caller is mid-workspace
-	 * creation, and a stale ready entry is a far smaller problem than aborting.
-	 */
 	async claimIssue(issueKey: string): Promise<boolean> {
 		if (this.bdMissing) return false;
 
@@ -716,18 +626,7 @@ export class BeadsProvider implements IssueTrackerProvider {
 		}
 	}
 
-	/**
-	 * `assignee: me` in the watchlist config. Beads assignees are free text, so
-	 * "me" has to resolve to the same string `bd` stamps on an issue when it
-	 * claims one. That is `$BEADS_ACTOR`, then `git user.name`, then `$USER` —
-	 * skipping the git identity matches nothing on the common setup where a
-	 * full name is configured but the OS login is a handle.
-	 */
 	private async currentUser(): Promise<string | undefined> {
-		// Memoized as a promise, not a string: the watchlist polls on a timer and
-		// this forks `git config` on every miss, and "no identity anywhere" is a
-		// legitimate answer that a string cache could never record. Caching the
-		// promise also collapses two polls that overlap into one fork.
 		this.currentUserCache ??= this.resolveCurrentUser();
 		return this.currentUserCache;
 	}

--- a/source/providers/beads-provider.ts
+++ b/source/providers/beads-provider.ts
@@ -1,0 +1,754 @@
+// Beads issue tracker provider — wraps the `bd` CLI (git-native, local-first)
+import {execFile} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {promisify} from 'node:util';
+import {getMainRepoRoot} from '../config.ts';
+import {issueKeyPrefix} from '../issue-utils.ts';
+import {createLogger} from '../logger.ts';
+import {sanitizeSubprocessError} from '../sanitize-error.ts';
+import {displayPopup} from '../tmux.ts';
+import {pLimit} from './concurrency.ts';
+import {StateColorCache} from './state-color-cache.ts';
+import type {
+	IssueTrackerProvider,
+	TrackerIssue,
+	TrackerProviderName,
+} from './types.ts';
+
+const execFileAsync = promisify(execFile);
+
+const log = createLogger('beads-provider');
+const CACHE_TTL_MS = 60_000;
+export const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 500;
+
+// `bd list`/`bd ready` cap results (50 and 100 respectively) unless told not to.
+// The rail and the watchlist both want the complete set.
+const NO_LIMIT = ['-n', '0'];
+
+/**
+ * Types the watchlist must never auto-spawn a workspace for. A watchlist match
+ * turns into a worktree plus a Claude session with no one in the loop, and none
+ * of these is a thing to sit down and write code against: epic, convoy and
+ * molecule are containers whose children are the real work, event rows are
+ * audit records, and merge-request rows stand for a change that already exists.
+ * Decisions/ADRs are absent on purpose — writing one produces a real diff.
+ *
+ * The new-session picker deliberately does not filter: a person is choosing
+ * there, and opening a worktree against a container to poke at its children is
+ * a legitimate thing to want.
+ */
+const NON_WORK_TYPES = [
+	'--exclude-type',
+	'epic,convoy,molecule,event,merge-request',
+];
+
+export function isEnoent(err: unknown): boolean {
+	return (
+		err instanceof Error &&
+		'code' in err &&
+		(err as NodeJS.ErrnoException).code === 'ENOENT'
+	);
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+	return new Promise(resolve => {
+		setTimeout(resolve, ms);
+	});
+}
+
+interface CacheEntry {
+	issue: TrackerIssue | null;
+	timestamp: number;
+}
+
+/**
+ * Beads status -> color. Beads exposes no per-status color of its own. These
+ * are ANSI names rather than hex so they follow the user's terminal theme.
+ */
+const BEADS_STATUS_COLORS: Record<string, string> = {
+	open: 'gray',
+	in_progress: 'blue',
+	blocked: 'yellow',
+	deferred: 'magenta',
+	closed: 'green',
+	pinned: 'yellowBright',
+	hooked: 'magentaBright',
+};
+
+const FALLBACK_STATUS_COLOR = 'gray';
+
+/** Best effort — a temp directory that outlives us is harmless, a throw is not. */
+function removeQuietly(dir: string | undefined): void {
+	if (!dir) return;
+	try {
+		fs.rmSync(dir, {recursive: true, force: true});
+	} catch {
+		// Nothing useful to do about a temp directory we cannot remove.
+	}
+}
+
+/**
+ * Fold a user-authored status onto the spelling beads stores it under.
+ * Watchlists get carried over from Linear and Jira, so the same status arrives
+ * as "In Progress", "in progress" or "in_progress" depending on where it was
+ * copied from. The reachability warning and the filter that actually drops rows
+ * both read these strings, and they used to normalize differently — one
+ * spelling could be warned about as unreachable and matched anyway.
+ */
+export function normalizeBeadsStatus(status: string): string {
+	return status.trim().toLowerCase().replace(/\s+/g, '_');
+}
+
+/**
+ * What `bd ready` can actually return. Its help is explicit: "Excludes
+ * in_progress, blocked, deferred, and hooked issues." Membership is always
+ * tested through `normalizeBeadsStatus`, so the display spelling folds onto
+ * this one entry rather than needing a listing of its own.
+ */
+const READY_STATUSES = new Set(['open']);
+
+/**
+ * Which of the configured watchlist statuses `bd ready` can never return.
+ * A watchlist carried over from Linear or Jira ("In Progress") would otherwise
+ * sit permanently empty with nothing to explain it.
+ */
+export function unreachableReadyStatuses(statuses: string[]): string[] {
+	return statuses.filter(s => {
+		const normalized = normalizeBeadsStatus(s);
+		return normalized !== '' && !READY_STATUSES.has(normalized);
+	});
+}
+
+/**
+ * `auto_remove_when_done` keys off the Linear-flavored state types in
+ * `auto-remove.ts` (`completed`/`canceled`), so beads' terminal status has to
+ * be reported under that name. Every other status passes through verbatim —
+ * beads supports user-defined statuses via its `status.custom` config key and
+ * an unknown one must never throw.
+ */
+export function beadsStateType(status: string): string {
+	return status === 'closed' ? 'completed' : status;
+}
+
+export function beadsStateName(status: string): string {
+	return status
+		.split('_')
+		.map(word => (word ? word[0]!.toUpperCase() + word.slice(1) : word))
+		.join(' ');
+}
+
+/**
+ * The issue-source prefix of a beads ID — everything ahead of the hash.
+ *
+ * Beads IDs are `<prefix>-<hash>` with an optional `.N` suffix per nesting
+ * level (`sddamico-hic`, `seatgeek-ticket-management-cli-bqm`, `bd-a3f8e9.1`).
+ * One database routinely holds several prefixes, which is what makes prefix
+ * matching a usable stand-in for Linear/Jira's project field. Unlike the shared
+ * `issueKeyPrefix`, a prefixless ID reports no prefix at all rather than
+ * itself, so `mapBeadsIssue` can leave `project` null.
+ */
+export function beadsIssuePrefix(issueId: string): string {
+	const prefix = issueKeyPrefix(issueId);
+	return prefix === issueId.split('.')[0] ? '' : prefix;
+}
+
+/**
+ * Pull the payload out of `bd`'s JSON, tolerating every shape it ships.
+ *
+ * Current releases print the bare value; `BD_JSON_ENVELOPE=1` (and beads 2.0 by
+ * default) wraps it as `{schema_version, data}`. Single-issue commands like
+ * `bd show` return a one-element *array*, not an object, despite what the
+ * schema doc says. Callers get a list either way.
+ */
+export function unwrapBeadsJson(
+	stdout: string,
+): Array<Record<string, unknown>> {
+	const parsed = JSON.parse(stdout) as unknown;
+	const payload =
+		parsed !== null &&
+		typeof parsed === 'object' &&
+		!Array.isArray(parsed) &&
+		'data' in parsed
+			? (parsed as {data: unknown}).data
+			: parsed;
+
+	if (Array.isArray(payload)) {
+		return payload.filter(
+			(item): item is Record<string, unknown> =>
+				item !== null && typeof item === 'object',
+		);
+	}
+
+	if (payload !== null && typeof payload === 'object') {
+		return [payload as Record<string, unknown>];
+	}
+
+	return [];
+}
+
+/**
+ * `bd --json` is schema'd but not validated by us, so every field is read
+ * through here: a row that arrives with a number where a string belongs
+ * degrades to the default rather than throwing halfway through a batch and
+ * taking the rest of the list with it.
+ */
+function stringField(raw: Record<string, unknown>, key: string): string {
+	const value = raw[key];
+	return typeof value === 'string' ? value : '';
+}
+
+export function mapBeadsIssue(raw: Record<string, unknown>): TrackerIssue {
+	const identifier = stringField(raw, 'id');
+	const status = stringField(raw, 'status') || 'open';
+	const prefix = beadsIssuePrefix(identifier);
+
+	const rawLabels = raw['labels'];
+	const labels = Array.isArray(rawLabels)
+		? (rawLabels as unknown[]).filter((l): l is string => typeof l === 'string')
+		: undefined;
+
+	return {
+		identifier,
+		title: stringField(raw, 'title'),
+		state: {
+			name: beadsStateName(status),
+			type: beadsStateType(status),
+			color: BEADS_STATUS_COLORS[status] ?? FALLBACK_STATUS_COLOR,
+		},
+		// Beads has no project field; the ID prefix is its issue-source
+		// partition, so it fills both slots that `tracker_projects` matches on.
+		project: prefix ? {name: prefix, key: prefix} : null,
+		labels,
+	};
+}
+
+/**
+ * Argv for the issue-detail popup. `-C` for the same reason every other bd call
+ * sets its cwd: the popup runs in the pane's directory, so from a worktree bd
+ * would auto-discover that worktree's checked-out `.beads/` copy and show a
+ * different database than the rail was reading.
+ */
+export function buildIssuePopupArgv(
+	mainRoot: string,
+	issueKey: string,
+): string[] {
+	return ['bd', '-C', mainRoot, 'show', `--id=${issueKey}`, '--long'];
+}
+
+export type CliExecutor = (
+	command: string,
+	args: string[],
+	options: {
+		encoding: BufferEncoding;
+		timeout: number;
+		cwd: string;
+		env: NodeJS.ProcessEnv;
+	},
+) => Promise<string>;
+
+export type SleepFn = (ms: number) => Promise<void>;
+
+export class BeadsProvider implements IssueTrackerProvider {
+	get name(): TrackerProviderName {
+		return 'beads';
+	}
+
+	private readonly issueCache = new Map<string, CacheEntry>();
+	private readonly stateColors: StateColorCache;
+	private readonly execCli: CliExecutor;
+	private readonly sleepFn: SleepFn;
+	private readonly resolveCwd: () => string;
+	private bdMissing = false;
+	private currentUserCache?: Promise<string | undefined>;
+
+	constructor(
+		execCli?: CliExecutor,
+		sleepFn?: SleepFn,
+		stateColorCache?: StateColorCache,
+		resolveCwd?: () => string,
+	) {
+		this.execCli =
+			execCli ??
+			(async (cmd, args, opts) => {
+				const {stdout} = await execFileAsync(cmd, args, opts);
+				return stdout;
+			});
+		this.sleepFn = sleepFn ?? defaultSleep;
+		this.stateColors = stateColorCache ?? new StateColorCache();
+		this.resolveCwd = resolveCwd ?? getMainRepoRoot;
+	}
+
+	/**
+	 * Every `bd` call runs from the main repo root — not the worktree, which
+	 * carries its own checked-out `.beads/` that bd would auto-discover — so
+	 * all workspaces read and write the one canonical database. Asks for the
+	 * enveloped JSON so the shape stays stable across the 2.0 default flip.
+	 * Only stdout is parsed: pre-2.0 releases put a deprecation notice for
+	 * bare `--json` on stderr.
+	 */
+	private async runBd(args: string[], timeout: number): Promise<string> {
+		return this.execCli('bd', args, {
+			encoding: 'utf-8',
+			timeout,
+			cwd: this.resolveCwd(),
+			env: {...process.env, BD_JSON_ENVELOPE: '1'},
+		});
+	}
+
+	/**
+	 * Keyed under the requested spelling as well when the two differ. `getIssue`
+	 * deliberately accepts a row whose id is not what it asked for (bd resolves
+	 * aliases and folds case), and storing only bd's spelling left the requested
+	 * key permanently absent: every read re-forked bd, and `getIssueCached` —
+	 * which the space list calls on each render — answered null forever, so the
+	 * row never stopped saying "Loading…".
+	 */
+	private cache(issue: TrackerIssue, requestedKey?: string): void {
+		const entry = {issue, timestamp: Date.now()};
+		this.issueCache.set(issue.identifier, entry);
+		if (requestedKey && requestedKey !== issue.identifier) {
+			this.issueCache.set(requestedKey, entry);
+		}
+
+		this.stateColors.update(issue.state.name, issue.state.color);
+	}
+
+	private noteMissing(action: string): void {
+		this.bdMissing = true;
+		log.warn(
+			`bd binary not found on PATH — beads ${action} disabled. Install beads or check your PATH.`,
+		);
+	}
+
+	async getIssue(issueKey: string): Promise<TrackerIssue | null> {
+		if (this.bdMissing) {
+			return this.issueCache.get(issueKey)?.issue ?? null;
+		}
+
+		const cached = this.issueCache.get(issueKey);
+		if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+			if (cached.issue) {
+				this.stateColors.update(
+					cached.issue.state.name,
+					cached.issue.state.color,
+				);
+			}
+
+			return cached.issue;
+		}
+
+		let lastError: unknown;
+		for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+			try {
+				// `--id=` rather than a positional: an ID whose prefix starts with
+				// a dash reaches bd's flag parser as a flag ("unknown shorthand
+				// flag: 'e' in -eird-xyz"). Subcommands with no --id take `--`
+				// instead; see closeIssue.
+				const output = await this.runBd(
+					['show', `--id=${issueKey}`, '--json'],
+					20_000,
+				);
+				const rows = unwrapBeadsJson(output);
+				const row =
+					rows.find(r => r['id'] === issueKey) ?? rows[0] ?? undefined;
+				if (!row) {
+					this.issueCache.set(issueKey, {issue: null, timestamp: Date.now()});
+					return null;
+				}
+
+				const issue = mapBeadsIssue(row);
+				this.cache(issue, issueKey);
+				log.debug(`Fetched beads issue ${issueKey}: ${issue.title}`);
+				return issue;
+			} catch (err) {
+				if (isEnoent(err)) {
+					this.noteMissing('issue fetching');
+					this.issueCache.set(issueKey, {issue: null, timestamp: Date.now()});
+					return null;
+				}
+
+				lastError = err;
+				if (attempt < MAX_RETRIES) {
+					log.debug(
+						`Fetch beads issue ${issueKey} failed (attempt ${attempt}/${MAX_RETRIES}), retrying…`,
+					);
+					await this.sleepFn(RETRY_DELAY_MS);
+				}
+			}
+		}
+
+		log.warn(
+			`Failed to fetch beads issue ${issueKey} after ${MAX_RETRIES} attempts`,
+			sanitizeSubprocessError(lastError),
+		);
+		this.issueCache.set(issueKey, {issue: null, timestamp: Date.now()});
+		return null;
+	}
+
+	async getIssues(
+		issueKeys: string[],
+	): Promise<Map<string, TrackerIssue | null>> {
+		const results = new Map<string, TrackerIssue | null>();
+		if (issueKeys.length === 0) return results;
+
+		if (this.bdMissing) {
+			for (const key of issueKeys) {
+				results.set(key, this.issueCache.get(key)?.issue ?? null);
+			}
+
+			return results;
+		}
+
+		try {
+			const output = await this.runBd(
+				['list', `--id=${issueKeys.join(',')}`, '--json', ...NO_LIMIT],
+				30_000,
+			);
+			const found = new Set<string>();
+
+			for (const row of unwrapBeadsJson(output)) {
+				const issue = mapBeadsIssue(row);
+				if (!issue.identifier) continue;
+				found.add(issue.identifier);
+				results.set(issue.identifier, issue);
+				this.cache(issue);
+			}
+
+			const unresolved = issueKeys.filter(key => !found.has(key));
+			if (unresolved.length > 0) {
+				const fetched = await pLimit(
+					unresolved.map(
+						key => async () =>
+							this.getIssue(key).then(
+								issue => [key, issue] as [string, TrackerIssue | null],
+							),
+					),
+					3,
+				);
+				for (const entry of fetched) {
+					if (entry) results.set(entry[0], entry[1]);
+				}
+			}
+
+			return results;
+		} catch (err) {
+			if (isEnoent(err)) {
+				this.noteMissing('issue fetching');
+				for (const key of issueKeys) {
+					results.set(key, this.issueCache.get(key)?.issue ?? null);
+				}
+
+				return results;
+			}
+
+			log.debug('Batch bd list failed, falling back to individual fetches');
+		}
+
+		const fetched = await pLimit(
+			issueKeys.map(
+				key => async () =>
+					this.getIssue(key).then(
+						issue => [key, issue] as [string, TrackerIssue | null],
+					),
+			),
+			3,
+		);
+		for (const entry of fetched) {
+			if (entry) results.set(entry[0], entry[1]);
+		}
+
+		return results;
+	}
+
+	getIssueCached(issueKey: string): TrackerIssue | null {
+		return this.issueCache.get(issueKey)?.issue ?? null;
+	}
+
+	getWorkflowStateColor(stateName: string): string | null {
+		return (
+			this.stateColors.get(stateName) ??
+			BEADS_STATUS_COLORS[stateName.toLowerCase().replace(/\s+/g, '_')] ??
+			null
+		);
+	}
+
+	clearCache(): void {
+		this.issueCache.clear();
+	}
+
+	/**
+	 * Beads issues are local — there is nothing to open in a browser. The rail's
+	 * `o` key goes through `openIssue()` instead; this stays empty so any caller
+	 * that still reaches for a URL degrades to "no link" rather than launching a
+	 * browser at a bogus address.
+	 */
+	buildIssueUrl(): string {
+		return '';
+	}
+
+	openIssue(issueKey: string): boolean {
+		return displayPopup(buildIssuePopupArgv(this.resolveCwd(), issueKey));
+	}
+
+	/**
+	 * Watchlist source. `bd ready` is beads' own notion of actionable work —
+	 * open issues whose blocking dependencies are all closed — which is a
+	 * stronger filter than a status query and the reason it's used here instead
+	 * of `bd list --status`. A configured `statuses` list narrows further;
+	 * omitting it takes every ready issue.
+	 */
+	async searchAssignedIssues(
+		assignee: string | undefined,
+		statuses: string[],
+	): Promise<TrackerIssue[]> {
+		if (this.bdMissing) return [];
+
+		const args = ['ready', '--json', ...NO_LIMIT, ...NON_WORK_TYPES];
+		const who = assignee === 'me' ? await this.currentUser() : assignee;
+		if (who) args.push('--assignee', who);
+
+		const wanted = new Set(statuses.map(s => normalizeBeadsStatus(s)));
+		log.info(
+			`Watchlist query: bd ready${who ? ` --assignee ${who}` : ''}${
+				wanted.size > 0 ? ` (statuses: ${statuses.join(', ')})` : ''
+			}`,
+		);
+
+		const unreachable = unreachableReadyStatuses(statuses);
+		if (unreachable.length > 0) {
+			log.warn(
+				`issue_watchlist.statuses includes ${unreachable.join(', ')}, which \`bd ready\` never returns — it excludes in_progress, blocked, deferred and hooked issues. Those statuses will match nothing.`,
+			);
+		}
+
+		try {
+			const output = await this.runBd(args, 30_000);
+			const results: TrackerIssue[] = [];
+
+			for (const row of unwrapBeadsJson(output)) {
+				const issue = mapBeadsIssue(row);
+				if (!issue.identifier) continue;
+				if (
+					wanted.size > 0 &&
+					!wanted.has(normalizeBeadsStatus(issue.state.type)) &&
+					!wanted.has(normalizeBeadsStatus(issue.state.name))
+				) {
+					continue;
+				}
+
+				results.push(issue);
+				this.cache(issue);
+			}
+
+			if (results.length > 0) {
+				log.info(
+					`Watchlist results: ${results.map(i => `${i.identifier} (${i.state.name})`).join(', ')}`,
+				);
+			} else {
+				log.info('Watchlist results: none');
+			}
+
+			return results;
+		} catch (err) {
+			if (isEnoent(err)) {
+				this.noteMissing('issue search');
+				return [];
+			}
+
+			log.warn('Failed to search beads issues', sanitizeSubprocessError(err));
+			return [];
+		}
+	}
+
+	/**
+	 * Suggestion source for the new-session prompt. Unlike the watchlist, this
+	 * takes no assignee filter: the picker exists to answer "what could I start
+	 * next", and beads issues are frequently unassigned until someone claims
+	 * them, so filtering by assignee would usually empty the list.
+	 */
+	async listReadyIssues(): Promise<TrackerIssue[]> {
+		if (this.bdMissing) return [];
+
+		try {
+			const output = await this.runBd(['ready', '--json', ...NO_LIMIT], 10_000);
+			const results: TrackerIssue[] = [];
+
+			for (const row of unwrapBeadsJson(output)) {
+				const issue = mapBeadsIssue(row);
+				if (!issue.identifier) continue;
+				results.push(issue);
+				this.cache(issue);
+			}
+
+			return results;
+		} catch (err) {
+			if (isEnoent(err)) {
+				this.noteMissing('ready issue listing');
+				return [];
+			}
+
+			log.warn(
+				'Failed to list ready beads issues',
+				sanitizeSubprocessError(err),
+			);
+			return [];
+		}
+	}
+
+	/**
+	 * Drops the cached copy rather than rewriting its state: `bd close` also
+	 * stamps closed_at and can cascade to dependents, so the next read should
+	 * come from bd rather than from a locally-patched guess.
+	 */
+	async closeIssue(issueKey: string): Promise<boolean> {
+		if (this.bdMissing) return false;
+
+		try {
+			// `close`, `update` and `comments add` take the ID positionally and
+			// offer no --id escape, so `--` is what stops a dash-led prefix from
+			// being parsed as a flag. Same hazard getIssue guards with `--id=`.
+			await this.runBd(['close', '--', issueKey], 30_000);
+			this.issueCache.delete(issueKey);
+			return true;
+		} catch (err) {
+			if (isEnoent(err)) {
+				this.noteMissing('issue closing');
+				return false;
+			}
+
+			log.warn(
+				`Failed to close beads ${issueKey}`,
+				sanitizeSubprocessError(err),
+			);
+			return false;
+		}
+	}
+
+	/**
+	 * `--claim` both assigns the issue and moves it to in_progress, which is
+	 * what drops it from `bd ready` (see searchAssignedIssues — ready excludes
+	 * in_progress). Failure is logged and swallowed: the caller is mid-workspace
+	 * creation, and a stale ready entry is a far smaller problem than aborting.
+	 */
+	async claimIssue(issueKey: string): Promise<boolean> {
+		if (this.bdMissing) return false;
+
+		try {
+			await this.runBd(['update', '--claim', '--', issueKey], 30_000);
+			this.issueCache.delete(issueKey);
+			return true;
+		} catch (err) {
+			if (isEnoent(err)) {
+				this.noteMissing('issue claiming');
+				return false;
+			}
+
+			log.warn(
+				`Failed to claim beads ${issueKey}`,
+				sanitizeSubprocessError(err),
+			);
+			return false;
+		}
+	}
+
+	async createComment(issueKey: string, body: string): Promise<boolean> {
+		if (this.bdMissing) return false;
+
+		// Via a file rather than an argv entry: comment bodies are whole Q&A
+		// transcripts, well past a comfortable argument length.
+		// Staged inside a private 0700 directory rather than at a name derived
+		// from pid and clock: `os.tmpdir()` is shared and world-writable on
+		// Linux, where a predictable path lets another user pre-plant a symlink
+		// that the write would follow.
+		let bodyDir: string | undefined;
+		let bodyPath: string | undefined;
+		try {
+			bodyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pappardelle-beads-'));
+			bodyPath = path.join(bodyDir, 'comment.md');
+			fs.writeFileSync(bodyPath, body, {mode: 0o600});
+		} catch (err) {
+			log.warn(
+				'Failed to stage beads comment body',
+				sanitizeSubprocessError(err),
+			);
+			// mkdtemp can succeed and the write still fail (ENOSPC, a restrictive
+			// umask). The finally below belongs to the *next* try, so without this
+			// the private directory is orphaned on every failed AskUserQuestion.
+			removeQuietly(bodyDir);
+			return false;
+		}
+
+		try {
+			let lastError: unknown;
+			for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+				try {
+					await this.runBd(
+						['comments', 'add', '-f', bodyPath, '--', issueKey],
+						30_000,
+					);
+					return true;
+				} catch (err) {
+					if (isEnoent(err)) {
+						this.noteMissing('comment posting');
+						return false;
+					}
+
+					lastError = err;
+					if (attempt < MAX_RETRIES) {
+						log.debug(
+							`Post comment on beads ${issueKey} failed (attempt ${attempt}/${MAX_RETRIES}), retrying…`,
+						);
+						await this.sleepFn(RETRY_DELAY_MS);
+					}
+				}
+			}
+
+			log.warn(
+				`Failed to post comment on beads ${issueKey} after ${MAX_RETRIES} attempts`,
+				sanitizeSubprocessError(lastError),
+			);
+			return false;
+		} finally {
+			removeQuietly(bodyDir);
+		}
+	}
+
+	/**
+	 * `assignee: me` in the watchlist config. Beads assignees are free text, so
+	 * "me" has to resolve to the same string `bd` stamps on an issue when it
+	 * claims one. That is `$BEADS_ACTOR`, then `git user.name`, then `$USER` —
+	 * skipping the git identity matches nothing on the common setup where a
+	 * full name is configured but the OS login is a handle.
+	 */
+	private async currentUser(): Promise<string | undefined> {
+		// Memoized as a promise, not a string: the watchlist polls on a timer and
+		// this forks `git config` on every miss, and "no identity anywhere" is a
+		// legitimate answer that a string cache could never record. Caching the
+		// promise also collapses two polls that overlap into one fork.
+		this.currentUserCache ??= this.resolveCurrentUser();
+		return this.currentUserCache;
+	}
+
+	private async resolveCurrentUser(): Promise<string | undefined> {
+		const fromEnv = process.env['BEADS_ACTOR']?.trim();
+		if (fromEnv) return fromEnv;
+
+		try {
+			const gitName = await this.execCli('git', ['config', 'user.name'], {
+				encoding: 'utf-8',
+				timeout: 5000,
+				cwd: this.resolveCwd(),
+				env: process.env,
+			});
+			const name = gitName.trim();
+			if (name) return name;
+		} catch {
+			// No git identity configured, or git is unavailable — fall through.
+		}
+
+		return process.env['USER'] ?? process.env['LOGNAME'] ?? undefined;
+	}
+}

--- a/source/providers/index.ts
+++ b/source/providers/index.ts
@@ -1,10 +1,16 @@
 // Provider factory — creates and caches provider singletons
+import {BeadsProvider} from './beads-provider.ts';
 import {GitHubProvider} from './github-provider.ts';
 import {GitLabProvider} from './gitlab-provider.ts';
 import {JiraProvider} from './jira-provider.ts';
 import {createDefaultLinearGraphQLClient} from './linear-graphql.ts';
 import {LinearProvider} from './linear-provider.ts';
-import type {IssueTrackerProvider, VcsHostProvider} from './types.ts';
+import type {
+	IssueTrackerProvider,
+	TrackerProviderName,
+	VcsHostProvider,
+	VcsProviderName,
+} from './types.ts';
 
 export type {
 	TrackerIssue,
@@ -12,16 +18,18 @@ export type {
 	PipelineStatus,
 	RailStatus,
 	IssueTrackerProvider,
+	TrackerProviderName,
 	VcsHostProvider,
+	VcsProviderName,
 } from './types.ts';
 
 export interface IssueTrackerConfig {
-	provider: 'linear' | 'jira';
+	provider: TrackerProviderName;
 	base_url?: string; // Required for Jira
 }
 
 export interface VcsHostConfig {
-	provider: 'github' | 'gitlab';
+	provider: VcsProviderName;
 	host?: string; // For self-hosted GitLab
 }
 
@@ -32,7 +40,9 @@ let vcsHostConfigKey: string | null = null;
 
 function trackerKey(config?: IssueTrackerConfig): string {
 	const provider = config?.provider ?? 'linear';
-	return provider === 'jira' ? `jira:${config?.base_url ?? ''}` : 'linear';
+	if (provider === 'jira') return `jira:${config?.base_url ?? ''}`;
+	if (provider === 'beads') return 'beads';
+	return 'linear';
 }
 
 function vcsKey(config?: VcsHostConfig): string {
@@ -88,6 +98,11 @@ export function createIssueTracker(
 			}
 
 			issueTrackerInstance = new JiraProvider(config.base_url);
+			break;
+		}
+
+		case 'beads': {
+			issueTrackerInstance = new BeadsProvider();
 			break;
 		}
 

--- a/source/providers/jira-provider.ts
+++ b/source/providers/jira-provider.ts
@@ -5,7 +5,11 @@ import {createLogger} from '../logger.ts';
 import {sanitizeSubprocessError} from '../sanitize-error.ts';
 import {pLimit} from './concurrency.ts';
 import {StateColorCache} from './state-color-cache.ts';
-import type {IssueTrackerProvider, TrackerIssue} from './types.ts';
+import type {
+	IssueTrackerProvider,
+	TrackerIssue,
+	TrackerProviderName,
+} from './types.ts';
 
 const execFileAsync = promisify(execFile);
 
@@ -143,7 +147,7 @@ export type CliExecutor = (
 export type SleepFn = (ms: number) => Promise<void>;
 
 export class JiraProvider implements IssueTrackerProvider {
-	get name() {
+	get name(): TrackerProviderName {
 		return 'jira';
 	}
 

--- a/source/providers/linear-provider.ts
+++ b/source/providers/linear-provider.ts
@@ -4,7 +4,11 @@ import {promisify} from 'node:util';
 import {createLogger} from '../logger.ts';
 import {sanitizeSubprocessError} from '../sanitize-error.ts';
 import {StateColorCache} from './state-color-cache.ts';
-import type {IssueTrackerProvider, TrackerIssue} from './types.ts';
+import type {
+	IssueTrackerProvider,
+	TrackerIssue,
+	TrackerProviderName,
+} from './types.ts';
 
 const execFileAsync = promisify(execFile);
 
@@ -86,7 +90,7 @@ interface CacheEntry {
 }
 
 export class LinearProvider implements IssueTrackerProvider {
-	get name() {
+	get name(): TrackerProviderName {
 		return 'linear';
 	}
 

--- a/source/providers/types.ts
+++ b/source/providers/types.ts
@@ -2,6 +2,16 @@
 // These abstractions allow pappardelle to work with Linear/Jira and GitHub/GitLab
 
 /**
+ * The trackers pappardelle can talk to. Declared once here rather than as an
+ * inline union at each use: key grammar, list layout and claim support all
+ * branch on it, and a `string` parameter at any of those lets a typo through to
+ * a silent fallback.
+ */
+export type TrackerProviderName = 'linear' | 'jira' | 'beads';
+
+export type VcsProviderName = 'github' | 'gitlab';
+
+/**
  * Provider-agnostic issue representation.
  * Maps to LinearIssue shape for backwards compatibility.
  */
@@ -73,7 +83,7 @@ export interface RailStatus {
  * Issue tracker provider interface (Linear, Jira, etc.)
  */
 export interface IssueTrackerProvider {
-	readonly name: string;
+	readonly name: TrackerProviderName;
 
 	/** Fetch an issue by key, with caching */
 	getIssue(issueKey: string): Promise<TrackerIssue | null>;
@@ -93,6 +103,14 @@ export interface IssueTrackerProvider {
 	/** Build the web URL for an issue */
 	buildIssueUrl(issueKey: string): string;
 
+	/**
+	 * Show the issue to the user in place, for trackers whose issues have no
+	 * web page (beads is local-only). Providers that can produce a URL leave
+	 * this undefined and the caller falls back to `buildIssueUrl` + `open`.
+	 * Returns false when the issue could not be displayed.
+	 */
+	openIssue?(issueKey: string): boolean;
+
 	/** Post a comment on an issue */
 	createComment(issueKey: string, body: string): Promise<boolean>;
 
@@ -101,6 +119,35 @@ export interface IssueTrackerProvider {
 		assignee: string | undefined,
 		statuses: string[],
 	): Promise<TrackerIssue[]>;
+
+	/**
+	 * Unblocked, unstarted work the user could pick up right now, offered as
+	 * suggestions in the new-session prompt. Only trackers that can answer this
+	 * cheaply and locally implement it — a remote round-trip on every keystroke-
+	 * free dialog open is not worth the latency — so callers must treat an
+	 * undefined method as "no suggestions" rather than an error.
+	 */
+	listReadyIssues?(): Promise<TrackerIssue[]>;
+
+	/**
+	 * Mark an issue done from inside the TUI. Only trackers whose "close" is a
+	 * single local, unambiguous transition implement it — remote trackers model
+	 * completion as a workflow state whose name varies per project, so there is
+	 * no safe default to pick on the user's behalf.
+	 */
+	closeIssue?(issueKey: string): Promise<boolean>;
+
+	/**
+	 * Take ownership of an issue and move it out of the ready pool, called as a
+	 * workspace starts building. Without it a ready-work suggestion stays ready
+	 * for the whole of setup, so opening several workspaces back to back keeps
+	 * re-offering the ones already in flight.
+	 *
+	 * Same restraint as closeIssue: only trackers with a single unambiguous
+	 * local transition implement it. Advisory — a false return means the issue
+	 * keeps showing up, never that workspace creation should stop.
+	 */
+	claimIssue?(issueKey: string): Promise<boolean>;
 }
 
 /**

--- a/source/providers/types.ts
+++ b/source/providers/types.ts
@@ -1,12 +1,6 @@
 // Provider interfaces for issue trackers and VCS hosts
 // These abstractions allow pappardelle to work with Linear/Jira and GitHub/GitLab
 
-/**
- * The trackers pappardelle can talk to. Declared once here rather than as an
- * inline union at each use: key grammar, list layout and claim support all
- * branch on it, and a `string` parameter at any of those lets a typo through to
- * a silent fallback.
- */
 export type TrackerProviderName = 'linear' | 'jira' | 'beads';
 
 export type VcsProviderName = 'github' | 'gitlab';
@@ -103,12 +97,7 @@ export interface IssueTrackerProvider {
 	/** Build the web URL for an issue */
 	buildIssueUrl(issueKey: string): string;
 
-	/**
-	 * Show the issue to the user in place, for trackers whose issues have no
-	 * web page (beads is local-only). Providers that can produce a URL leave
-	 * this undefined and the caller falls back to `buildIssueUrl` + `open`.
-	 * Returns false when the issue could not be displayed.
-	 */
+	/** Show the issue to the user in place. */
 	openIssue?(issueKey: string): boolean;
 
 	/** Post a comment on an issue */
@@ -122,30 +111,16 @@ export interface IssueTrackerProvider {
 
 	/**
 	 * Unblocked, unstarted work the user could pick up right now, offered as
-	 * suggestions in the new-session prompt. Only trackers that can answer this
-	 * cheaply and locally implement it — a remote round-trip on every keystroke-
-	 * free dialog open is not worth the latency — so callers must treat an
-	 * undefined method as "no suggestions" rather than an error.
+	 * suggestions in the new-session prompt.
 	 */
 	listReadyIssues?(): Promise<TrackerIssue[]>;
 
-	/**
-	 * Mark an issue done from inside the TUI. Only trackers whose "close" is a
-	 * single local, unambiguous transition implement it — remote trackers model
-	 * completion as a workflow state whose name varies per project, so there is
-	 * no safe default to pick on the user's behalf.
-	 */
+	/** Mark an issue done from inside the TUI. */
 	closeIssue?(issueKey: string): Promise<boolean>;
 
 	/**
 	 * Take ownership of an issue and move it out of the ready pool, called as a
-	 * workspace starts building. Without it a ready-work suggestion stays ready
-	 * for the whole of setup, so opening several workspaces back to back keeps
-	 * re-offering the ones already in flight.
-	 *
-	 * Same restraint as closeIssue: only trackers with a single unambiguous
-	 * local transition implement it. Advisory — a false return means the issue
-	 * keeps showing up, never that workspace creation should stop.
+	 * workspace starts building.
 	 */
 	claimIssue?(issueKey: string): Promise<boolean>;
 }

--- a/source/session-routing.test.ts
+++ b/source/session-routing.test.ts
@@ -144,17 +144,19 @@ test('getSpaceCount includes main worktree (regression: previously filtered out)
 // ============================================================================
 
 test('buildNewSessionArgs returns only the idow arg (no --open)', t => {
-	const args = buildNewSessionArgs('STA-500');
+	const args = buildNewSessionArgs('STA-500', {existingIssue: false});
 	t.deepEqual(args, ['STA-500']);
 });
 
 test('buildNewSessionArgs passes description as-is', t => {
-	const args = buildNewSessionArgs('add dark mode to settings');
+	const args = buildNewSessionArgs('add dark mode to settings', {
+		existingIssue: false,
+	});
 	t.deepEqual(args, ['add dark mode to settings']);
 });
 
 test('buildNewSessionArgs does not include --resume or --open', t => {
-	const args = buildNewSessionArgs('STA-500');
+	const args = buildNewSessionArgs('STA-500', {existingIssue: false});
 	t.false(args.includes('--resume'));
 	t.false(args.includes('--open'));
 });
@@ -166,6 +168,7 @@ test('buildNewSessionArgs does not include --resume or --open', t => {
 test('buildNewSessionArgs forwards --profile when profile name provided', t => {
 	const args = buildNewSessionArgs('upload a personal image to trotbooks', {
 		profileName: 'trotbooks',
+		existingIssue: false,
 	});
 	t.deepEqual(args, [
 		'--profile',
@@ -175,23 +178,27 @@ test('buildNewSessionArgs forwards --profile when profile name provided', t => {
 });
 
 test('buildNewSessionArgs omits --profile when profileName is null', t => {
-	const args = buildNewSessionArgs('add dark mode', {profileName: null});
+	const args = buildNewSessionArgs('add dark mode', {
+		profileName: null,
+		existingIssue: false,
+	});
 	t.deepEqual(args, ['add dark mode']);
 });
 
 test('buildNewSessionArgs omits --profile when profileName is empty string', t => {
-	const args = buildNewSessionArgs('add dark mode', {profileName: ''});
-	t.deepEqual(args, ['add dark mode']);
-});
-
-test('buildNewSessionArgs omits --profile when opts omitted (back-compat)', t => {
-	const args = buildNewSessionArgs('add dark mode');
+	const args = buildNewSessionArgs('add dark mode', {
+		profileName: '',
+		existingIssue: false,
+	});
 	t.deepEqual(args, ['add dark mode']);
 });
 
 test('buildNewSessionArgs puts --profile before the input so idow parses it', t => {
 	// idow checks $1 for --profile; the flag must come before the input.
-	const args = buildNewSessionArgs('STA-500', {profileName: 'pappardelle'});
+	const args = buildNewSessionArgs('STA-500', {
+		profileName: 'pappardelle',
+		existingIssue: false,
+	});
 	t.is(args[0], '--profile');
 	t.is(args[1], 'pappardelle');
 	t.is(args[2], 'STA-500');
@@ -214,7 +221,30 @@ test('buildOpenWorkspaceArgs passes issue key as last arg', t => {
 
 test('buildOpenWorkspaceArgs returns exact expected args', t => {
 	const args = buildOpenWorkspaceArgs('ENG-42');
-	t.deepEqual(args, ['--resume', '--open', 'ENG-42']);
+	t.deepEqual(args, ['--resume', '--open', '--existing-issue', 'ENG-42']);
+});
+
+test('buildNewSessionArgs marks tracker-supplied keys as existing issues', t => {
+	t.deepEqual(buildNewSessionArgs('pappardelle-a1b2', {existingIssue: true}), [
+		'--existing-issue',
+		'pappardelle-a1b2',
+	]);
+});
+
+test('buildNewSessionArgs orders --profile ahead of --existing-issue', t => {
+	t.deepEqual(
+		buildNewSessionArgs('pappardelle-a1b2', {
+			profileName: 'vendor',
+			existingIssue: true,
+		}),
+		['--profile', 'vendor', '--existing-issue', 'pappardelle-a1b2'],
+	);
+});
+
+test('buildNewSessionArgs leaves typed input unflagged', t => {
+	t.deepEqual(buildNewSessionArgs('add dark mode', {existingIssue: false}), [
+		'add dark mode',
+	]);
 });
 
 // ============================================================================
@@ -244,6 +274,46 @@ Issue:     https://linear.app/stardust-labs/issue/STA-633
 test('extracts issue key with non-STA prefix', t => {
 	const stdout = 'Workspace ENG-42 is ready!\n';
 	t.is(extractIssueKeyFromIdowOutput(stdout), 'ENG-42');
+});
+
+// beads mints lowercase prefixes with an alphanumeric suffix rather than the
+// uppercase/numeric shape Linear and Jira use. Failing to match these left the
+// space unregistered and hung the TUI's pending row with no error.
+test('extracts beads-shaped issue key', t => {
+	t.is(
+		extractIssueKeyFromIdowOutput('Workspace pappardelle-osc is ready!\n'),
+		'pappardelle-osc',
+	);
+	t.is(
+		extractIssueKeyFromIdowOutput('Workspace myproj-a1b2 is ready!\n'),
+		'myproj-a1b2',
+	);
+});
+
+// A beads prefix defaults to the repo directory name, so it can carry hyphens
+// and underscores of its own. Stopping at the first hyphen truncated the key
+// and left the pending row waiting on a space that never arrived.
+test('extracts beads key whose prefix contains hyphens or underscores', t => {
+	t.is(
+		extractIssueKeyFromIdowOutput('Workspace vendor-sdk-a1b2 is ready!\n'),
+		'vendor-sdk-a1b2',
+	);
+	t.is(
+		extractIssueKeyFromIdowOutput('Workspace my_service-a1b2 is ready!\n'),
+		'my_service-a1b2',
+	);
+});
+
+test('extracts a hierarchical beads child key', t => {
+	t.is(
+		extractIssueKeyFromIdowOutput('Workspace vendor-sdk-a1b2.1 is ready!\n'),
+		'vendor-sdk-a1b2.1',
+	);
+});
+
+test('extracts beads key wrapped in ANSI color codes', t => {
+	const stdout = '[0;32mWorkspace pappardelle-osc is ready![0m\n';
+	t.is(extractIssueKeyFromIdowOutput(stdout), 'pappardelle-osc');
 });
 
 test('returns null when idow output has no workspace line', t => {

--- a/source/session-routing.test.ts
+++ b/source/session-routing.test.ts
@@ -144,19 +144,19 @@ test('getSpaceCount includes main worktree (regression: previously filtered out)
 // ============================================================================
 
 test('buildNewSessionArgs returns only the idow arg (no --open)', t => {
-	const args = buildNewSessionArgs('STA-500', {existingIssue: false});
+	const args = buildNewSessionArgs('STA-500', {inputIsIssueKey: false});
 	t.deepEqual(args, ['STA-500']);
 });
 
 test('buildNewSessionArgs passes description as-is', t => {
 	const args = buildNewSessionArgs('add dark mode to settings', {
-		existingIssue: false,
+		inputIsIssueKey: false,
 	});
 	t.deepEqual(args, ['add dark mode to settings']);
 });
 
 test('buildNewSessionArgs does not include --resume or --open', t => {
-	const args = buildNewSessionArgs('STA-500', {existingIssue: false});
+	const args = buildNewSessionArgs('STA-500', {inputIsIssueKey: false});
 	t.false(args.includes('--resume'));
 	t.false(args.includes('--open'));
 });
@@ -168,7 +168,7 @@ test('buildNewSessionArgs does not include --resume or --open', t => {
 test('buildNewSessionArgs forwards --profile when profile name provided', t => {
 	const args = buildNewSessionArgs('upload a personal image to trotbooks', {
 		profileName: 'trotbooks',
-		existingIssue: false,
+		inputIsIssueKey: false,
 	});
 	t.deepEqual(args, [
 		'--profile',
@@ -180,7 +180,7 @@ test('buildNewSessionArgs forwards --profile when profile name provided', t => {
 test('buildNewSessionArgs omits --profile when profileName is null', t => {
 	const args = buildNewSessionArgs('add dark mode', {
 		profileName: null,
-		existingIssue: false,
+		inputIsIssueKey: false,
 	});
 	t.deepEqual(args, ['add dark mode']);
 });
@@ -188,7 +188,7 @@ test('buildNewSessionArgs omits --profile when profileName is null', t => {
 test('buildNewSessionArgs omits --profile when profileName is empty string', t => {
 	const args = buildNewSessionArgs('add dark mode', {
 		profileName: '',
-		existingIssue: false,
+		inputIsIssueKey: false,
 	});
 	t.deepEqual(args, ['add dark mode']);
 });
@@ -197,7 +197,7 @@ test('buildNewSessionArgs puts --profile before the input so idow parses it', t 
 	// idow checks $1 for --profile; the flag must come before the input.
 	const args = buildNewSessionArgs('STA-500', {
 		profileName: 'pappardelle',
-		existingIssue: false,
+		inputIsIssueKey: false,
 	});
 	t.is(args[0], '--profile');
 	t.is(args[1], 'pappardelle');
@@ -221,28 +221,28 @@ test('buildOpenWorkspaceArgs passes issue key as last arg', t => {
 
 test('buildOpenWorkspaceArgs returns exact expected args', t => {
 	const args = buildOpenWorkspaceArgs('ENG-42');
-	t.deepEqual(args, ['--resume', '--open', '--existing-issue', 'ENG-42']);
+	t.deepEqual(args, ['--resume', '--open', '--issue-key', 'ENG-42']);
 });
 
 test('buildNewSessionArgs marks tracker-supplied keys as existing issues', t => {
-	t.deepEqual(buildNewSessionArgs('pappardelle-a1b2', {existingIssue: true}), [
-		'--existing-issue',
-		'pappardelle-a1b2',
-	]);
+	t.deepEqual(
+		buildNewSessionArgs('pappardelle-a1b2', {inputIsIssueKey: true}),
+		['--issue-key', 'pappardelle-a1b2'],
+	);
 });
 
-test('buildNewSessionArgs orders --profile ahead of --existing-issue', t => {
+test('buildNewSessionArgs orders --profile ahead of --issue-key', t => {
 	t.deepEqual(
 		buildNewSessionArgs('pappardelle-a1b2', {
 			profileName: 'vendor',
-			existingIssue: true,
+			inputIsIssueKey: true,
 		}),
-		['--profile', 'vendor', '--existing-issue', 'pappardelle-a1b2'],
+		['--profile', 'vendor', '--issue-key', 'pappardelle-a1b2'],
 	);
 });
 
 test('buildNewSessionArgs leaves typed input unflagged', t => {
-	t.deepEqual(buildNewSessionArgs('add dark mode', {existingIssue: false}), [
+	t.deepEqual(buildNewSessionArgs('add dark mode', {inputIsIssueKey: false}), [
 		'add dark mode',
 	]);
 });

--- a/source/session-routing.ts
+++ b/source/session-routing.ts
@@ -55,6 +55,13 @@ export interface PendingSession {
 	 */
 	profileName?: string | null;
 	/**
+	 * The key came from the tracker (watchlist poll, ready-work picker) rather
+	 * than from something the user typed, so idow is told to trust it instead of
+	 * re-deriving the input's kind from its shape. Also what gates the claim —
+	 * `--claim` reassigns and reopens, so it must never touch a typed key.
+	 */
+	existingIssue: boolean;
+	/**
 	 * Emoji slot for the pending row (left of the Claude status icon).
 	 * Mirrors the emoji-rail behavior of real rows so the Claude thinking
 	 * icon stays vertically aligned while the session spins up. Resolved
@@ -98,21 +105,25 @@ export function getSpaceCount(
  */
 export function buildNewSessionArgs(
 	idowArg: string,
-	opts?: {profileName?: string | null},
+	opts: {profileName?: string | null; existingIssue: boolean},
 ): string[] {
-	const profileName = opts?.profileName;
-	if (profileName) {
-		return ['--profile', profileName, idowArg];
-	}
-	return [idowArg];
+	const args: string[] = [];
+	if (opts.profileName) args.push('--profile', opts.profileName);
+	if (opts.existingIssue) args.push('--existing-issue');
+	args.push(idowArg);
+	return args;
 }
 
 /**
  * Build idow args for opening a workspace (apps, links, iTerm, etc.).
  * Uses --resume (no Claude prompt) + --open (enable open steps).
+ *
+ * --existing-issue because the key names a workspace that already exists;
+ * without it a beads key whose prefix this repo doesn't list reads as prose and
+ * idow files a duplicate issue instead of opening the space.
  */
 export function buildOpenWorkspaceArgs(issueKey: string): string[] {
-	return ['--resume', '--open', issueKey];
+	return ['--resume', '--open', '--existing-issue', issueKey];
 }
 
 export function isPendingSessionResolved(
@@ -136,6 +147,8 @@ export function isPendingSessionResolved(
  * Returns the issue key (e.g. "STA-633") or null if not found.
  */
 export function extractIssueKeyFromIdowOutput(stdout: string): string | null {
-	const match = stdout.match(/Workspace ([A-Z][A-Z0-9]*-\d+) is ready/);
+	const match = stdout.match(
+		/Workspace ([A-Za-z\d_]+(?:-[A-Za-z\d_]+)+(?:\.\d+){0,3}) is ready/,
+	);
 	return match ? match[1]! : null;
 }

--- a/source/session-routing.ts
+++ b/source/session-routing.ts
@@ -56,9 +56,7 @@ export interface PendingSession {
 	profileName?: string | null;
 	/**
 	 * The key came from the tracker (watchlist poll, ready-work picker) rather
-	 * than from something the user typed, so idow is told to trust it instead of
-	 * re-deriving the input's kind from its shape. Also what gates the claim —
-	 * `--claim` reassigns and reopens, so it must never touch a typed key.
+	 * than from something the user typed.
 	 */
 	existingIssue: boolean;
 	/**
@@ -117,10 +115,6 @@ export function buildNewSessionArgs(
 /**
  * Build idow args for opening a workspace (apps, links, iTerm, etc.).
  * Uses --resume (no Claude prompt) + --open (enable open steps).
- *
- * --existing-issue because the key names a workspace that already exists;
- * without it a beads key whose prefix this repo doesn't list reads as prose and
- * idow files a duplicate issue instead of opening the space.
  */
 export function buildOpenWorkspaceArgs(issueKey: string): string[] {
 	return ['--resume', '--open', '--existing-issue', issueKey];

--- a/source/session-routing.ts
+++ b/source/session-routing.ts
@@ -56,9 +56,10 @@ export interface PendingSession {
 	profileName?: string | null;
 	/**
 	 * The key came from the tracker (watchlist poll, ready-work picker) rather
-	 * than from something the user typed.
+	 * than from something the user typed, so idow takes it verbatim instead of
+	 * running its own input-type detection.
 	 */
-	existingIssue: boolean;
+	inputIsIssueKey: boolean;
 	/**
 	 * Emoji slot for the pending row (left of the Claude status icon).
 	 * Mirrors the emoji-rail behavior of real rows so the Claude thinking
@@ -103,11 +104,11 @@ export function getSpaceCount(
  */
 export function buildNewSessionArgs(
 	idowArg: string,
-	opts: {profileName?: string | null; existingIssue: boolean},
+	opts: {profileName?: string | null; inputIsIssueKey: boolean},
 ): string[] {
 	const args: string[] = [];
 	if (opts.profileName) args.push('--profile', opts.profileName);
-	if (opts.existingIssue) args.push('--existing-issue');
+	if (opts.inputIsIssueKey) args.push('--issue-key');
 	args.push(idowArg);
 	return args;
 }
@@ -117,7 +118,7 @@ export function buildNewSessionArgs(
  * Uses --resume (no Claude prompt) + --open (enable open steps).
  */
 export function buildOpenWorkspaceArgs(issueKey: string): string[] {
-	return ['--resume', '--open', '--existing-issue', issueKey];
+	return ['--resume', '--open', '--issue-key', issueKey];
 }
 
 export function isPendingSessionResolved(

--- a/source/spawn-env.test.ts
+++ b/source/spawn-env.test.ts
@@ -17,3 +17,19 @@ test('buildSpawnEnv does not mutate process.env', t => {
 	buildSpawnEnv('/tmp/fake-project');
 	t.is(process.env['PAPPARDELLE_PROJECT_ROOT'], before);
 });
+
+test('buildSpawnEnv passes the main repo root when given one', t => {
+	const env = buildSpawnEnv('/tmp/fake-project', '/tmp/fake-main');
+	t.is(env['PAPPARDELLE_MAIN_REPO_ROOT'], '/tmp/fake-main');
+});
+
+test.serial('buildSpawnEnv omits the main repo root when there is none', t => {
+	const before = process.env['PAPPARDELLE_MAIN_REPO_ROOT'];
+	delete process.env['PAPPARDELLE_MAIN_REPO_ROOT'];
+	try {
+		t.false('PAPPARDELLE_MAIN_REPO_ROOT' in buildSpawnEnv('/tmp/fake-project'));
+	} finally {
+		if (before !== undefined)
+			process.env['PAPPARDELLE_MAIN_REPO_ROOT'] = before;
+	}
+});

--- a/source/spawn-env.ts
+++ b/source/spawn-env.ts
@@ -1,11 +1,18 @@
 /**
  * Build env object for spawning the idow script.
  * Passes PAPPARDELLE_PROJECT_ROOT so the shell scripts resolve config
- * from the user's project directory, not the pappardelle source repo.
+ * from the user's project directory, not the pappardelle source repo, and
+ * PAPPARDELLE_MAIN_REPO_ROOT so nothing downstream re-derives it — idow hands
+ * it on to the workspace's tmux sessions, where the Claude Code hooks read it
+ * instead of resolving the main checkout on every tool use.
  */
-export function buildSpawnEnv(repoRoot: string): NodeJS.ProcessEnv {
+export function buildSpawnEnv(
+	repoRoot: string,
+	mainRepoRoot?: string,
+): NodeJS.ProcessEnv {
 	return {
 		...process.env,
 		PAPPARDELLE_PROJECT_ROOT: repoRoot,
+		...(mainRepoRoot ? {PAPPARDELLE_MAIN_REPO_ROOT: mainRepoRoot} : {}),
 	};
 }

--- a/source/synchronized-output.test.ts
+++ b/source/synchronized-output.test.ts
@@ -31,21 +31,36 @@ const TMUX_SOURCE = readFileSync(join(__dirname, 'tmux.ts'), 'utf-8');
 
 type Call = readonly string[];
 
-const recorder = (result?: {
+type Outcome = {
 	error?: Error;
 	status: number | null;
 	stdout: string;
-}): {calls: Call[]; runner: OuterTmuxRunner} => {
+};
+
+const recorder = (
+	result?: Outcome | ((args: Call) => Outcome),
+): {calls: Call[]; runner: OuterTmuxRunner} => {
 	const outcome = result ?? {status: 0, stdout: ''};
 	const calls: Call[] = [];
 	return {
 		calls,
 		runner(args) {
 			calls.push(args);
-			return outcome;
+			return typeof outcome === 'function' ? outcome(args) : outcome;
 		},
 	};
 };
+
+/** A runner whose `show-options` reports the given terminal-features entries. */
+const withFeatures = (...entries: string[]) =>
+	recorder(args =>
+		args[0] === 'show-options'
+			? {status: 0, stdout: entries.join('\n') + '\n'}
+			: {status: 0, stdout: ''},
+	);
+
+const setOptionCalls = (calls: Call[]) =>
+	calls.filter(args => args[0] === 'set-option');
 
 test('sets terminal-features on both the outer and the inner socket', t => {
 	const outer = recorder();
@@ -59,8 +74,8 @@ test('sets terminal-features on both the outer and the inner socket', t => {
 		'terminal-features',
 		`,${SYNC_TERMINAL_FEATURE}`,
 	];
-	t.deepEqual(outer.calls, [expected]);
-	t.deepEqual(inner.calls, [expected]);
+	t.deepEqual(setOptionCalls(outer.calls), [expected]);
+	t.deepEqual(setOptionCalls(inner.calls), [expected]);
 });
 
 test('appends rather than assigns, so user-configured features survive', t => {
@@ -70,7 +85,7 @@ test('appends rather than assigns, so user-configured features survive', t => {
 	const outer = recorder();
 	enableSynchronizedOutput(outer.runner, recorder().runner);
 
-	const [args] = outer.calls;
+	const [args] = setOptionCalls(outer.calls);
 	t.true(args!.includes('-ga'), 'must append');
 	t.false(args!.includes('-g'), 'must not use a bare assigning -g');
 	t.true(
@@ -86,7 +101,7 @@ test('the inner-socket call routes through innerTmuxArgs (keeps the -L flag)', t
 	const inner = recorder();
 	enableSynchronizedOutput(recorder().runner, inner.runner);
 
-	t.deepEqual(innerTmuxArgs(inner.calls[0]!), [
+	t.deepEqual(innerTmuxArgs(setOptionCalls(inner.calls)[0]!), [
 		'-L',
 		'pappardelle_inner',
 		'set-option',
@@ -121,7 +136,82 @@ test('a failure on the outer socket still attempts the inner socket', t => {
 
 	enableSynchronizedOutput(throwing, inner.runner);
 
-	t.is(inner.calls.length, 1);
+	t.is(setOptionCalls(inner.calls).length, 1);
+});
+
+test('skips the append when the feature is already present', t => {
+	// `-ga` is unconditional and `terminal-features` is server-scope, so without
+	// this check every launch against a long-lived tmux server piles on another
+	// copy: 19 `*:Sync` entries were observed on a live pappardelle_inner socket.
+	// The duplicates don't change rendering (tmux unions the features) but they
+	// make the option unreadable for exactly the color/redraw debugging it exists
+	// to support.
+	const outer = withFeatures('xterm*:clipboard', SYNC_TERMINAL_FEATURE);
+
+	enableSynchronizedOutput(outer.runner, recorder().runner);
+
+	t.deepEqual(setOptionCalls(outer.calls), []);
+});
+
+test('still appends when other features are configured but Sync is not', t => {
+	const outer = withFeatures('xterm*:clipboard', '*:RGB');
+
+	enableSynchronizedOutput(outer.runner, recorder().runner);
+
+	t.is(setOptionCalls(outer.calls).length, 1);
+});
+
+test('the presence check reads the option from the same socket', t => {
+	const inner = withFeatures();
+
+	enableSynchronizedOutput(recorder().runner, inner.runner);
+
+	t.deepEqual(inner.calls[0], ['show-options', '-gqv', 'terminal-features']);
+});
+
+test('each socket is checked independently', t => {
+	// The outer and inner sockets are separate tmux servers with separate option
+	// tables; one already carrying Sync says nothing about the other.
+	const outer = withFeatures(SYNC_TERMINAL_FEATURE);
+	const inner = withFeatures();
+
+	enableSynchronizedOutput(outer.runner, inner.runner);
+
+	t.deepEqual(setOptionCalls(outer.calls), []);
+	t.is(setOptionCalls(inner.calls).length, 1);
+});
+
+test('appends when the presence check fails, rather than losing the feature', t => {
+	// A duplicate entry is cosmetic; a missing one brings the flicker back. When
+	// we can't read the option, prefer the old unconditional behaviour.
+	const failing = recorder(args =>
+		args[0] === 'show-options'
+			? {status: 1, stdout: ''}
+			: {status: 0, stdout: ''},
+	);
+	const throwing = recorder(args => {
+		if (args[0] === 'show-options') {
+			throw new Error('tmux not found');
+		}
+
+		return {status: 0, stdout: ''};
+	});
+
+	enableSynchronizedOutput(failing.runner, throwing.runner);
+
+	t.is(setOptionCalls(failing.calls).length, 1);
+	t.is(setOptionCalls(throwing.calls).length, 1);
+});
+
+test('a substring match does not count as the feature being present', t => {
+	// `*:Sync` must match a whole array entry. tmux prints one entry per line, and
+	// an entry like `xterm*:SyncSomething` is a different feature on a different
+	// terminal pattern.
+	const outer = withFeatures('xterm*:SyncSomething', 'foo*:Sync');
+
+	enableSynchronizedOutput(outer.runner, recorder().runner);
+
+	t.is(setOptionCalls(outer.calls).length, 1);
 });
 
 test('setupPappardellLayout enables synchronized output', t => {

--- a/source/tmux-pane-query.test.ts
+++ b/source/tmux-pane-query.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression for the sidebar's "rows render nothing but the emoji" bug.
+ *
+ * `tmux display-message -p '#{pane_width}'` resolves against the *active* pane,
+ * not the calling process's pane. pappardelle lives in a sidebar the user
+ * normally isn't focused on, so the untargeted query reported the (much wider)
+ * claude pane. The list then laid its rows out for a width the pane didn't
+ * have, and Yoga's shrink chewed the issue key and title off every row.
+ */
+import test from 'ava';
+import {paneQueryArgs} from './tmux.ts';
+
+test('a pane id is passed through as an explicit -t target', t => {
+	t.deepEqual(paneQueryArgs('#{pane_width}', '%7'), [
+		'display-message',
+		'-p',
+		'-t',
+		'%7',
+		'#{pane_width}',
+	]);
+});
+
+test('the target precedes the format string (tmux rejects the other order)', t => {
+	const args = paneQueryArgs('#{pane_height}', '%12');
+	t.true(args.indexOf('-t') < args.indexOf('#{pane_height}'));
+	t.is(args.at(-1), '#{pane_height}');
+});
+
+test('without a pane id the query falls back to the untargeted form', t => {
+	// Outside tmux $TMUX_PANE is unset; the spawn fails and the caller's
+	// fallback dimension is used, so the untargeted form is harmless here.
+	t.deepEqual(paneQueryArgs('#{pane_width}', undefined), [
+		'display-message',
+		'-p',
+		'#{pane_width}',
+	]);
+	t.deepEqual(paneQueryArgs('#{pane_width}', ''), [
+		'display-message',
+		'-p',
+		'#{pane_width}',
+	]);
+});

--- a/source/tmux-sessions.test.ts
+++ b/source/tmux-sessions.test.ts
@@ -196,3 +196,42 @@ test('buildClaudeResumeCommand shell-quotes non-standard issue keys', t => {
 	// Must still reference --name twice.
 	t.is((cmd.match(/--name /g) ?? []).length, 2);
 });
+
+// Session-name encoding for beads' hierarchical IDs
+test('getSessionNames encodes the dot in a beads child ID', t => {
+	// tmux rewrites '.' to '_' in session names, so a raw name could never be
+	// found again by has-session, and a space that always looks absent gets
+	// respawned forever.
+	const names = getSessionNames('bd-a3f8e9.1', 'pappa');
+	t.is(names.claude, 'claude-pappa-bd-a3f8e9_1');
+	t.is(names.companion, 'companion-pappa-bd-a3f8e9_1');
+});
+
+test('extractIssueKeyFromSession decodes a beads child ID', t => {
+	t.is(
+		extractIssueKeyFromSession('claude-pappa-bd-a3f8e9_1', 'pappa'),
+		'bd-a3f8e9.1',
+	);
+});
+
+test('session-name encoding survives an underscore in the key', t => {
+	// A beads prefix defaults to the repo directory name, so my_service-a1b2 is
+	// an ordinary ID. Decoding every '_' to '.' would hand back my.service-a1b2.
+	const {claude} = getSessionNames('my_service-a1b2', 'pappa');
+	t.is(claude, 'claude-pappa-my__service-a1b2');
+	t.is(extractIssueKeyFromSession(claude, 'pappa'), 'my_service-a1b2');
+});
+
+test('session-name encoding round-trips every tracker key shape', t => {
+	for (const key of [
+		'STA-123',
+		'bd-a1b2',
+		'bd-a3f8e9.1',
+		'bd-a3f8e9.1.2',
+		'my_service-a1b2',
+		'my_service-a3f8e9.1',
+	]) {
+		const {claude} = getSessionNames(key, 'pappa');
+		t.is(extractIssueKeyFromSession(claude, 'pappa'), key);
+	}
+});

--- a/source/tmux.ts
+++ b/source/tmux.ts
@@ -1,6 +1,6 @@
 // Tmux session attachment for pappardelle
 // Attaches to existing claude-STA-XXX and companion-STA-XXX sessions created by idow
-import {exec, execSync, spawnSync} from 'node:child_process';
+import {exec, execSync, spawn, spawnSync} from 'node:child_process';
 import {existsSync, readFileSync, statSync, writeFileSync} from 'node:fs';
 import {homedir} from 'node:os';
 import {join} from 'node:path';
@@ -88,7 +88,7 @@ export function extractIssueKeyFromSession(
 ): string | null {
 	const prefix = getSessionPrefix('claude', repoName);
 	if (!sessionName.startsWith(prefix)) return null;
-	return sessionName.slice(prefix.length);
+	return fromSessionKey(sessionName.slice(prefix.length));
 }
 
 // Track which space is currently being viewed
@@ -169,6 +169,14 @@ export function innerSessionExists(sessionName: string): boolean {
 	}
 }
 
+export function toSessionKey(issueKey: string): string {
+	return issueKey.replaceAll('_', '__').replaceAll('.', '_');
+}
+
+export function fromSessionKey(sessionKey: string): string {
+	return sessionKey.replaceAll(/__|_/g, match => (match === '__' ? '_' : '.'));
+}
+
 /**
  * Get session names for a space.
  * Optional repoName parameter for testing; defaults to getRepoName().
@@ -182,9 +190,10 @@ export function getSessionNames(
 } {
 	const claudePrefix = getSessionPrefix('claude', repoName);
 	const companionPrefix = getSessionPrefix('companion', repoName);
+	const key = toSessionKey(issueKey);
 	return {
-		claude: `${claudePrefix}${issueKey}`,
-		companion: `${companionPrefix}${issueKey}`,
+		claude: `${claudePrefix}${key}`,
+		companion: `${companionPrefix}${key}`,
 	};
 }
 
@@ -218,6 +227,55 @@ function claudeFlag(flag: string, value?: string): string {
 	if (!value) return '';
 	const safe = /^[A-Za-z0-9._-]+$/.test(value) ? value : shellQuote(value);
 	return ` ${flag} ${safe}`;
+}
+
+// No `-F`: it would let the pager exit on its own for output that fits the
+// popup, which is exactly the flash-and-vanish this pager exists to prevent.
+const POPUP_PAGER = 'less -R';
+
+/**
+ * Show a command's output in a dismissible tmux popup over the current client.
+ * Used by trackers whose issues have no web page to open: beads keeps
+ * everything local, so `o` renders `bd show` here instead of launching a
+ * browser. Runs on the outer socket, where the TUI's own client lives.
+ *
+ * Detached like the other `o`-key launchers (`open`, `cursor`): the popup owns
+ * the terminal until the user dismisses it, and waiting on it here would stall
+ * Ink's render loop. `argv` is quoted rather than interpolated because
+ * display-popup takes a shell command string, not an argument vector.
+ * Returns false when there's no tmux client to draw over.
+ *
+ * The output goes through a pager because `-E` tears the popup down the moment
+ * the command exits, and the commands worth showing here print and exit
+ * immediately, and without it the popup flashes for a frame. The pager also makes
+ * an issue body taller than the popup scrollable instead of truncated.
+ */
+export function buildPopupCommand(argv: string[]): string {
+	return `${argv.map(arg => shellQuote(arg)).join(' ')} | ${POPUP_PAGER}`;
+}
+
+export function displayPopup(argv: string[]): boolean {
+	if (argv.length === 0 || !process.env['TMUX']) return false;
+	const command = buildPopupCommand(argv);
+	try {
+		const child = spawn(
+			'tmux',
+			['display-popup', '-E', '-w', '80%', '-h', '80%', command],
+			{detached: true, stdio: 'ignore'},
+		);
+
+		// A tmux that isn't on this process's PATH surfaces asynchronously, after
+		// the try block has already returned success. With no listener Node
+		// rethrows it and takes the whole TUI down over a popup that didn't open,
+		// so swallow it the way launchBrowser does — the worst case is a popup the
+		// user can see for themselves never appeared.
+		child.on('error', () => {});
+		child.unref();
+		return true;
+	} catch (error) {
+		log.debug(`display-popup failed: ${String(error)}`);
+		return false;
+	}
 }
 
 /**
@@ -540,6 +598,34 @@ const defaultInnerTmuxRunner: OuterTmuxRunner = args => {
 export const SYNC_TERMINAL_FEATURE = '*:Sync';
 
 /**
+ * Whether this socket's `terminal-features` already carries our Sync entry.
+ *
+ * `-v` prints one array entry per line with no `name[i]` prefix, so a whole-line
+ * comparison is the array-element test; a substring search would confuse us with
+ * a different terminal pattern that happens to name the same feature. Any
+ * failure reports "absent": a duplicate entry is cosmetic, a missing one brings
+ * the flicker back.
+ */
+function hasSynchronizedOutputFeature(run: OuterTmuxRunner): boolean {
+	try {
+		const {error, status, stdout} = run([
+			'show-options',
+			'-gqv',
+			'terminal-features',
+		]);
+		if (error || status !== 0) {
+			return false;
+		}
+
+		return stdout
+			.split('\n')
+			.some(line => line.trim() === SYNC_TERMINAL_FEATURE);
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Make tmux batch each repaint into a single atomic frame.
  *
  * tmux only wraps a redraw in DEC 2026 when it believes the attached client's
@@ -558,6 +644,10 @@ export const SYNC_TERMINAL_FEATURE = '*:Sync';
  * user-configured features survive, and terminals that don't implement DEC 2026
  * ignore the private mode, which is what makes the blanket `*` workable.
  *
+ * The append is also guarded by a presence check. The tmux server outlives any
+ * one Pappardelle run, so an unconditional `-ga` piles on another copy of the
+ * entry per launch.
+ *
  * Runners are exposed for tests only; production uses the spawnSync defaults.
  */
 export function enableSynchronizedOutput(
@@ -569,6 +659,10 @@ export function enableSynchronizedOutput(
 		['inner', innerRunner],
 	] as const) {
 		try {
+			if (hasSynchronizedOutputFeature(run)) {
+				continue;
+			}
+
 			const {error, status} = run([
 				'set-option',
 				'-ga',
@@ -626,11 +720,11 @@ export function cleanupOrphanedInnerSessions(
 		for (const name of result.stdout.trim().split('\n')) {
 			let key: string | null = null;
 			if (name.startsWith(claudePrefix)) {
-				key = name.slice(claudePrefix.length);
+				key = fromSessionKey(name.slice(claudePrefix.length));
 			} else if (name.startsWith(companionPrefix)) {
-				key = name.slice(companionPrefix.length);
+				key = fromSessionKey(name.slice(companionPrefix.length));
 			} else if (name.startsWith(legacyCompanionPrefix)) {
-				key = name.slice(legacyCompanionPrefix.length);
+				key = fromSessionKey(name.slice(legacyCompanionPrefix.length));
 			} else {
 				continue;
 			}
@@ -852,21 +946,35 @@ function getTmuxWindowSize(): {width: number; height: number} | null {
 }
 
 /**
- * Get current terminal/pane width from tmux
+ * Build the `tmux display-message` argv for reading a pane format variable.
+ *
+ * `display-message` resolves an untargeted format against the *active* pane,
+ * not the calling process's pane. pappardelle lives in a sidebar the user
+ * spends most of their time focused away from, so an untargeted query reports
+ * whatever pane the cursor happens to be in — usually the much wider claude
+ * pane. `$TMUX_PANE` is the pane id tmux exports into every process it spawns,
+ * so targeting it is what pins the answer to our own pane.
  */
-export function getTmuxPaneWidth(): number {
+export function paneQueryArgs(format: string, paneId?: string): string[] {
+	const args = ['display-message', '-p'];
+	if (paneId) args.push('-t', paneId);
+	args.push(format);
+	return args;
+}
+
+function queryPaneDimension(format: string, fallback: number): number {
 	try {
 		const result = spawnSync(
 			'tmux',
-			['display-message', '-p', '#{pane_width}'],
+			paneQueryArgs(format, process.env['TMUX_PANE']),
 			{encoding: 'utf-8', timeout: 5000},
 		);
 		if (result.error || result.status !== 0) {
-			return 120; // Default fallback
+			return fallback;
 		}
-		return parseInt(result.stdout.trim(), 10) || 120;
+		return parseInt(result.stdout.trim(), 10) || fallback;
 	} catch {
-		return 120;
+		return fallback;
 	}
 }
 
@@ -892,22 +1000,17 @@ function getPaneWidth(paneId: string): number | null {
 }
 
 /**
+ * Get current terminal/pane width from tmux
+ */
+export function getTmuxPaneWidth(): number {
+	return queryPaneDimension('#{pane_width}', 120);
+}
+
+/**
  * Get current terminal/pane height from tmux
  */
 export function getTmuxPaneHeight(): number {
-	try {
-		const result = spawnSync(
-			'tmux',
-			['display-message', '-p', '#{pane_height}'],
-			{encoding: 'utf-8', timeout: 5000},
-		);
-		if (result.error || result.status !== 0) {
-			return 40; // Default fallback
-		}
-		return parseInt(result.stdout.trim(), 10) || 40;
-	} catch {
-		return 40;
-	}
+	return queryPaneDimension('#{pane_height}', 40);
 }
 
 /**
@@ -1254,8 +1357,8 @@ export function attachToSpace(
 
 	// Load config once for all session creation. The companion command and the
 	// Claude launch flags are resolved profile-aware (via the issue title) so a
-	// per-project profile can override the default git UI / model / effort —
-	// this matters only when the sessions don't already exist (idow creates
+	// per-project profile can override the default git UI, model, and effort.
+	// This matters only when the sessions don't already exist (idow creates
 	// them with the same resolution at workspace-create time).
 	let skipPermissions = false;
 	let companionCommand = DEFAULT_COMPANION_COMMAND;

--- a/source/tmux.ts
+++ b/source/tmux.ts
@@ -229,26 +229,10 @@ function claudeFlag(flag: string, value?: string): string {
 	return ` ${flag} ${safe}`;
 }
 
-// No `-F`: it would let the pager exit on its own for output that fits the
-// popup, which is exactly the flash-and-vanish this pager exists to prevent.
 const POPUP_PAGER = 'less -R';
 
 /**
  * Show a command's output in a dismissible tmux popup over the current client.
- * Used by trackers whose issues have no web page to open: beads keeps
- * everything local, so `o` renders `bd show` here instead of launching a
- * browser. Runs on the outer socket, where the TUI's own client lives.
- *
- * Detached like the other `o`-key launchers (`open`, `cursor`): the popup owns
- * the terminal until the user dismisses it, and waiting on it here would stall
- * Ink's render loop. `argv` is quoted rather than interpolated because
- * display-popup takes a shell command string, not an argument vector.
- * Returns false when there's no tmux client to draw over.
- *
- * The output goes through a pager because `-E` tears the popup down the moment
- * the command exits, and the commands worth showing here print and exit
- * immediately, and without it the popup flashes for a frame. The pager also makes
- * an issue body taller than the popup scrollable instead of truncated.
  */
 export function buildPopupCommand(argv: string[]): string {
 	return `${argv.map(arg => shellQuote(arg)).join(' ')} | ${POPUP_PAGER}`;
@@ -264,11 +248,6 @@ export function displayPopup(argv: string[]): boolean {
 			{detached: true, stdio: 'ignore'},
 		);
 
-		// A tmux that isn't on this process's PATH surfaces asynchronously, after
-		// the try block has already returned success. With no listener Node
-		// rethrows it and takes the whole TUI down over a popup that didn't open,
-		// so swallow it the way launchBrowser does — the worst case is a popup the
-		// user can see for themselves never appeared.
 		child.on('error', () => {});
 		child.unref();
 		return true;
@@ -599,12 +578,6 @@ export const SYNC_TERMINAL_FEATURE = '*:Sync';
 
 /**
  * Whether this socket's `terminal-features` already carries our Sync entry.
- *
- * `-v` prints one array entry per line with no `name[i]` prefix, so a whole-line
- * comparison is the array-element test; a substring search would confuse us with
- * a different terminal pattern that happens to name the same feature. Any
- * failure reports "absent": a duplicate entry is cosmetic, a missing one brings
- * the flicker back.
  */
 function hasSynchronizedOutputFeature(run: OuterTmuxRunner): boolean {
 	try {
@@ -643,10 +616,6 @@ function hasSynchronizedOutputFeature(run: OuterTmuxRunner): boolean {
  * Two things keep that safe: we append (`-ga`) instead of assigning, so any
  * user-configured features survive, and terminals that don't implement DEC 2026
  * ignore the private mode, which is what makes the blanket `*` workable.
- *
- * The append is also guarded by a presence check. The tmux server outlives any
- * one Pappardelle run, so an unconditional `-ga` piles on another copy of the
- * entry per launch.
  *
  * Runners are exposed for tests only; production uses the spawnSync defaults.
  */
@@ -947,13 +916,6 @@ function getTmuxWindowSize(): {width: number; height: number} | null {
 
 /**
  * Build the `tmux display-message` argv for reading a pane format variable.
- *
- * `display-message` resolves an untargeted format against the *active* pane,
- * not the calling process's pane. pappardelle lives in a sidebar the user
- * spends most of their time focused away from, so an untargeted query reports
- * whatever pane the cursor happens to be in — usually the much wider claude
- * pane. `$TMUX_PANE` is the pane id tmux exports into every process it spawns,
- * so targeting it is what pins the answer to our own pane.
  */
 export function paneQueryArgs(format: string, paneId?: string): string[] {
 	const args = ['display-message', '-p'];

--- a/source/tracker.ts
+++ b/source/tracker.ts
@@ -39,12 +39,7 @@ export function clearCache(): void {
 	tracker().clearCache();
 }
 
-/**
- * Claim an issue, for trackers that support it. Resolves false rather than
- * throwing on every failure path — no tracker configured, tracker without the
- * capability, or the claim itself failing — because the sole caller is starting
- * a workspace and must not be blocked by a bookkeeping step.
- */
+/** Claim an issue, for trackers that support it. */
 export async function claimIssue(issueKey: string): Promise<boolean> {
 	try {
 		const provider = tracker();

--- a/source/tracker.ts
+++ b/source/tracker.ts
@@ -38,3 +38,19 @@ export async function searchAssignedIssues(
 export function clearCache(): void {
 	tracker().clearCache();
 }
+
+/**
+ * Claim an issue, for trackers that support it. Resolves false rather than
+ * throwing on every failure path — no tracker configured, tracker without the
+ * capability, or the claim itself failing — because the sole caller is starting
+ * a workspace and must not be blocked by a bookkeeping step.
+ */
+export async function claimIssue(issueKey: string): Promise<boolean> {
+	try {
+		const provider = tracker();
+		if (!provider.claimIssue) return false;
+		return await provider.claimIssue(issueKey);
+	} catch {
+		return false;
+	}
+}

--- a/source/types.ts
+++ b/source/types.ts
@@ -89,9 +89,13 @@ export const ACTIVE_STATUS_TIMEOUT = 10 * 60 * 1000;
 
 // Claude status display
 // Note: "processing" and "running_tool" use ClaudeAnimation instead of a static icon
+// `unknown` carries no color at all: the muted ANSI name it used to use is
+// bright black, which Solarized-family themes define as the background, so the
+// icon went invisible on the rows that most need explaining. `dim` mutes it
+// against whatever foreground the terminal actually has.
 export const CLAUDE_STATUS_DISPLAY: Record<
 	ClaudeStatus,
-	{color: string; icon?: string}
+	{color?: string; icon?: string; dim?: boolean}
 > = {
 	processing: {color: COLORS.CLAUDE_ORANGE},
 	running_tool: {color: COLORS.CLAUDE_ORANGE},
@@ -100,5 +104,5 @@ export const CLAUDE_STATUS_DISPLAY: Record<
 	compacting: {color: 'yellow', icon: '◇'},
 	ended: {color: 'green', icon: '●'},
 	error: {color: 'red', icon: '✗'},
-	unknown: {color: 'gray', icon: '?'},
+	unknown: {icon: '?', dim: true},
 };

--- a/source/types.ts
+++ b/source/types.ts
@@ -90,9 +90,7 @@ export const ACTIVE_STATUS_TIMEOUT = 10 * 60 * 1000;
 // Claude status display
 // Note: "processing" and "running_tool" use ClaudeAnimation instead of a static icon
 // `unknown` carries no color at all: the muted ANSI name it used to use is
-// bright black, which Solarized-family themes define as the background, so the
-// icon went invisible on the rows that most need explaining. `dim` mutes it
-// against whatever foreground the terminal actually has.
+// bright black.
 export const CLAUDE_STATUS_DISPLAY: Record<
 	ClaudeStatus,
 	{color?: string; icon?: string; dim?: boolean}

--- a/source/update-check.test.ts
+++ b/source/update-check.test.ts
@@ -125,17 +125,26 @@ test('readInstalledVersion: returns null when version missing', t => {
 // readInstalledVersionFromGit
 // ============================================================================
 
-test('readInstalledVersionFromGit: returns the latest semver tag reachable from HEAD', t => {
-	const dir = mkdtempSync(path.join(tmpdir(), 'pap-uc-git-'));
-	try {
-		initRepoWithTag(dir, 'v1.2.3');
-		t.is(readInstalledVersionFromGit(dir), 'v1.2.3');
-	} finally {
-		rmSync(dir, {recursive: true, force: true});
-	}
-});
+// These tests build real git repos via execFileSync, which blocks AVA's worker
+// thread on a synchronous OS wait. Running many of them concurrently (AVA's
+// default) starves AVA's IPC heartbeat for the whole batch's duration, which
+// exceeds its idle timeout and reports every test in the file — including
+// unrelated instant ones — as pending. Keeping these serial fixes that without
+// slowing down the rest of the file.
+test.serial(
+	'readInstalledVersionFromGit: returns the latest semver tag reachable from HEAD',
+	t => {
+		const dir = mkdtempSync(path.join(tmpdir(), 'pap-uc-git-'));
+		try {
+			initRepoWithTag(dir, 'v1.2.3');
+			t.is(readInstalledVersionFromGit(dir), 'v1.2.3');
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	},
+);
 
-test('readInstalledVersionFromGit: ignores non-semver tags', t => {
+test.serial('readInstalledVersionFromGit: ignores non-semver tags', t => {
 	const dir = mkdtempSync(path.join(tmpdir(), 'pap-uc-git-'));
 	try {
 		initRepoWithTag(dir, 'not-a-version');
@@ -145,15 +154,18 @@ test('readInstalledVersionFromGit: ignores non-semver tags', t => {
 	}
 });
 
-test('readInstalledVersionFromGit: returns null when no tags exist', t => {
-	const dir = mkdtempSync(path.join(tmpdir(), 'pap-uc-git-'));
-	try {
-		initRepoWithTag(dir, null);
-		t.is(readInstalledVersionFromGit(dir), null);
-	} finally {
-		rmSync(dir, {recursive: true, force: true});
-	}
-});
+test.serial(
+	'readInstalledVersionFromGit: returns null when no tags exist',
+	t => {
+		const dir = mkdtempSync(path.join(tmpdir(), 'pap-uc-git-'));
+		try {
+			initRepoWithTag(dir, null);
+			t.is(readInstalledVersionFromGit(dir), null);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	},
+);
 
 test('readInstalledVersionFromGit: returns null when not a git repo', t => {
 	const dir = mkdtempSync(path.join(tmpdir(), 'pap-uc-git-'));
@@ -168,7 +180,7 @@ test('readInstalledVersionFromGit: returns null when not a git repo', t => {
 // resolveInstalledVersion (git tag preferred, package.json fallback)
 // ============================================================================
 
-test('resolveInstalledVersion: uses the git tag when present', t => {
+test.serial('resolveInstalledVersion: uses the git tag when present', t => {
 	const dir = mkdtempSync(path.join(tmpdir(), 'pap-uc-resolve-'));
 	try {
 		initRepoWithTag(dir, 'v2.0.0');
@@ -182,19 +194,22 @@ test('resolveInstalledVersion: uses the git tag when present', t => {
 	}
 });
 
-test('resolveInstalledVersion: falls back to package.json when no tags', t => {
-	const dir = mkdtempSync(path.join(tmpdir(), 'pap-uc-resolve-'));
-	try {
-		initRepoWithTag(dir, null);
-		writeFileSync(
-			path.join(dir, 'package.json'),
-			JSON.stringify({version: '0.1.0'}),
-		);
-		t.is(resolveInstalledVersion(dir), '0.1.0');
-	} finally {
-		rmSync(dir, {recursive: true, force: true});
-	}
-});
+test.serial(
+	'resolveInstalledVersion: falls back to package.json when no tags',
+	t => {
+		const dir = mkdtempSync(path.join(tmpdir(), 'pap-uc-resolve-'));
+		try {
+			initRepoWithTag(dir, null);
+			writeFileSync(
+				path.join(dir, 'package.json'),
+				JSON.stringify({version: '0.1.0'}),
+			);
+			t.is(resolveInstalledVersion(dir), '0.1.0');
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	},
+);
 
 test('resolveInstalledVersion: returns null when neither source works', t => {
 	const dir = mkdtempSync(path.join(tmpdir(), 'pap-uc-resolve-'));
@@ -209,87 +224,105 @@ test('resolveInstalledVersion: returns null when neither source works', t => {
 // resolveDisplayVersion (help-overlay version: real tag vs -dev build)
 // ============================================================================
 
-test('resolveDisplayVersion: real release checkout reports the tag, not dev', t => {
-	const proj = mkdtempSync(path.join(tmpdir(), 'pap-disp-proj-'));
-	const install = mkdtempSync(path.join(tmpdir(), 'pap-disp-inst-'));
-	try {
-		initRepoWithTag(proj, 'v0.7.9');
-		initRepoWithTag(install, 'v0.7.9');
-		t.deepEqual(resolveDisplayVersion(proj, install), {
-			version: 'v0.7.9',
-			isDev: false,
-		});
-	} finally {
-		rmSync(proj, {recursive: true, force: true});
-		rmSync(install, {recursive: true, force: true});
-	}
-});
+test.serial(
+	'resolveDisplayVersion: real release checkout reports the tag, not dev',
+	t => {
+		const proj = mkdtempSync(path.join(tmpdir(), 'pap-disp-proj-'));
+		const install = mkdtempSync(path.join(tmpdir(), 'pap-disp-inst-'));
+		try {
+			initRepoWithTag(proj, 'v0.7.9');
+			initRepoWithTag(install, 'v0.7.9');
+			t.deepEqual(resolveDisplayVersion(proj, install), {
+				version: 'v0.7.9',
+				isDev: false,
+			});
+		} finally {
+			rmSync(proj, {recursive: true, force: true});
+			rmSync(install, {recursive: true, force: true});
+		}
+	},
+);
 
-test('resolveDisplayVersion: monorepo/worktree build reports the installed clone tag, flagged -dev', t => {
-	// projectDir has no vX.Y.Z tag (mirrors the monorepo); installed clone does.
-	const proj = mkdtempSync(path.join(tmpdir(), 'pap-disp-proj-'));
-	const install = mkdtempSync(path.join(tmpdir(), 'pap-disp-inst-'));
-	try {
-		initRepoWithTag(proj, null);
-		initRepoWithTag(install, 'v0.7.9');
-		t.deepEqual(resolveDisplayVersion(proj, install), {
-			version: 'v0.7.9',
-			isDev: true,
-		});
-	} finally {
-		rmSync(proj, {recursive: true, force: true});
-		rmSync(install, {recursive: true, force: true});
-	}
-});
+test.serial(
+	'resolveDisplayVersion: monorepo/worktree build reports the installed clone tag, flagged -dev',
+	t => {
+		// projectDir has no vX.Y.Z tag (mirrors the monorepo); installed clone does.
+		const proj = mkdtempSync(path.join(tmpdir(), 'pap-disp-proj-'));
+		const install = mkdtempSync(path.join(tmpdir(), 'pap-disp-inst-'));
+		try {
+			initRepoWithTag(proj, null);
+			initRepoWithTag(install, 'v0.7.9');
+			t.deepEqual(resolveDisplayVersion(proj, install), {
+				version: 'v0.7.9',
+				isDev: true,
+			});
+		} finally {
+			rmSync(proj, {recursive: true, force: true});
+			rmSync(install, {recursive: true, force: true});
+		}
+	},
+);
 
-test('resolveDisplayVersion: NEVER reports the stale package.json 0.1.0 for a dev build', t => {
-	// Regression guard for STA-1494: a worktree build whose package.json says
-	// 0.1.0 must surface the installed clone's real tag (as -dev), not 0.1.0.
-	const proj = mkdtempSync(path.join(tmpdir(), 'pap-disp-proj-'));
-	const install = mkdtempSync(path.join(tmpdir(), 'pap-disp-inst-'));
-	try {
-		initRepoWithTag(proj, null);
-		writeFileSync(
-			path.join(proj, 'package.json'),
-			JSON.stringify({version: '0.1.0'}),
-		);
-		initRepoWithTag(install, 'v0.7.9');
-		const result = resolveDisplayVersion(proj, install);
-		t.not(result.version, '0.1.0');
-		t.deepEqual(result, {version: 'v0.7.9', isDev: true});
-	} finally {
-		rmSync(proj, {recursive: true, force: true});
-		rmSync(install, {recursive: true, force: true});
-	}
-});
+test.serial(
+	'resolveDisplayVersion: NEVER reports the stale package.json 0.1.0 for a dev build',
+	t => {
+		// Regression guard for STA-1494: a worktree build whose package.json says
+		// 0.1.0 must surface the installed clone's real tag (as -dev), not 0.1.0.
+		const proj = mkdtempSync(path.join(tmpdir(), 'pap-disp-proj-'));
+		const install = mkdtempSync(path.join(tmpdir(), 'pap-disp-inst-'));
+		try {
+			initRepoWithTag(proj, null);
+			writeFileSync(
+				path.join(proj, 'package.json'),
+				JSON.stringify({version: '0.1.0'}),
+			);
+			initRepoWithTag(install, 'v0.7.9');
+			const result = resolveDisplayVersion(proj, install);
+			t.not(result.version, '0.1.0');
+			t.deepEqual(result, {version: 'v0.7.9', isDev: true});
+		} finally {
+			rmSync(proj, {recursive: true, force: true});
+			rmSync(install, {recursive: true, force: true});
+		}
+	},
+);
 
-test('resolveDisplayVersion: returns null version (sha-only) when nothing is resolvable', t => {
-	const proj = mkdtempSync(path.join(tmpdir(), 'pap-disp-proj-'));
-	const install = mkdtempSync(path.join(tmpdir(), 'pap-disp-inst-'));
-	try {
-		initRepoWithTag(proj, null);
-		initRepoWithTag(install, null);
-		t.deepEqual(resolveDisplayVersion(proj, install), {
-			version: null,
-			isDev: false,
-		});
-	} finally {
-		rmSync(proj, {recursive: true, force: true});
-		rmSync(install, {recursive: true, force: true});
-	}
-});
+test.serial(
+	'resolveDisplayVersion: returns null version (sha-only) when nothing is resolvable',
+	t => {
+		const proj = mkdtempSync(path.join(tmpdir(), 'pap-disp-proj-'));
+		const install = mkdtempSync(path.join(tmpdir(), 'pap-disp-inst-'));
+		try {
+			initRepoWithTag(proj, null);
+			initRepoWithTag(install, null);
+			t.deepEqual(resolveDisplayVersion(proj, install), {
+				version: null,
+				isDev: false,
+			});
+		} finally {
+			rmSync(proj, {recursive: true, force: true});
+			rmSync(install, {recursive: true, force: true});
+		}
+	},
+);
 
-test('resolveDisplayVersion: defaults installedRoot to ~/.pappardelle/repo', t => {
-	// When projectDir itself carries the tag, the default installedRoot is never
-	// consulted, so this is safe to run without touching the real home dir.
-	const proj = mkdtempSync(path.join(tmpdir(), 'pap-disp-proj-'));
-	try {
-		initRepoWithTag(proj, 'v1.2.3');
-		t.deepEqual(resolveDisplayVersion(proj), {version: 'v1.2.3', isDev: false});
-	} finally {
-		rmSync(proj, {recursive: true, force: true});
-	}
-});
+test.serial(
+	'resolveDisplayVersion: defaults installedRoot to ~/.pappardelle/repo',
+	t => {
+		// When projectDir itself carries the tag, the default installedRoot is never
+		// consulted, so this is safe to run without touching the real home dir.
+		const proj = mkdtempSync(path.join(tmpdir(), 'pap-disp-proj-'));
+		try {
+			initRepoWithTag(proj, 'v1.2.3');
+			t.deepEqual(resolveDisplayVersion(proj), {
+				version: 'v1.2.3',
+				isDev: false,
+			});
+		} finally {
+			rmSync(proj, {recursive: true, force: true});
+		}
+	},
+);
 
 // ============================================================================
 // Cache IO
@@ -426,123 +459,138 @@ test('checkForUpdate: returns null when LOCAL_MODE', async t => {
 	}
 });
 
-test('checkForUpdate: returns null when cache says we are up to date', async t => {
-	const fake = setupFakeInstall('0.1.0');
-	try {
-		writeCachedCheck(fake.cachePath, {
-			checkedAt: Date.now(),
-			latestVersion: '0.1.0',
-		});
-		const result = await checkForUpdate({
-			projectDir: fake.projectDir,
-			cachePath: fake.cachePath,
-		});
-		t.is(result, null);
-	} finally {
-		fake.cleanup();
-	}
-});
+test.serial(
+	'checkForUpdate: returns null when cache says we are up to date',
+	async t => {
+		const fake = setupFakeInstall('0.1.0');
+		try {
+			writeCachedCheck(fake.cachePath, {
+				checkedAt: Date.now(),
+				latestVersion: '0.1.0',
+			});
+			const result = await checkForUpdate({
+				projectDir: fake.projectDir,
+				cachePath: fake.cachePath,
+			});
+			t.is(result, null);
+		} finally {
+			fake.cleanup();
+		}
+	},
+);
 
-test('checkForUpdate: surfaces update when cache shows a newer version', async t => {
-	const fake = setupFakeInstall('0.1.0');
-	try {
-		writeCachedCheck(fake.cachePath, {
-			checkedAt: Date.now(),
-			latestVersion: 'v0.2.0',
-		});
-		const result = await checkForUpdate({
-			projectDir: fake.projectDir,
-			cachePath: fake.cachePath,
-		});
-		t.deepEqual(result, {installedVersion: '0.1.0', latestVersion: 'v0.2.0'});
-	} finally {
-		fake.cleanup();
-	}
-});
+test.serial(
+	'checkForUpdate: surfaces update when cache shows a newer version',
+	async t => {
+		const fake = setupFakeInstall('0.1.0');
+		try {
+			writeCachedCheck(fake.cachePath, {
+				checkedAt: Date.now(),
+				latestVersion: 'v0.2.0',
+			});
+			const result = await checkForUpdate({
+				projectDir: fake.projectDir,
+				cachePath: fake.cachePath,
+			});
+			t.deepEqual(result, {installedVersion: '0.1.0', latestVersion: 'v0.2.0'});
+		} finally {
+			fake.cleanup();
+		}
+	},
+);
 
-test('checkForUpdate: returns null when installed version is newer than cached', async t => {
-	// Can happen if you manually bump package.json locally.
-	const fake = setupFakeInstall('0.3.0');
-	try {
-		writeCachedCheck(fake.cachePath, {
-			checkedAt: Date.now(),
-			latestVersion: '0.2.0',
-		});
-		const result = await checkForUpdate({
-			projectDir: fake.projectDir,
-			cachePath: fake.cachePath,
-		});
-		t.is(result, null);
-	} finally {
-		fake.cleanup();
-	}
-});
+test.serial(
+	'checkForUpdate: returns null when installed version is newer than cached',
+	async t => {
+		// Can happen if you manually bump package.json locally.
+		const fake = setupFakeInstall('0.3.0');
+		try {
+			writeCachedCheck(fake.cachePath, {
+				checkedAt: Date.now(),
+				latestVersion: '0.2.0',
+			});
+			const result = await checkForUpdate({
+				projectDir: fake.projectDir,
+				cachePath: fake.cachePath,
+			});
+			t.is(result, null);
+		} finally {
+			fake.cleanup();
+		}
+	},
+);
 
-test('checkForUpdate: bypasses stale cache, calls fetchLatest, and rewrites the cache', async t => {
-	const fake = setupFakeInstall('0.1.0');
-	try {
-		const now = 1_800_000_000_000;
-		const STALE_TTL_MS = 25 * 60 * 60 * 1000;
-		writeCachedCheck(fake.cachePath, {
-			checkedAt: now - STALE_TTL_MS,
-			latestVersion: 'v0.1.0',
-		});
+test.serial(
+	'checkForUpdate: bypasses stale cache, calls fetchLatest, and rewrites the cache',
+	async t => {
+		const fake = setupFakeInstall('0.1.0');
+		try {
+			const now = 1_800_000_000_000;
+			const STALE_TTL_MS = 25 * 60 * 60 * 1000;
+			writeCachedCheck(fake.cachePath, {
+				checkedAt: now - STALE_TTL_MS,
+				latestVersion: 'v0.1.0',
+			});
 
-		let fetchCalls = 0;
-		const result = await checkForUpdate({
-			projectDir: fake.projectDir,
-			cachePath: fake.cachePath,
-			now,
-			async fetchLatest() {
-				fetchCalls += 1;
-				return 'v0.5.0';
-			},
-		});
+			let fetchCalls = 0;
+			const result = await checkForUpdate({
+				projectDir: fake.projectDir,
+				cachePath: fake.cachePath,
+				now,
+				async fetchLatest() {
+					fetchCalls += 1;
+					return 'v0.5.0';
+				},
+			});
 
-		t.is(fetchCalls, 1, 'stub should be called exactly once');
-		t.deepEqual(result, {installedVersion: '0.1.0', latestVersion: 'v0.5.0'});
+			t.is(fetchCalls, 1, 'stub should be called exactly once');
+			t.deepEqual(result, {installedVersion: '0.1.0', latestVersion: 'v0.5.0'});
 
-		const refreshed = readCachedCheck(fake.cachePath);
-		t.deepEqual(
-			refreshed,
-			{checkedAt: now, latestVersion: 'v0.5.0'},
-			'cache should be rewritten with the new value and fresh timestamp',
-		);
-	} finally {
-		fake.cleanup();
-	}
-});
+			const refreshed = readCachedCheck(fake.cachePath);
+			t.deepEqual(
+				refreshed,
+				{checkedAt: now, latestVersion: 'v0.5.0'},
+				'cache should be rewritten with the new value and fresh timestamp',
+			);
+		} finally {
+			fake.cleanup();
+		}
+	},
+);
 
-test('checkForUpdate: stale cache + fetchLatest returning null does not corrupt the cache', async t => {
-	const fake = setupFakeInstall('0.1.0');
-	try {
-		const now = 1_800_000_000_000;
-		const STALE_TTL_MS = 25 * 60 * 60 * 1000;
-		const staleEntry: CacheEntry = {
-			checkedAt: now - STALE_TTL_MS,
-			latestVersion: 'v0.1.0',
-		};
-		writeCachedCheck(fake.cachePath, staleEntry);
+test.serial(
+	'checkForUpdate: stale cache + fetchLatest returning null does not corrupt the cache',
+	async t => {
+		const fake = setupFakeInstall('0.1.0');
+		try {
+			const now = 1_800_000_000_000;
+			const STALE_TTL_MS = 25 * 60 * 60 * 1000;
+			const staleEntry: CacheEntry = {
+				checkedAt: now - STALE_TTL_MS,
+				latestVersion: 'v0.1.0',
+			};
+			writeCachedCheck(fake.cachePath, staleEntry);
 
-		const result = await checkForUpdate({
-			projectDir: fake.projectDir,
-			cachePath: fake.cachePath,
-			now,
-			async fetchLatest() {
-				return null;
-			},
-		});
+			const result = await checkForUpdate({
+				projectDir: fake.projectDir,
+				cachePath: fake.cachePath,
+				now,
+				async fetchLatest() {
+					return null;
+				},
+			});
 
-		t.is(result, null);
-		t.deepEqual(
-			readCachedCheck(fake.cachePath),
-			staleEntry,
-			'cache must not be overwritten when fetchLatest yields null',
-		);
-	} finally {
-		fake.cleanup();
-	}
-});
+			t.is(result, null);
+			t.deepEqual(
+				readCachedCheck(fake.cachePath),
+				staleEntry,
+				'cache must not be overwritten when fetchLatest yields null',
+			);
+		} finally {
+			fake.cleanup();
+		}
+	},
+);
 
 // ============================================================================
 // safeCheckForUpdate contract — must never reject, regardless of input
@@ -562,21 +610,24 @@ test('safeCheckForUpdate: resolves to null for LOCAL_MODE', async t => {
 	}
 });
 
-test('safeCheckForUpdate: swallows a throwing fetchLatest and resolves to null', async t => {
-	const fake = setupFakeInstall('0.1.0');
-	try {
-		const now = 1_800_000_000_000;
-		// No cache written — orchestrator will go straight to fetchLatest.
-		const result = await safeCheckForUpdate({
-			projectDir: fake.projectDir,
-			cachePath: fake.cachePath,
-			now,
-			async fetchLatest() {
-				throw new Error('boom');
-			},
-		});
-		t.is(result, null, 'the wrapper must not propagate the throw');
-	} finally {
-		fake.cleanup();
-	}
-});
+test.serial(
+	'safeCheckForUpdate: swallows a throwing fetchLatest and resolves to null',
+	async t => {
+		const fake = setupFakeInstall('0.1.0');
+		try {
+			const now = 1_800_000_000_000;
+			// No cache written — orchestrator will go straight to fetchLatest.
+			const result = await safeCheckForUpdate({
+				projectDir: fake.projectDir,
+				cachePath: fake.cachePath,
+				now,
+				async fetchLatest() {
+					throw new Error('boom');
+				},
+			});
+			t.is(result, null, 'the wrapper must not propagate the throw');
+		} finally {
+			fake.cleanup();
+		}
+	},
+);

--- a/source/watchlist.test.ts
+++ b/source/watchlist.test.ts
@@ -251,3 +251,24 @@ test('filterByKeyPrefixes excludes hyphenless (malformed) identifiers', t => {
 	t.is(result.length, 1);
 	t.is(result[0]!.identifier, 'STA-1');
 });
+
+test('filterByKeyPrefixes matches a beads prefix containing hyphens', t => {
+	// Splitting on the first hyphen produced 'SEATGEEK', which matched nothing,
+	// so the watchlist silently spawned zero workspaces.
+	const issues = [
+		makeIssue('seatgeek-ticket-management-cli-bqm'),
+		makeIssue('other-hic'),
+	];
+	const filtered = filterByKeyPrefixes(issues, [
+		'seatgeek-ticket-management-cli',
+	]);
+	t.deepEqual(
+		filtered.map(i => i.identifier),
+		['seatgeek-ticket-management-cli-bqm'],
+	);
+});
+
+test('filterByKeyPrefixes ignores a beads child suffix', t => {
+	const issues = [makeIssue('pap-a3f8e9.1')];
+	t.is(filterByKeyPrefixes(issues, ['pap']).length, 1);
+});

--- a/source/watchlist.ts
+++ b/source/watchlist.ts
@@ -1,5 +1,6 @@
 // Issue watchlist — polls the issue tracker for assigned issues with matching statuses
 // and determines which ones need new workspaces spawned.
+import {issueKeyPrefix} from './issue-utils.ts';
 import type {TrackerIssue} from './providers/types.ts';
 
 /**
@@ -56,6 +57,6 @@ export function filterByKeyPrefixes(
 	);
 	if (prefixSet.size === 0) return issues;
 	return issues.filter(issue =>
-		prefixSet.has(issue.identifier.split('-')[0]!.toUpperCase()),
+		prefixSet.has(issueKeyPrefix(issue.identifier).toUpperCase()),
 	);
 }

--- a/source/workspace-deinit.ts
+++ b/source/workspace-deinit.ts
@@ -13,6 +13,7 @@ export interface DeinitResult {
 export interface DeinitContext {
 	issueKey?: string;
 	repoRoot?: string;
+	mainRepoRoot?: string;
 	repoName?: string;
 }
 
@@ -77,6 +78,9 @@ function expandVars(
 		ISSUE_KEY: context?.issueKey ?? '',
 		WORKTREE_PATH: worktreePath,
 		REPO_ROOT: context?.repoRoot ?? '',
+		// Falls back to REPO_ROOT: the two coincide outside a linked worktree,
+		// which is where deinit runs from in every case but a nested one.
+		MAIN_REPO_ROOT: context?.mainRepoRoot ?? context?.repoRoot ?? '',
 		REPO_NAME: context?.repoName ?? '',
 	};
 	if (context?.issueKey) {

--- a/test/helpers/register-tsx.cjs
+++ b/test/helpers/register-tsx.cjs
@@ -1,0 +1,4 @@
+const {register} = require('tsx/esm/api');
+
+// AVA runs tests in worker threads, where tsx's automatic registration is skipped.
+register();


### PR DESCRIPTION
Adds [beads](https://github.com/gastownhall/beads) as an issue-tracker provider to pappardelle... plus the surrounding fixes/changes to make it more intuitive

[![Video Demo](https://www.youtube.com/watch?v=DWdTP4JYsSQ)](https://www.youtube.com/watch?v=DWdTP4JYsSQ)

## Changes

**The new provider**: `source/providers/beads-provider.ts`
**Two consumers of `bd ready`**:
- the watchlist (`searchAssignedIssues`) which supports a pseudo-software factory workflow using bead's issue types (true software factory stuff is a followup 😁)
- the new-session picker (`listReadyIssues`) which allows you to pick an issue for your workspace if you don't remember the issue number...

**Two-line issue rail**: handles some UI clunkiness with beads verbosity
**Adds 'x' as a keybinding to close a workspace**

A tricky part of this change was that the issue id format was baked into a lot of the application and bead's issue format broke the assumptions so there's a bit of invasive work here to handle bead's formatting

There's also some trickiness with making beads work correctly with worktrees (want to make sure you're writing to the correct database, not the one in the worktree), so this includes a few changes to make that work

## Review history

An earlier round of review happened on the fork PR (sddamico/pappardelle#21), which is now closed in favour of this one. Its 95 threads are all resolved; the two commits addressing them are on this branch.
