### PR TITLE
Apply the home/project/local config layers everywhere: idow reads and TUI provider init

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,12 @@ jobs:
       - name: tmux session name encoding
         run: ./scripts/test-session-name-encoding.sh
 
+      - name: Config layer merge in idow
+        run: ./scripts/test-config-layers.sh
+
+      - name: companion_command resolution
+        run: ./scripts/test-companion-command.sh
+
   python-tests:
     name: Python Tests
     runs-on: ubuntu-latest

--- a/pappardelle-config.md
+++ b/pappardelle-config.md
@@ -938,7 +938,7 @@ companion_command?: string; // top-level and per-profile
 
 **How it works:**
 
-- **Resolution order** (first defined wins): the matched profile's `companion_command` → the top-level `companion_command` → the built-in default `GIT_OPTIONAL_LOCKS=0 gitui`. Mirrors `getCompanionCommand()` in `source/config.ts`.
+- **Resolution order** (first defined wins): the matched profile's `companion_command` → the top-level `companion_command` → the built-in default `GIT_OPTIONAL_LOCKS=0 gitui`. Both levels are read from the merged config, so a top-level value in `~/.pappardelle/.pappardelle.yml` applies in every repo whose own config is silent, and a project or local layer overrides it. Mirrors `getCompanionCommand()` in `source/config.ts`; the bash side lives in `scripts/resolve-claude-config.sh`.
 - **Any command works** — a different git UI (`lazygit`, `tig`), a dev server (`npm run dev`), a log tailer (`tail -f log`), etc. The string is run verbatim in a shell-backed tmux session, so it persists even if the command exits.
 - **Empty string = plain shell.** An explicitly empty `companion_command: ""` (top-level or per-profile) leaves the pane as a bare shell — nothing is launched. An _absent_ value falls through to the next resolution level; only an explicit `""` short-circuits to "run nothing".
 - **The default carries `GIT_OPTIONAL_LOCKS=0`**, which keeps the git UI from taking lock files for read-only ops, avoiding contention with Claude's concurrent git calls. Custom commands run exactly as written — add the prefix yourself if your command is git-heavy.

--- a/pappardelle-config.md
+++ b/pappardelle-config.md
@@ -26,8 +26,6 @@ Config is assembled from up to three files, deep-merged lowest → highest prior
 
 Later layers override earlier ones key by key, so a home config setting `claude.model` still applies in a repo whose `.pappardelle.yml` never mentions it. Only the conflicting keys are replaced — `keybindings` are smart-merged rather than wholesale replaced.
 
-Both entry points see the same merged result. The TUI merges in `loadConfigFromPaths()`; `idow` merges the same three files once at startup (`merge_config_layers` in `scripts/provider-helpers.sh`) and reads every field from that document, so a profile, `team_prefix`, provider, `companion_command`, app, link, or hook declared only in the home config applies to workspaces launched from any repo.
-
 ## Configuration Schema
 
 ```yaml
@@ -940,7 +938,7 @@ companion_command?: string; // top-level and per-profile
 
 **How it works:**
 
-- **Resolution order** (first defined wins): the matched profile's `companion_command` → the top-level `companion_command` → the built-in default `GIT_OPTIONAL_LOCKS=0 gitui`. Both levels are read from the merged config layers, so a top-level value in `~/.pappardelle/.pappardelle.yml` applies in every repo whose own config is silent. Mirrors `getCompanionCommand()` in `source/config.ts`; the bash side lives in `scripts/resolve-claude-config.sh`.
+- **Resolution order** (first defined wins): the matched profile's `companion_command` → the top-level `companion_command` → the built-in default `GIT_OPTIONAL_LOCKS=0 gitui`. Mirrors `getCompanionCommand()` in `source/config.ts`; the bash side lives in `scripts/resolve-claude-config.sh`.
 - **Any command works** — a different git UI (`lazygit`, `tig`), a dev server (`npm run dev`), a log tailer (`tail -f log`), etc. The string is run verbatim in a shell-backed tmux session, so it persists even if the command exits.
 - **Empty string = plain shell.** An explicitly empty `companion_command: ""` (top-level or per-profile) leaves the pane as a bare shell — nothing is launched. An _absent_ value falls through to the next resolution level; only an explicit `""` short-circuits to "run nothing".
 - **The default carries `GIT_OPTIONAL_LOCKS=0`**, which keeps the git UI from taking lock files for read-only ops, avoiding contention with Claude's concurrent git calls. Custom commands run exactly as written — add the prefix yourself if your command is git-heavy.

--- a/pappardelle-config.md
+++ b/pappardelle-config.md
@@ -26,6 +26,8 @@ Config is assembled from up to three files, deep-merged lowest → highest prior
 
 Later layers override earlier ones key by key, so a home config setting `claude.model` still applies in a repo whose `.pappardelle.yml` never mentions it. Only the conflicting keys are replaced — `keybindings` are smart-merged rather than wholesale replaced.
 
+Both entry points see the same merged result. The TUI merges in `loadConfigFromPaths()`; `idow` merges the same three files once at startup (`merge_config_layers` in `scripts/provider-helpers.sh`) and reads every field from that document, so a profile, `team_prefix`, provider, `companion_command`, app, link, or hook declared only in the home config applies to workspaces launched from any repo.
+
 ## Configuration Schema
 
 ```yaml
@@ -938,7 +940,7 @@ companion_command?: string; // top-level and per-profile
 
 **How it works:**
 
-- **Resolution order** (first defined wins): the matched profile's `companion_command` → the top-level `companion_command` → the built-in default `GIT_OPTIONAL_LOCKS=0 gitui`. Both levels are read from the merged config, so a top-level value in `~/.pappardelle/.pappardelle.yml` applies in every repo whose own config is silent, and a project or local layer overrides it. Mirrors `getCompanionCommand()` in `source/config.ts`; the bash side lives in `scripts/resolve-claude-config.sh`.
+- **Resolution order** (first defined wins): the matched profile's `companion_command` → the top-level `companion_command` → the built-in default `GIT_OPTIONAL_LOCKS=0 gitui`. Both levels are read from the merged config layers, so a top-level value in `~/.pappardelle/.pappardelle.yml` applies in every repo whose own config is silent. Mirrors `getCompanionCommand()` in `source/config.ts`; the bash side lives in `scripts/resolve-claude-config.sh`.
 - **Any command works** — a different git UI (`lazygit`, `tig`), a dev server (`npm run dev`), a log tailer (`tail -f log`), etc. The string is run verbatim in a shell-backed tmux session, so it persists even if the command exits.
 - **Empty string = plain shell.** An explicitly empty `companion_command: ""` (top-level or per-profile) leaves the pane as a bare shell — nothing is launched. An _absent_ value falls through to the next resolution level; only an explicit `""` short-circuits to "run nothing".
 - **The default carries `GIT_OPTIONAL_LOCKS=0`**, which keeps the git UI from taking lock files for read-only ops, avoiding contention with Claude's concurrent git calls. Custom commands run exactly as written — add the prefix yourself if your command is git-heavy.

--- a/scripts/idow
+++ b/scripts/idow
@@ -765,10 +765,10 @@ else
     print_success "No PR/MR yet (the agent opens one at its first real commit)"
 fi
 
-# Resolve the companion-pane command: per-profile override → top-level → gitui
-# default. yq's // keeps an explicit empty string ("plain shell") and only falls
-# through on a missing/null key. Mirrors getCompanionCommand() in config.ts.
-COMPANION_COMMAND=$(yq -r "(.profiles.$SELECTED_PROFILE.companion_command // .companion_command) // \"GIT_OPTIONAL_LOCKS=0 gitui\"" "$CONFIG_PATH" 2>/dev/null)
+# Resolve the companion-pane command across all config layers (home → project
+# → local), per-profile override → top-level → gitui default. Reading only the
+# project file here used to skip a home-config default entirely.
+COMPANION_COMMAND=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH" --home-config "$HOME_CONFIG_PATH" --profile "$SELECTED_PROFILE" | jq -r '.companion_command')
 
 # Step 7: Ensure Claude and companion tmux sessions exist (always, regardless of --open)
 print_step 7 "Starting Claude tmux session..."

--- a/scripts/idow
+++ b/scripts/idow
@@ -136,9 +136,6 @@ resolve_repo_config() {
     fi
 }
 
-# The committed project layer. CONFIG_PATH is repointed at the merged
-# home -> project -> local document once the helpers are loaded; every yq
-# read below that point goes through the merged file.
 PROJECT_CONFIG_PATH=$(resolve_repo_config .pappardelle.yml)
 CONFIG_PATH="$PROJECT_CONFIG_PATH"
 # Personal defaults shared across every repo. Must stay in step with

--- a/scripts/idow
+++ b/scripts/idow
@@ -136,7 +136,11 @@ resolve_repo_config() {
     fi
 }
 
-CONFIG_PATH=$(resolve_repo_config .pappardelle.yml)
+# The committed project layer. CONFIG_PATH is repointed at the merged
+# home -> project -> local document once the helpers are loaded; every yq
+# read below that point goes through the merged file.
+PROJECT_CONFIG_PATH=$(resolve_repo_config .pappardelle.yml)
+CONFIG_PATH="$PROJECT_CONFIG_PATH"
 # Personal defaults shared across every repo. Must stay in step with
 # getDefaultHomeConfigDir() in source/config.ts, which is what the TUI reads.
 HOME_CONFIG_PATH="$HOME/.pappardelle/.pappardelle.yml"
@@ -174,7 +178,7 @@ fi
 # These are the top-level values; once a profile is selected, the launch flags
 # are re-resolved profile-first via resolve_claude_launch_flags below.
 LOCAL_CONFIG_PATH=$(resolve_repo_config .pappardelle.local.yml)
-CLAUDE_CONFIG_JSON=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH" --home-config "$HOME_CONFIG_PATH")
+CLAUDE_CONFIG_JSON=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$PROJECT_CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH" --home-config "$HOME_CONFIG_PATH")
 INIT_CMD=$(echo "$CLAUDE_CONFIG_JSON" | jq -r '.init_cmd')
 SKIP_PERMISSIONS=$(echo "$CLAUDE_CONFIG_JSON" | jq -r '.skip_permissions')
 CLAUDE_MODEL=$(echo "$CLAUDE_CONFIG_JSON" | jq -r '.model')
@@ -189,7 +193,7 @@ CLAUDE_EFFORT=$(echo "$CLAUDE_CONFIG_JSON" | jq -r '.effort')
 resolve_claude_launch_flags() {
     local profile="$1"
     local json
-    json=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH" --home-config "$HOME_CONFIG_PATH" --profile "$profile")
+    json=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$PROJECT_CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH" --home-config "$HOME_CONFIG_PATH" --profile "$profile")
     CLAUDE_MODEL=$(echo "$json" | jq -r '.model')
     CLAUDE_EFFORT=$(echo "$json" | jq -r '.effort')
     [[ -n "$CLAUDE_MODEL" ]] && log "Claude model: $CLAUDE_MODEL"
@@ -200,6 +204,14 @@ resolve_claude_launch_flags() {
 # Source provider-agnostic helpers
 # shellcheck source=provider-helpers.sh
 source "$SCRIPT_DIR/provider-helpers.sh"
+
+# From here on, read the merged config so home and local layers apply to
+# every field (profiles, team_prefix, providers, apps, links, hooks, ...),
+# not only the Claude settings that resolve-claude-config.sh layers itself.
+MERGED_CONFIG_PATH=$(mktemp -t pappardelle-config.XXXXXX)
+trap 'rm -f "$MERGED_CONFIG_PATH"' EXIT
+merge_config_layers "$HOME_CONFIG_PATH" "$PROJECT_CONFIG_PATH" "$LOCAL_CONFIG_PATH" > "$MERGED_CONFIG_PATH"
+CONFIG_PATH="$MERGED_CONFIG_PATH"
 
 # Detect configured providers
 TRACKER_PROVIDER=$(get_issue_tracker_provider "$CONFIG_PATH")
@@ -765,10 +777,10 @@ else
     print_success "No PR/MR yet (the agent opens one at its first real commit)"
 fi
 
-# Resolve the companion-pane command across all config layers (home → project
-# → local), per-profile override → top-level → gitui default. Reading only the
-# project file here used to skip a home-config default entirely.
-COMPANION_COMMAND=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH" --home-config "$HOME_CONFIG_PATH" --profile "$SELECTED_PROFILE" | jq -r '.companion_command')
+# Resolve the companion-pane command: per-profile override → top-level → gitui
+# default, over the merged config layers. Mirrors getCompanionCommand() in
+# config.ts; the empty-string-means-plain-shell rule lives in the resolver.
+COMPANION_COMMAND=$("$SCRIPT_DIR/resolve-claude-config.sh" --config "$PROJECT_CONFIG_PATH" --local-config "$LOCAL_CONFIG_PATH" --home-config "$HOME_CONFIG_PATH" --profile "$SELECTED_PROFILE" | jq -r '.companion_command')
 
 # Step 7: Ensure Claude and companion tmux sessions exist (always, regardless of --open)
 print_step 7 "Starting Claude tmux session..."

--- a/scripts/provider-helpers.sh
+++ b/scripts/provider-helpers.sh
@@ -7,6 +7,28 @@
 #
 # Requires: yq, jq, and the relevant CLI tools (linctl/acli, gh/glab)
 
+# Deep-merge the config layers into one YAML document on stdout, lowest to
+# highest priority: home -> project -> local. Missing files are skipped. Maps
+# merge key by key and arrays replace wholesale, which is what deepMerge() in
+# source/config.ts does, so the TUI and idow see the same effective config.
+# Args: $1=home_config_path, $2=project_config_path, $3=local_config_path
+merge_config_layers() {
+    local files=() f
+    for f in "$@"; do
+        [[ -n "$f" && -f "$f" ]] && files+=("$f")
+    done
+    [[ ${#files[@]} -gt 0 ]] || { echo "{}"; return; }
+    if [[ ${#files[@]} -eq 1 ]]; then
+        cat "${files[0]}"
+        return
+    fi
+    local expr="select(fileIndex==0)" i
+    for (( i=1; i<${#files[@]}; i++ )); do
+        expr="$expr * select(fileIndex==$i)"
+    done
+    yq eval-all "$expr" "${files[@]}"
+}
+
 # Get the issue tracker provider from .pappardelle.yml
 # Returns: "linear" (default), "jira", or "beads"
 get_issue_tracker_provider() {

--- a/scripts/resolve-claude-config.sh
+++ b/scripts/resolve-claude-config.sh
@@ -24,8 +24,14 @@
 # change which layer wins. Mirrored by getClaudeModel()/getClaudeEffort() in
 # source/config.ts and pinned by scripts/test-claude-model-effort.sh.
 #
+# companion_command is resolved here too, profile-first over the merged layers,
+# so a top-level value in the home config reaches every repo. The built-in
+# default applies only when no layer defines the key at any level; an explicit
+# "" (plain shell) is preserved. Mirrors getCompanionCommand() in source/config.ts.
+#
 # Output: JSON object with resolved values:
-#   {"init_cmd": "...", "skip_permissions": "true|false", "model": "...", "effort": "..."}
+#   {"init_cmd": "...", "skip_permissions": "true|false", "model": "...", "effort": "...",
+#    "companion_command": "..."}
 
 set -e
 
@@ -121,7 +127,16 @@ resolve_launch_field() {
 MODEL=$(resolve_launch_field model)
 EFFORT=$(resolve_launch_field effort)
 
+DEFAULT_COMPANION_COMMAND="GIT_OPTIONAL_LOCKS=0 gitui"
+export PAPPARDELLE_DEFAULT_COMPANION_COMMAND="$DEFAULT_COMPANION_COMMAND"
+if [[ -n "$PROFILE" ]]; then
+    COMPANION_COMMAND=$(echo "$RESOLVED" | yq -r \
+        '(.profiles[strenv(PAPPARDELLE_PROFILE)].companion_command // .companion_command) // strenv(PAPPARDELLE_DEFAULT_COMPANION_COMMAND)')
+else
+    COMPANION_COMMAND=$(echo "$RESOLVED" | yq -r '.companion_command // strenv(PAPPARDELLE_DEFAULT_COMPANION_COMMAND)')
+fi
+
 # Output as JSON (use jq to handle escaping of special characters)
 jq -n --arg init_cmd "$INIT_CMD" --arg skip_permissions "$SKIP_PERMISSIONS" \
-  --arg model "$MODEL" --arg effort "$EFFORT" \
-  '{init_cmd: $init_cmd, skip_permissions: $skip_permissions, model: $model, effort: $effort}'
+  --arg model "$MODEL" --arg effort "$EFFORT" --arg companion_command "$COMPANION_COMMAND" \
+  '{init_cmd: $init_cmd, skip_permissions: $skip_permissions, model: $model, effort: $effort, companion_command: $companion_command}'

--- a/scripts/test-companion-command.sh
+++ b/scripts/test-companion-command.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
 
-# Test: companion_command resolution in idow (STA-1464)
+# Test: companion_command resolution in resolve-claude-config.sh (STA-1464)
 #
-# Verifies the resolution chain the idow yq one-liner implements:
-#   profiles.<name>.companion_command → companion_command → "GIT_OPTIONAL_LOCKS=0 gitui"
+# Exercises the REAL resolver across config layers and profile levels:
+#   home config → project config → local config, then profile → top-level → default.
 #
 # This mirrors getCompanionCommand() in source/config.ts. The two resolvers run
 # in different languages (bash/yq vs TS) and must agree, so we pin the bash side
 # here. Key behaviors: per-profile override beats top-level; an explicit empty
-# string is preserved (means "plain shell"); a missing key falls through.
+# string is preserved (means "plain shell"); a missing key falls through; a
+# home-config default reaches a repo whose own config never mentions the key.
 #
 # Usage: ./test-companion-command.sh
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PASS=0
 FAIL=0
 
@@ -45,51 +47,56 @@ assert_eq() {
     fi
 }
 
-# Mirror idow's companion_command resolution exactly (keep in sync with idow).
-# Args: <profile_name> <config_path>
+# Run the real resolver for a profile against whatever setup_configs() last wrote.
 resolve_companion_command() {
-    local profile="$1"
-    local config_path="$2"
-    yq -r "(.profiles.$profile.companion_command // .companion_command) // \"GIT_OPTIONAL_LOCKS=0 gitui\"" "$config_path"
+    "$SCRIPT_DIR/resolve-claude-config.sh" \
+        --config "$TMPDIR_ROOT/.pappardelle.yml" \
+        --local-config "$TMPDIR_ROOT/.pappardelle.local.yml" \
+        --home-config "$TMPDIR_ROOT/home/.pappardelle.yml" \
+        --profile "$1" | jq -r '.companion_command'
 }
 
-setup_config() {
-    local body="$1"
+# setup_configs <project_yaml> [local_yaml] [home_yaml]
+setup_configs() {
     TMPDIR_ROOT=$(mktemp -d)
-    printf '%s\n' "$body" > "$TMPDIR_ROOT/.pappardelle.yml"
+    mkdir -p "$TMPDIR_ROOT/home"
+    printf '%s\n' "$1" > "$TMPDIR_ROOT/.pappardelle.yml"
+    if [[ -n "${2:-}" ]]; then
+        printf '%s\n' "$2" > "$TMPDIR_ROOT/.pappardelle.local.yml"
+    fi
+    if [[ -n "${3:-}" ]]; then
+        printf '%s\n' "$3" > "$TMPDIR_ROOT/home/.pappardelle.yml"
+    fi
 }
 
-# ==========================================================================
-
-echo -e "\n${BOLD}Test: defaults to gitui when neither profile nor top-level set${RESET}"
-setup_config "version: 1
-default_profile: api
-profiles:
+API_PROFILE="profiles:
   api:
     display_name: API
     keywords: [api]"
-result=$(resolve_companion_command "api" "$TMPDIR_ROOT/.pappardelle.yml")
-assert_eq "default → gitui" "GIT_OPTIONAL_LOCKS=0 gitui" "$result"
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: defaults to gitui when no layer sets it${RESET}"
+setup_configs "version: 1
+default_profile: api
+$API_PROFILE"
+assert_eq "default → gitui" "GIT_OPTIONAL_LOCKS=0 gitui" "$(resolve_companion_command api)"
 cleanup; unset TMPDIR_ROOT
 
 # ==========================================================================
 
 echo -e "\n${BOLD}Test: top-level companion_command applies when profile has none${RESET}"
-setup_config "version: 1
+setup_configs "version: 1
 default_profile: api
 companion_command: lazygit
-profiles:
-  api:
-    display_name: API
-    keywords: [api]"
-result=$(resolve_companion_command "api" "$TMPDIR_ROOT/.pappardelle.yml")
-assert_eq "top-level lazygit" "lazygit" "$result"
+$API_PROFILE"
+assert_eq "top-level lazygit" "lazygit" "$(resolve_companion_command api)"
 cleanup; unset TMPDIR_ROOT
 
 # ==========================================================================
 
 echo -e "\n${BOLD}Test: per-profile companion_command beats top-level${RESET}"
-setup_config "version: 1
+setup_configs "version: 1
 default_profile: backend
 companion_command: gitui
 profiles:
@@ -100,31 +107,24 @@ profiles:
   frontend:
     display_name: Frontend
     keywords: [frontend]"
-result=$(resolve_companion_command "backend" "$TMPDIR_ROOT/.pappardelle.yml")
-assert_eq "profile override wins" "make run" "$result"
-# A profile without its own override falls back to the top-level value.
-result=$(resolve_companion_command "frontend" "$TMPDIR_ROOT/.pappardelle.yml")
-assert_eq "profile without override → top-level" "gitui" "$result"
+assert_eq "profile override wins" "make run" "$(resolve_companion_command backend)"
+assert_eq "profile without override → top-level" "gitui" "$(resolve_companion_command frontend)"
 cleanup; unset TMPDIR_ROOT
 
 # ==========================================================================
 
 echo -e "\n${BOLD}Test: explicit empty string is preserved (plain shell)${RESET}"
-setup_config "version: 1
+setup_configs "version: 1
 default_profile: api
 companion_command: \"\"
-profiles:
-  api:
-    display_name: API
-    keywords: [api]"
-result=$(resolve_companion_command "api" "$TMPDIR_ROOT/.pappardelle.yml")
-assert_eq "empty top-level stays empty" "" "$result"
+$API_PROFILE"
+assert_eq "empty top-level stays empty" "" "$(resolve_companion_command api)"
 cleanup; unset TMPDIR_ROOT
 
 # ==========================================================================
 
 echo -e "\n${BOLD}Test: per-profile empty string overrides a non-empty top-level${RESET}"
-setup_config "version: 1
+setup_configs "version: 1
 default_profile: docs
 companion_command: gitui
 profiles:
@@ -132,18 +132,64 @@ profiles:
     display_name: Docs
     keywords: [docs]
     companion_command: \"\""
-result=$(resolve_companion_command "docs" "$TMPDIR_ROOT/.pappardelle.yml")
-assert_eq "profile empty wins over top-level" "" "$result"
+assert_eq "profile empty wins over top-level" "" "$(resolve_companion_command docs)"
 cleanup; unset TMPDIR_ROOT
 
 # ==========================================================================
 
+echo -e "\n${BOLD}Test: home-config top-level reaches a project that never mentions it${RESET}"
+setup_configs "version: 1
+default_profile: api
+$API_PROFILE" "" "version: 1
+companion_command: hunk diff --watch"
+assert_eq "home top-level → project profile" "hunk diff --watch" "$(resolve_companion_command api)"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: project top-level beats home top-level${RESET}"
+setup_configs "version: 1
+default_profile: api
+companion_command: tig
+$API_PROFILE" "" "version: 1
+companion_command: hunk diff --watch"
+assert_eq "project top-level wins" "tig" "$(resolve_companion_command api)"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: home-config per-profile override applies to a project-declared profile${RESET}"
+setup_configs "version: 1
+default_profile: api
+companion_command: tig
+$API_PROFILE" "" "version: 1
+profiles:
+  api:
+    companion_command: make run"
+assert_eq "home profile override beats project top-level" "make run" "$(resolve_companion_command api)"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: local config beats project and home${RESET}"
+setup_configs "version: 1
+default_profile: api
+companion_command: tig
+$API_PROFILE" "companion_command: \"\"" "version: 1
+companion_command: hunk diff --watch"
+assert_eq "local empty string wins over both" "" "$(resolve_companion_command api)"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: idow reads companion_command from the layered resolver, not the project file${RESET}"
+IDOW_RAW_LOOKUPS=$(grep -c 'companion_command // .companion_command' "$SCRIPT_DIR/idow" || true)
+assert_eq "no single-file yq lookup left in idow" "0" "$IDOW_RAW_LOOKUPS"
+IDOW_RESOLVER_LOOKUPS=$(grep -c "jq -r '.companion_command'" "$SCRIPT_DIR/idow" || true)
+assert_eq "idow takes companion_command from resolver JSON" "1" "$IDOW_RESOLVER_LOOKUPS"
+
+# ==========================================================================
+
 echo ""
-TOTAL=$((PASS + FAIL))
-if [[ "$FAIL" -eq 0 ]]; then
-    echo -e "${GREEN}${BOLD}All $TOTAL tests passed${RESET}"
-    exit 0
-else
-    echo -e "${RED}${BOLD}$FAIL of $TOTAL tests failed${RESET}"
-    exit 1
-fi
+echo -e "${BOLD}Results: ${GREEN}$PASS passed${RESET}, ${RED}$FAIL failed${RESET}"
+[[ $FAIL -eq 0 ]]

--- a/scripts/test-config-layers.sh
+++ b/scripts/test-config-layers.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# Test: idow reads the merged home -> project -> local config
+#
+# idow used to layer only the Claude settings (through resolve-claude-config.sh)
+# and read everything else — profiles, team_prefix, providers, apps, links,
+# hooks, companion_command — from the project .pappardelle.yml alone, so a home
+# config never reached the launch path. It now merges the three layers once
+# (merge_config_layers in provider-helpers.sh) and points CONFIG_PATH at the
+# result. This pins the merge semantics (must match deepMerge() in
+# source/config.ts: maps merge key by key, arrays replace) and guards the idow
+# wiring.
+#
+# Usage: ./test-config-layers.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+cleanup() {
+    if [[ -n "${TMPDIR_ROOT:-}" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local test_name="$1"
+    local expected="$2"
+    local actual="$3"
+
+    if [[ "$actual" == "$expected" ]]; then
+        echo -e "  ${GREEN}PASS${RESET} $test_name"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${RESET} $test_name"
+        echo "    Expected: \"$expected\""
+        echo "    Actual:   \"$actual\""
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# shellcheck source=provider-helpers.sh
+source "$SCRIPT_DIR/provider-helpers.sh"
+
+# setup_configs <project_yaml> [local_yaml] [home_yaml]
+setup_configs() {
+    TMPDIR_ROOT=$(mktemp -d)
+    mkdir -p "$TMPDIR_ROOT/home"
+    printf '%s\n' "$1" > "$TMPDIR_ROOT/.pappardelle.yml"
+    if [[ -n "${2:-}" ]]; then
+        printf '%s\n' "$2" > "$TMPDIR_ROOT/.pappardelle.local.yml"
+    fi
+    if [[ -n "${3:-}" ]]; then
+        printf '%s\n' "$3" > "$TMPDIR_ROOT/home/.pappardelle.yml"
+    fi
+}
+
+merged() {
+    merge_config_layers "$TMPDIR_ROOT/home/.pappardelle.yml" "$TMPDIR_ROOT/.pappardelle.yml" "$TMPDIR_ROOT/.pappardelle.local.yml"
+}
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: project-only config passes through unchanged${RESET}"
+setup_configs "version: 1
+team_prefix: STA
+profiles:
+  api:
+    display_name: API"
+assert_eq "team_prefix" "STA" "$(merged | yq -r '.team_prefix')"
+assert_eq "profile list" "api" "$(merged | yq -r '.profiles | keys | .[]')"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: home-only settings reach a project that never mentions them${RESET}"
+setup_configs "version: 1
+profiles:
+  api:
+    display_name: API" "" "version: 1
+team_prefix: RXAI
+default_profile: rex-ai
+companion_command: hunk diff --watch
+issue_tracker:
+  provider: jira
+vcs_host:
+  provider: gitlab
+  host: gitlab.example.com
+profiles:
+  rex-ai:
+    display_name: REx AI
+    keywords: [rex]
+    links:
+      - url: \"\${ISSUE_URL}\"
+        title: Jira"
+assert_eq "team_prefix from home" "RXAI" "$(merged | yq -r '.team_prefix')"
+assert_eq "default_profile from home" "rex-ai" "$(merged | yq -r '.default_profile')"
+assert_eq "home profile joins the project's" "api rex-ai" "$(merged | yq -r '.profiles | keys | sort | join(" ")')"
+assert_eq "home profile keywords survive" "rex" "$(merged | yq -r '.profiles.rex-ai.keywords[0]')"
+assert_eq "home profile links survive" "Jira" "$(merged | yq -r '.profiles.rex-ai.links[0].title')"
+assert_eq "provider from home" "jira" "$(get_issue_tracker_provider <(merged))"
+assert_eq "gitlab host from home" "gitlab.example.com" "$(get_gitlab_host <(merged))"
+assert_eq "companion_command from home" "hunk diff --watch" "$(merged | yq -r '.companion_command')"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: project beats home, local beats both, key by key${RESET}"
+setup_configs "version: 1
+team_prefix: PROJ
+profiles:
+  api:
+    display_name: API
+    claude:
+      initialization_command: /do" "team_prefix: LOCAL
+profiles:
+  api:
+    claude:
+      model: opus" "version: 1
+team_prefix: HOME
+companion_command: hunk diff --watch
+profiles:
+  api:
+    display_name: Home API
+    emoji: X
+    claude:
+      effort: high"
+assert_eq "scalar: local wins" "LOCAL" "$(merged | yq -r '.team_prefix')"
+assert_eq "profile scalar: project beats home" "API" "$(merged | yq -r '.profiles.api.display_name')"
+assert_eq "profile key only in home survives" "X" "$(merged | yq -r '.profiles.api.emoji')"
+assert_eq "nested map merges across all three layers" "/do high opus" \
+    "$(merged | yq -r '.profiles.api.claude | [.initialization_command, .effort, .model] | join(" ")')"
+assert_eq "home-only top-level key survives" "hunk diff --watch" "$(merged | yq -r '.companion_command')"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: arrays replace, they do not append (matches deepMerge in config.ts)${RESET}"
+setup_configs "version: 1
+profiles:
+  api:
+    keywords: [project-kw]" "" "version: 1
+profiles:
+  api:
+    keywords: [home-kw-1, home-kw-2]"
+assert_eq "project array replaces home array" "project-kw" "$(merged | yq -r '.profiles.api.keywords | join(",")')"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: missing home and local files are skipped, not errors${RESET}"
+setup_configs "version: 1
+team_prefix: ONLY"
+assert_eq "no home, no local" "ONLY" "$(merged | yq -r '.team_prefix')"
+assert_eq "nonexistent explicit path is skipped" "ONLY" \
+    "$(merge_config_layers "/nonexistent/home.yml" "$TMPDIR_ROOT/.pappardelle.yml" "" | yq -r '.team_prefix')"
+cleanup; unset TMPDIR_ROOT
+
+# ==========================================================================
+
+echo -e "\n${BOLD}Test: idow wiring${RESET}"
+IDOW="$SCRIPT_DIR/idow"
+assert_eq "idow merges the layers into CONFIG_PATH" "1" "$(grep -c 'CONFIG_PATH="\$MERGED_CONFIG_PATH"' "$IDOW" || true)"
+assert_eq "merge runs before the first provider read" "yes" \
+    "$(awk '/CONFIG_PATH="\$MERGED_CONFIG_PATH"/{m=NR} /get_issue_tracker_provider "\$CONFIG_PATH"/{r=NR} END{print (m && r && m<r) ? "yes" : "no"}' "$IDOW")"
+assert_eq "no yq read bypasses the merge via PROJECT_CONFIG_PATH" "0" "$(grep -c 'yq .*PROJECT_CONFIG_PATH' "$IDOW" || true)"
+assert_eq "resolver calls take the project layer and merge themselves" "0" \
+    "$(grep 'resolve-claude-config\.sh"' "$IDOW" | grep -vc -- '--config "$PROJECT_CONFIG_PATH"' || true)"
+
+# ==========================================================================
+
+echo ""
+echo -e "${BOLD}Results: ${GREEN}$PASS passed${RESET}, ${RED}$FAIL failed${RESET}"
+[[ $FAIL -eq 0 ]]

--- a/source/config.ts
+++ b/source/config.ts
@@ -660,25 +660,66 @@ export function loadConfig(): PappardelleConfig {
 }
 
 /**
- * Load just the provider configs (issue_tracker, vcs_host) from .pappardelle.yml.
- * Skips full config validation so providers can be initialized even when
- * unrelated config sections (e.g. profiles) have errors.
+ * Load just the provider configs (issue_tracker, vcs_host) from the merged
+ * home -> project -> local layers, without validating the rest of the config
+ * so providers can be initialized even when unrelated sections (e.g.
+ * profiles) have errors. A layer that fails to parse is skipped for the same
+ * reason. Reads the same files as loadConfigFromPaths(); the defaults are
+ * what loadConfig() uses.
  */
-export function loadProviderConfigs(): {
+export function loadProviderConfigs(opts?: {
+	homeConfigDir?: string;
+	projectDir?: string;
+	fallbackProjectDir?: () => string | undefined;
+}): {
 	issue_tracker?: IssueTrackerConfig;
 	vcs_host?: VcsHostConfig;
 } {
-	const configPath = findRepoConfig('.pappardelle.yml');
+	const {homeConfigDir, projectDir, fallbackProjectDir} = opts ?? {
+		homeConfigDir: getDefaultHomeConfigDir(),
+		projectDir: getRepoRoot(),
+		fallbackProjectDir: getMainRepoRoot,
+	};
 
-	if (!configPath) {
-		return {};
-	}
+	const resolveProjectFile = (filename: string): string | undefined => {
+		if (projectDir) {
+			const candidate = path.join(projectDir, filename);
+			if (fs.existsSync(candidate)) return candidate;
+		}
 
-	const content = fs.readFileSync(configPath, 'utf-8');
-	const raw = YAML.load(content) as Record<string, unknown>;
+		const fallbackDir = fallbackProjectDir?.();
+		if (fallbackDir) {
+			const candidate = path.join(fallbackDir, filename);
+			if (fs.existsSync(candidate)) return candidate;
+		}
+
+		return undefined;
+	};
+
+	const readLayer = (
+		filePath: string | undefined,
+	): Record<string, unknown> | null => {
+		if (!filePath || !fs.existsSync(filePath)) return null;
+		try {
+			const parsed = YAML.load(fs.readFileSync(filePath, 'utf-8'));
+			return parsed && typeof parsed === 'object'
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	};
+
+	const merged = mergeConfigLayers(
+		readLayer(
+			homeConfigDir ? path.join(homeConfigDir, '.pappardelle.yml') : undefined,
+		),
+		readLayer(resolveProjectFile('.pappardelle.yml')),
+		readLayer(resolveProjectFile('.pappardelle.local.yml')),
+	);
 	return {
-		issue_tracker: raw['issue_tracker'] as IssueTrackerConfig | undefined,
-		vcs_host: raw['vcs_host'] as VcsHostConfig | undefined,
+		issue_tracker: merged['issue_tracker'] as IssueTrackerConfig | undefined,
+		vcs_host: merged['vcs_host'] as VcsHostConfig | undefined,
 	};
 }
 

--- a/source/provider-configs.test.ts
+++ b/source/provider-configs.test.ts
@@ -1,0 +1,134 @@
+import test from 'ava';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {loadProviderConfigs} from './config.ts';
+
+function setupTempDir(files: Record<string, string>): {
+	dir: string;
+	cleanup: () => void;
+} {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pappardelle-providers-'));
+	for (const [name, content] of Object.entries(files)) {
+		const filePath = path.join(dir, name);
+		fs.mkdirSync(path.dirname(filePath), {recursive: true});
+		fs.writeFileSync(filePath, content, 'utf-8');
+	}
+
+	return {
+		dir,
+		cleanup() {
+			fs.rmSync(dir, {recursive: true, force: true});
+		},
+	};
+}
+
+// ============================================================================
+// loadProviderConfigs — layered, validation-free provider lookup
+// ============================================================================
+
+test('loadProviderConfigs takes issue_tracker and vcs_host from the home layer', t => {
+	const {dir, cleanup} = setupTempDir({
+		'home/.pappardelle.yml': `version: 1
+issue_tracker:
+  provider: jira
+  base_url: https://example.atlassian.net
+vcs_host:
+  provider: gitlab
+  host: gitlab.example.com
+`,
+		'project/.pappardelle.yml': `version: 1
+profiles:
+  api:
+    display_name: API
+`,
+	});
+	try {
+		const cfg = loadProviderConfigs({
+			homeConfigDir: path.join(dir, 'home'),
+			projectDir: path.join(dir, 'project'),
+		});
+		t.is(cfg.issue_tracker?.provider, 'jira');
+		t.is(cfg.issue_tracker?.base_url, 'https://example.atlassian.net');
+		t.is(cfg.vcs_host?.provider, 'gitlab');
+		t.is(cfg.vcs_host?.host, 'gitlab.example.com');
+	} finally {
+		cleanup();
+	}
+});
+
+test('loadProviderConfigs lets project and local layers override home key by key', t => {
+	const {dir, cleanup} = setupTempDir({
+		'home/.pappardelle.yml': `version: 1
+issue_tracker:
+  provider: jira
+  base_url: https://home.atlassian.net
+vcs_host:
+  provider: gitlab
+  host: gitlab.home.example
+`,
+		'project/.pappardelle.yml': `version: 1
+issue_tracker:
+  base_url: https://project.atlassian.net
+`,
+		'project/.pappardelle.local.yml': `vcs_host:
+  host: gitlab.local.example
+`,
+	});
+	try {
+		const cfg = loadProviderConfigs({
+			homeConfigDir: path.join(dir, 'home'),
+			projectDir: path.join(dir, 'project'),
+		});
+		t.is(cfg.issue_tracker?.provider, 'jira');
+		t.is(cfg.issue_tracker?.base_url, 'https://project.atlassian.net');
+		t.is(cfg.vcs_host?.provider, 'gitlab');
+		t.is(cfg.vcs_host?.host, 'gitlab.local.example');
+	} finally {
+		cleanup();
+	}
+});
+
+test('loadProviderConfigs ignores validation errors elsewhere and skips an unparseable layer', t => {
+	const {dir, cleanup} = setupTempDir({
+		'home/.pappardelle.yml': `version: 1
+vcs_host:
+  provider: gitlab
+  host: gitlab.example.com
+`,
+		'project/.pappardelle.yml': `version: 1
+issue_tracker:
+  provider: beads
+profiles:
+  broken:
+    keywords: not-a-list
+`,
+		'project/.pappardelle.local.yml': `vcs_host: [unclosed
+`,
+	});
+	try {
+		const cfg = loadProviderConfigs({
+			homeConfigDir: path.join(dir, 'home'),
+			projectDir: path.join(dir, 'project'),
+		});
+		t.is(cfg.issue_tracker?.provider, 'beads');
+		t.is(cfg.vcs_host?.host, 'gitlab.example.com');
+	} finally {
+		cleanup();
+	}
+});
+
+test('loadProviderConfigs returns empty when no layer exists', t => {
+	const {dir, cleanup} = setupTempDir({});
+	try {
+		t.deepEqual(
+			loadProviderConfigs({
+				homeConfigDir: path.join(dir, 'home'),
+				projectDir: path.join(dir, 'project'),
+			}),
+			{issue_tracker: undefined, vcs_host: undefined},
+		);
+	} finally {
+		cleanup();
+	}
+});


### PR DESCRIPTION
## Problem

The three-layer config (home → project → local) was applied inconsistently:

**`idow`** read only the Claude settings that go through `resolve-claude-config.sh`. Every other field was read with `yq ... "$CONFIG_PATH"` against the project `.pappardelle.yml` alone

**The TUI** was correct everywhere `loadConfig()` is used, with one exception: `loadProviderConfigs()`, which initializes the issue-tracker and VCS-host singletons at startup, read `issue_tracker` / `vcs_host` from the project file only. A home config choosing Jira or a GitLab host was ignored by the app.

#14 wired `--home-config` into the two resolver calls, which fixed model/effort/init-cmd in `idow`, and nothing else.

## Change

- `merge_config_layers` deep-merges the three files with `yq eval-all`, skipping missing ones. Maps merge key by key and arrays replace, matching `deepMerge()` in `config.ts`

One known difference: `keybindings` are smart-merged in TS but replaced wholesale by the `yq` merge. `idow` does not read `keybindings`, so nothing observes it, but the helper should not be reused for that field without handling it.
